### PR TITLE
feat(delete_bm): Update response and tests for billable metric deletion

### DIFF
--- a/swagger.yaml
+++ b/swagger.yaml
@@ -214,12 +214,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ApiResponseNotFound'
-        '405':
-          description: Not Allowed error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiResponseNotAllowed'
   /billable_metrics/:
     get:
       tags:
@@ -2303,6 +2297,12 @@ components:
             - recurring_count_agg
         group:
           $ref: '#/components/schemas/BillableMetricGroup'
+        active_subscriptions_count:
+          type: integer
+          example: 0
+        draft_invoices_count:
+          type: integer
+          example: 0
     BillableMetric:
       type: object
       properties:

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -1616,6 +1616,42 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ApiResponseNotFound'
+  /invoices/{id}/retry_payment:
+    post:
+      tags:
+        - invoices
+      summary: Retry invoice payment
+      parameters:
+        - name: id
+          in: path
+          description: ID of the existing Lago Invoice
+          required: true
+          schema:
+            type: string
+            example: 183da83c-c007-4fbb-afcd-b00c07c41ffe
+      description: Retry invoice payment
+      operationId: retryPayment
+      responses:
+        '200':
+          description: Successful response
+        '401':
+          description: Unauthorized error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponseUnauthorized'
+        '404':
+          description: Not Found error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponseNotFound'
+        '405':
+          description: Not Allowed error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponseNotAllowed'
   /invoices/{id}/refresh:
     put:
       tags:


### PR DESCRIPTION
## Roadmap Task

👉  https://github.com/getlago/lago/issues/179

## Context

As a user, I want to be able to delete a billable metric that is linked to a subscription in case of a change of pricing (e.g. we no longer charge customers based on the number of API calls).

Once deleted, the corresponding charges will be removed from the plans and from all draft invoices.

Deleted metrics will still be included in past invoices (i.e. finalized invoices).

## Description

The goal of this PR is to add on the billable metric response:
- `active_subscriptions_count`
- `draft_invoices_count`
It also removes the 405 response from the delete query

These fields are used to know the impact of deleting billable metric.