### PR TITLE
feat(delete_plan): Add subscription and invoice counters to plans

### DIFF
--- a/swagger.yaml
+++ b/swagger.yaml
@@ -1260,12 +1260,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ApiResponseNotFound'
-        '405':
-          description: Not Allowed error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiResponseNotAllowed'
   /plans/:
     get:
       tags:

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -3209,6 +3209,12 @@ components:
         bill_charges_monthly:
           type: boolean
           example: false
+        active_subscriptions_count:
+          type: integer
+          example: 2
+        draft_invoices_count:
+          type: integer
+          example: 2
         charges:
           type: array
           items:


### PR DESCRIPTION
## Context

Currently, there is no way to delete objects linked to a subscription. This can be a real limitation during PoCs and onboarding, as users have to ping us to delete plans.

The goal of this feature is to be able to soft-delete a plan linked to an active or terminated subscription.

## Description

The goal of this PR is to add two counters in the plan response:
- `active_subscription_count`
- `draft_invoice_count`