### PR TITLE
feat(instant_charge): Add API route to show a fee

### DIFF
--- a/swagger.yaml
+++ b/swagger.yaml
@@ -64,6 +64,11 @@ tags:
     externalDocs:
       description: Find out more
       url: https://doc.getlago.com/docs/api/invoices/invoice-object
+  - name: fees
+    description: Everything about Fees
+    externalDocs:
+      description: Find out more
+      url: https://doc.getlago.com/docs/api/invoices/invoice-object#fee-object
   - name: wallets
     description: Everything about Wallet collection
     externalDocs:
@@ -1832,6 +1837,40 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ApiResponseUnauthorized'
+  /fees/{id}:
+    parameters:
+      - name: id
+        in: path
+        description: ID of the existing Lago Fee
+        required: true
+        schema:
+          type: string
+          example: 183da83c-c007-4fbb-afcd-b00c07c41ffe
+    get:
+      tags:
+        - fees
+      summary: Find fee by ID
+      description: Return a single fee
+      operationId: FindFee
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FeeObject'
+        '401':
+          description: Unauthorized error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponseUnauthorized'
+        '404':
+          description: Not Found error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponseNotFound'
   /wallets:
     post:
       tags:


### PR DESCRIPTION
## Roadmap Task

👉  https://github.com/getlago/lago/issues/149

## Context

Fintech companies want to deduct fees as transactions occur. They need to charge their customers instantly and report those fees in the invoice issued at the end of the billing period.

Example: 0.5% charge on FX transfers. When the customer makes a transfer of $100, they are immediately charged $0.5 (automatically deducted from their wallet). The corresponding fee is included in the invoice sent to the customer at the end of the billing period.

## Description

This PR documents a new route to retrieve a single fee via the API (`GET /api/v1/fees/:id`)

Related to https://github.com/getlago/lago-api/pull/866