### PR TITLE
feat(bm): Expose count of attached plans

### DIFF
--- a/swagger.yaml
+++ b/swagger.yaml
@@ -2432,6 +2432,7 @@ components:
         - created_at
         - active_subscriptions_count
         - draft_invoices_count
+        - plans_count
       properties:
         lago_id:
           type: string
@@ -2466,6 +2467,9 @@ components:
           type: integer
           example: 0
         draft_invoices_count:
+          type: integer
+          example: 0
+        plans_count:
           type: integer
           example: 0
     BillableMetric:

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -3523,6 +3523,7 @@ components:
       required:
         - lago_id
         - lago_billable_metric_id
+        - billable_metric_code
         - created_at
         - charge_model
       properties:
@@ -3532,6 +3533,9 @@ components:
         lago_billable_metric_id:
           type: string
           example: 278da83c-c007-4fbb-afcd-b00c07c41utg
+        billable_metric_code:
+          type: string
+          example: bm_code
         created_at:
           type: string
           example: 2022-09-14T16:35:31Z


### PR DESCRIPTION
## Context

Plans edition has some issue if you update some properties of a billable metric, especially if you change groups definition or aggregation type :

"After the billable metric edition, new dimensions are created with new group_id that do not match the ones in the plans already defined"

## Description

This PR exposes a new `plans_count` field in the `BillableMetric` response type to let the API users know if the BM is editable.

Related to https://github.com/getlago/lago-api/pull/914
