### PR TITLE
Fix #16 - Support loading API schema by version tag

### DIFF
--- a/.github/workflows/tags.yml
+++ b/.github/workflows/tags.yml
@@ -1,0 +1,30 @@
+name: Add tags
+
+on:
+  push:
+    branches:
+      - 'main'
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Parse openapi.yaml version
+        id: "parse-openapi"
+        uses: jbutcher5/read-yaml@main
+        with:
+          file: './openapi.yaml'
+          key-path: '["info", "version"]'
+
+      - name: Display OpenAPI version
+        run: echo "${{ steps.parse-openapi.outputs.data }}"
+
+      - name: Add tag
+        id: "add-tag"
+        uses: rickstaa/action-create-tag@v1
+        with:
+          tag: "${{ steps.parse-openapi.outputs.data }}"
+          tag_exists_error: false


### PR DESCRIPTION
Related issue (was closed incorrectly):
- #16 

**Permissions (do it before merge of this PR)**
1. Open https://github.com/getlago/lago-openapi/settings/actions
2. Scroll to page bottom.
3. Set `Workflow permissions` option to `Read and write permissions`
4. Click to `Save` button.

**How to test**
View or fork https://github.com/lorddaedra/testrepo/tree/main, change version in `swagger.yaml` and push to `main` (it works in my test repo)

**Motivation**
Now it's possible to load `opeanapi.yaml` by tag version (`0.28.0-beta`), for example, like this:
https://raw.githubusercontent.com/lorddaedra/testrepo/0.28.0-beta/openapi.yaml

Is required for:

- https://github.com/getlago/lago-python-client/issues/128