### PR TITLE
feat(taxes): Add tax resources

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3561,6 +3561,7 @@ components:
         vat_rate:
           type: number
           example: 25.00
+          deprecated: true
     OrganizationObject:
       type: object
       required:
@@ -3617,6 +3618,11 @@ components:
           example: 'UTC'
         billing_configuration:
           $ref: '#/components/schemas/BillingConfigurationOrganization'
+        tax_rates:
+          description: List of default organization tax rates
+          type: array
+          items:
+            $ref: '#/components/schemas/TaxRateObject'
     Organization:
       type: object
       required:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -69,6 +69,11 @@ tags:
     externalDocs:
       description: Find out more
       url: https://doc.getlago.com/docs/api/invoices/invoice-object#fee-object
+  - name: tax_rates
+    description: Everything about TaxRate collection
+    externalDocs:
+      description: Find out more
+      url: https://doc.getlago.com/docs/api/tax_rates/tax-rate-object
   - name: wallets
     description: Everything about Wallet collection
     externalDocs:
@@ -2233,6 +2238,184 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ApiResponseUnprocessableEntity'
+  /tax_rates:
+    post:
+      tags:
+        - tax_rates
+      summary: Create a tax rate
+      description: Create a tax rate
+      operationId: createTaxRate
+      requestBody:
+        description: Tax rate payload
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TaxRateInput'
+        required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TaxRate'
+        '400':
+          description: Bad Request error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponseBadRequest'
+        '401':
+          description: Unauthorized error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponseUnauthorized'
+        '422':
+          description: Unprocessable entity error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponseUnprocessableEntity'
+    get:
+      tags:
+        - tax_rates
+      summary: Find tax rates
+      description: Find all tax rates in certain organisation
+      operationId: findAllTaxRates
+      parameters:
+        - name: page
+          in: query
+          description: Number of page
+          required: false
+          explode: true
+          schema:
+            type: integer
+            example: 2
+        - name: per_page
+          in: query
+          description: Number of records per page
+          required: false
+          explode: true
+          schema:
+            type: integer
+            example: 20
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TaxRatesPaginated'
+        '401':
+          description: Unauthorized error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponseUnauthorized'
+  /tax_rates/{code}:
+    parameters:
+      - name: code
+        in: path
+        description: Code of the existing tax rate
+        required: true
+        schema:
+          type: string
+          example: 'example_code'
+    put:
+      tags:
+        - tax_rates
+      summary: Update an existing tax rate
+      description: Update an existing tax rate by code
+      operationId: updateTaxRate
+      requestBody:
+        description: Update an existing tax rate
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TaxRateInput'
+        required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TaxRate'
+        '400':
+          description: Bad Request error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponseBadRequest'
+        '401':
+          description: Unauthorized error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponseUnauthorized'
+        '404':
+          description: Not Found error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponseNotFound'
+        '422':
+          description: Unprocessable entity error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponseUnprocessableEntity'
+    get:
+      tags:
+        - tax_rates
+      summary: Find tax rate by code
+      description: Return a single tax rate
+      operationId: findTaxRate
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TaxRate'
+        '401':
+          description: Unauthorized error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponseUnauthorized'
+        '404':
+          description: Not Found error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponseNotFound'
+    delete:
+      tags:
+        - tax_rates
+      summary: Delete a tax rate
+      description: Delete a tax rate
+      operationId: destroyTaxRate
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TaxRate'
+        '401':
+          description: Unauthorized error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponseUnauthorized'
+        '404':
+          description: Not Found error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponseNotFound'
   /wallets:
     post:
       tags:
@@ -4838,6 +5021,86 @@ components:
                   description:
                     type: string
                     example: 'This is description'
+    TaxRateObject:
+      type: object
+      required:
+        - lago_id
+        - name
+        - code
+        - value
+        - applied_by_default
+        - customers_count
+        - created_at
+      properties:
+        lago_id:
+          type: string
+          format: 'uuid'
+          example: '1a901a90-1a90-1a90-1a90-1a901a901a90'
+        name:
+          type: string
+          example: 'example name'
+        code:
+          type: string
+          example: 'example_code'
+        description:
+          type: string
+          example: 'description'
+        value:
+          type: number
+          example: 25.00
+        applied_by_default:
+          type: boolean
+          example: true
+          description: True when tax rate is one of the organization's default
+        customers_count:
+          type: integer
+          example: 12
+        created_at:
+          type: string
+          format: 'date-time'
+          example: '2022-09-14T16:35:31Z'
+    TaxRate:
+      type: object
+      required:
+        - tax_rate
+      properties:
+        tax_rate:
+          $ref: '#/components/schemas/TaxRateObject'
+    TaxRatesPaginated:
+      type: object
+      required:
+        - tax_rates
+        - meta
+      properties:
+        tax_rates:
+          type: array
+          items:
+            $ref: '#/components/schemas/TaxRateObject'
+        meta:
+          $ref: '#/components/schemas/PaginationMeta'
+    TaxRateInput:
+      type: object
+      required:
+        - tax_rate
+      properties:
+        tax_rate:
+          type: object
+          properties:
+            name:
+              type: string
+              example: 'example name'
+            code:
+              type: string
+              example: 'example_code'
+            value:
+              type: number
+              example: 15.00
+            description:
+              type: string
+              example: 'description'
+            applied_by_default:
+              type: boolean
+              example: false
     WalletObject:
       type: object
       required:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1113,6 +1113,106 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ApiResponseNotFound'
+  /customers/{customer_external_id}/applied_tax_rates:
+    post:
+      tags:
+        - customers
+      summary: Apply a tax rate
+      description: Apply an existing tax rate to a customer
+      operationId: applyTaxRate
+      parameters:
+        - name: customer_external_id
+          in: path
+          description: External ID of the customer
+          required: true
+          schema:
+            type: string
+            example: '12345'
+      requestBody:
+        description: Apply tax rate body
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AppliedTaxRateInput'
+        required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AppliedTaxRate'
+        '400':
+          description: Bad Request error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponseBadRequest'
+        '401':
+          description: Unauthorized error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponseUnauthorized'
+        '404':
+          description: Not Found error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponseNotFound'
+        '422':
+          description: Unprocessable entity error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponseUnprocessableEntity'
+  /customers/{customer_external_id}/applied_tax_rates/{tax_rate_code}:
+    delete:
+      tags:
+        - customers
+      summary: Delete customer's appplied tax rate
+      description: Delete customer's appplied tax rate
+      operationId: deleteAppliedTaxRate
+      parameters:
+        - name: customer_external_id
+          in: path
+          description: External ID of the customer
+          required: true
+          schema:
+            type: string
+            example: '12345'
+        - name: tax_rate_code
+          in: path
+          description: Code of the applied tax rate
+          required: true
+          schema:
+            type: string
+            example: '12345'
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AppliedTaxRate'
+        '400':
+          description: Bad Request error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponseBadRequest'
+        '401':
+          description: Unauthorized error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponseUnauthorized'
+        '404':
+          description: Not Found error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponseNotFound'
   /events:
     post:
       tags:
@@ -3546,6 +3646,58 @@ components:
             percentage_rate:
               type: number
               example: 25.00
+    AppliedTaxRate:
+      type: object
+      required:
+        - applied_tax_rate
+      properties:
+        applied_tax_rate:
+          $ref: '#/components/schemas/AppliedTaxRateObject'
+    AppliedTaxRateInput:
+      type: object
+      required:
+        - applied_tax_rate
+      properties:
+        applied_tax_rate:
+          type: object
+          required:
+            - tax_rate_code
+          properties:
+            tax_rate_code:
+              type: string
+              example: 'example_code'
+    AppliedTaxRateObject:
+      type: object
+      required:
+        - lago_id
+        - lago_customer_id
+        - lago_tax_rate_id
+        - tax_rate_code
+        - external_customer_id
+        - created_at
+      properties:
+        lago_id:
+          type: string
+          format: 'uuid'
+          example: '1a901a90-1a90-1a90-1a90-1a901a901a90'
+        lago_customer_id:
+          type: string
+          format: 'uuid'
+          example: '1a901a90-1a90-1a90-1a90-1a901a901a90'
+        lago_tax_rate_id:
+          type: string
+          format: 'uuid'
+          example: '1a901a90-1a90-1a90-1a90-1a901a901a90'
+        tax_rate_code:
+          type: string
+          example: 'example_code'
+        external_customer_id:
+          type: string
+          example: '123456'
+        created_at:
+          type: string
+          format: 'date-time'
+          example: '2022-09-14T16:35:31Z'
     BillingConfigurationOrganization:
       type: object
       properties:
@@ -3707,6 +3859,7 @@ components:
         vat_rate:
           type: number
           example: 25.00
+          deprecated: true
     CustomerMetadataObject:
       type: object
       properties:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3717,7 +3717,7 @@ components:
           example: 'example_code'
         tax_rate:
           type: string
-          format: "^[0-9]+.?[0-9]*$"
+          format: '^[0-9]+.?[0-9]*$'
           example: "25.00"
         tax_description:
           type: string
@@ -4894,7 +4894,7 @@ components:
           example: 20
         taxes_rate:
           type: string
-          format: "^[0-9]+.?[0-9]*$"
+          format: '^[0-9]+.?[0-9]*$'
           example: '20.0'
         vat_amount_cents:
           type: integer
@@ -5583,6 +5583,15 @@ components:
           example: 'EUR'
         fee:
           $ref: '#/components/schemas/FeeObject'
+    CreditNoteAppliedTaxObject:
+      allOf:
+        - $ref: '#/components/schemas/BaseAppliedTax'
+      type: object
+      properties:
+        lago_credit_note_id:
+          type: string
+          format: 'uuid'
+          example: '1a901a90-1a90-1a90-1a90-1a901a901a90'
     CreditNoteObject:
       type: object
       required:
@@ -5595,18 +5604,13 @@ components:
         - reason
         - currency
         - total_amount_cents
-        - total_amount_currency
         - credit_amount_cents
-        - credit_amount_currency
         - refund_amount_cents
-        - refund_amount_currency
         - balance_amount_cents
-        - balance_amount_currency
-        - vat_amount_cents
-        - vat_amount_currency
-        - sub_total_vat_excluded_amount_cents
-        - sub_total_vat_excluded_amount_currency
+        - taxes_amount_cents
+        - sub_total_excluding_taxes_amount_cents
         - coupons_adjustement_amount_cents
+        - taxes_rate
         - created_at
         - updated_at
       properties:
@@ -5671,6 +5675,7 @@ components:
         vat_amount_cents:
           type: integer
           example: 20
+          deprecated: true
         vat_amount_currency:
           type: string
           example: 'EUR'
@@ -5706,6 +5711,13 @@ components:
         coupons_adjustement_amount_cents:
           type: integer
           example: 20
+        taxes_amount_cents:
+          type: integer
+          example: 20
+        taxes_rate:
+          type: string
+          format: '^[0-9]+.?[0-9]*$'
+          example: '20.0'
         created_at:
           type: string
           format: 'date-time'
@@ -5721,6 +5733,10 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/CreditNoteItemObject'
+        applied_taxes:
+          type: array
+          items:
+            $ref: '#/components/schemas/CreditNoteAppliedTaxObject'
     CreditNote:
       type: object
       required:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -69,11 +69,11 @@ tags:
     externalDocs:
       description: Find out more
       url: https://doc.getlago.com/docs/api/invoices/invoice-object#fee-object
-  - name: tax_rates
-    description: Everything about TaxRate collection
+  - name: taxes
+    description: Everything about Tax collection
     externalDocs:
       description: Find out more
-      url: https://doc.getlago.com/docs/api/tax_rates/tax-rate-object
+      url: https://doc.getlago.com/docs/api/taxes/tax-object
   - name: wallets
     description: Everything about Wallet collection
     externalDocs:
@@ -1113,13 +1113,13 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ApiResponseNotFound'
-  /customers/{customer_external_id}/applied_tax_rates:
+  /customers/{customer_external_id}/applied_taxes:
     post:
       tags:
         - customers
-      summary: Apply a tax rate
-      description: Apply an existing tax rate to a customer
-      operationId: applyTaxRate
+      summary: Apply a tax
+      description: Apply an existing tax to a customer
+      operationId: applyTax
       parameters:
         - name: customer_external_id
           in: path
@@ -1129,11 +1129,11 @@ paths:
             type: string
             example: '12345'
       requestBody:
-        description: Apply tax rate body
+        description: Apply tax body
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/AppliedTaxRateInput'
+              $ref: '#/components/schemas/AppliedTaxInput'
         required: true
       responses:
         '200':
@@ -1141,7 +1141,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/AppliedTaxRate'
+                $ref: '#/components/schemas/AppliedTax'
         '400':
           description: Bad Request error
           content:
@@ -1166,13 +1166,13 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ApiResponseUnprocessableEntity'
-  /customers/{customer_external_id}/applied_tax_rates/{tax_rate_code}:
+  /customers/{customer_external_id}/applied_taxes/{tax_code}:
     delete:
       tags:
         - customers
-      summary: Delete customer's appplied tax rate
-      description: Delete customer's appplied tax rate
-      operationId: deleteAppliedTaxRate
+      summary: Delete customer's appplied tax
+      description: Delete customer's appplied tax
+      operationId: deleteAppliedTax
       parameters:
         - name: customer_external_id
           in: path
@@ -1181,9 +1181,9 @@ paths:
           schema:
             type: string
             example: '12345'
-        - name: tax_rate_code
+        - name: tax_code
           in: path
-          description: Code of the applied tax rate
+          description: Code of the applied tax
           required: true
           schema:
             type: string
@@ -1194,7 +1194,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/AppliedTaxRate'
+                $ref: '#/components/schemas/AppliedTax'
         '400':
           description: Bad Request error
           content:
@@ -2338,19 +2338,19 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ApiResponseUnprocessableEntity'
-  /tax_rates:
+  /taxes:
     post:
       tags:
         - tax_rates
-      summary: Create a tax rate
-      description: Create a tax rate
-      operationId: createTaxRate
+      summary: Create a tax
+      description: Create a tax
+      operationId: createTax
       requestBody:
-        description: Tax rate payload
+        description: Tax payload
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/TaxRateInput'
+              $ref: '#/components/schemas/TaxInput'
         required: true
       responses:
         '200':
@@ -2358,7 +2358,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/TaxRate'
+                $ref: '#/components/schemas/Tax'
         '400':
           description: Bad Request error
           content:
@@ -2379,10 +2379,10 @@ paths:
                 $ref: '#/components/schemas/ApiResponseUnprocessableEntity'
     get:
       tags:
-        - tax_rates
-      summary: Find tax rates
-      description: Find all tax rates in certain organisation
-      operationId: findAllTaxRates
+        - taxes
+      summary: Find taxes
+      description: Find all taxes in certain organization
+      operationId: findAllTaxes
       parameters:
         - name: page
           in: query
@@ -2406,34 +2406,34 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/TaxRatesPaginated'
+                $ref: '#/components/schemas/TaxesPaginated'
         '401':
           description: Unauthorized error
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ApiResponseUnauthorized'
-  /tax_rates/{code}:
+  /taxes/{code}:
     parameters:
       - name: code
         in: path
-        description: Code of the existing tax rate
+        description: Code of the existing tax
         required: true
         schema:
           type: string
           example: 'example_code'
     put:
       tags:
-        - tax_rates
-      summary: Update an existing tax rate
-      description: Update an existing tax rate by code
-      operationId: updateTaxRate
+        - taxes
+      summary: Update an existing tax
+      description: Update an existing tax by code
+      operationId: updateTax
       requestBody:
-        description: Update an existing tax rate
+        description: Update an existing tax
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/TaxRateInput'
+              $ref: '#/components/schemas/TaxInput'
         required: true
       responses:
         '200':
@@ -2441,7 +2441,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/TaxRate'
+                $ref: '#/components/schemas/Tax'
         '400':
           description: Bad Request error
           content:
@@ -2468,17 +2468,17 @@ paths:
                 $ref: '#/components/schemas/ApiResponseUnprocessableEntity'
     get:
       tags:
-        - tax_rates
-      summary: Find tax rate by code
-      description: Return a single tax rate
-      operationId: findTaxRate
+        - taxes
+      summary: Find tax by code
+      description: Return a single tax
+      operationId: findTax
       responses:
         '200':
           description: Successful response
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/TaxRate'
+                $ref: '#/components/schemas/Tax'
         '401':
           description: Unauthorized error
           content:
@@ -2493,17 +2493,17 @@ paths:
                 $ref: '#/components/schemas/ApiResponseNotFound'
     delete:
       tags:
-        - tax_rates
-      summary: Delete a tax rate
-      description: Delete a tax rate
-      operationId: destroyTaxRate
+        - taxes
+      summary: Delete a tax
+      description: Delete a tax
+      operationId: destroyTax
       responses:
         '200':
           description: Successful response
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/TaxRate'
+                $ref: '#/components/schemas/Tax'
         '401':
           description: Unauthorized error
           content:
@@ -3646,33 +3646,33 @@ components:
             percentage_rate:
               type: number
               example: 25.00
-    AppliedTaxRate:
+    AppliedTax:
       type: object
       required:
-        - applied_tax_rate
+        - applied_tax
       properties:
-        applied_tax_rate:
-          $ref: '#/components/schemas/AppliedTaxRateObject'
-    AppliedTaxRateInput:
+        applied_tax:
+          $ref: '#/components/schemas/AppliedTaxObject'
+    AppliedTaxInput:
       type: object
       required:
-        - applied_tax_rate
+        - applied_tax
       properties:
-        applied_tax_rate:
+        applied_tax:
           type: object
           required:
-            - tax_rate_code
+            - tax_code
           properties:
-            tax_rate_code:
+            tax_code:
               type: string
               example: 'example_code'
-    AppliedTaxRateObject:
+    AppliedTaxObject:
       type: object
       required:
         - lago_id
         - lago_customer_id
-        - lago_tax_rate_id
-        - tax_rate_code
+        - lago_tax_id
+        - tax_code
         - external_customer_id
         - created_at
       properties:
@@ -3684,11 +3684,11 @@ components:
           type: string
           format: 'uuid'
           example: '1a901a90-1a90-1a90-1a90-1a901a901a90'
-        lago_tax_rate_id:
+        lago_tax_id:
           type: string
           format: 'uuid'
           example: '1a901a90-1a90-1a90-1a90-1a901a901a90'
-        tax_rate_code:
+        tax_code:
           type: string
           example: 'example_code'
         external_customer_id:
@@ -3770,11 +3770,11 @@ components:
           example: 'UTC'
         billing_configuration:
           $ref: '#/components/schemas/BillingConfigurationOrganization'
-        tax_rates:
-          description: List of default organization tax rates
+        taxes:
+          description: List of default organization taxes
           type: array
           items:
-            $ref: '#/components/schemas/TaxRateObject'
+            $ref: '#/components/schemas/TaxObject'
     Organization:
       type: object
       required:
@@ -5180,14 +5180,14 @@ components:
                   description:
                     type: string
                     example: 'This is description'
-    TaxRateObject:
+    TaxObject:
       type: object
       required:
         - lago_id
         - name
         - code
         - value
-        - applied_by_default
+        - applied_to_organization
         - customers_count
         - created_at
       properties:
@@ -5204,10 +5204,10 @@ components:
         description:
           type: string
           example: 'description'
-        value:
+        rate:
           type: number
           example: 25.00
-        applied_by_default:
+        applied_to_organization:
           type: boolean
           example: true
           description: True when tax rate is one of the organization's default
@@ -5218,31 +5218,31 @@ components:
           type: string
           format: 'date-time'
           example: '2022-09-14T16:35:31Z'
-    TaxRate:
+    Tax:
       type: object
       required:
-        - tax_rate
+        - tax
       properties:
-        tax_rate:
-          $ref: '#/components/schemas/TaxRateObject'
-    TaxRatesPaginated:
+        tax:
+          $ref: '#/components/schemas/TaxObject'
+    TaxesPaginated:
       type: object
       required:
-        - tax_rates
+        - taxes
         - meta
       properties:
-        tax_rates:
+        taxes:
           type: array
           items:
-            $ref: '#/components/schemas/TaxRateObject'
+            $ref: '#/components/schemas/TaxObject'
         meta:
           $ref: '#/components/schemas/PaginationMeta'
-    TaxRateInput:
+    TaxInput:
       type: object
       required:
-        - tax_rate
+        - tax
       properties:
-        tax_rate:
+        tax:
           type: object
           properties:
             name:
@@ -5251,13 +5251,13 @@ components:
             code:
               type: string
               example: 'example_code'
-            value:
+            rate:
               type: number
               example: 15.00
             description:
               type: string
               example: 'description'
-            applied_by_default:
+            applied_to_organization:
               type: boolean
               example: false
     WalletObject:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -4192,12 +4192,10 @@ components:
         - from_datetime
         - to_datetime
         - issuing_date
+        - currency
         - amount_cents
-        - amount_currency
+        - taxes_amount_cents
         - total_amount_cents
-        - total_amount_currency
-        - vat_amount_cents
-        - vat_amount_currency
         - charges_usage
       properties:
         from_datetime:
@@ -4212,24 +4210,34 @@ components:
           type: string
           format: 'date-time'
           example: '2022-09-15T00:00:00Z'
+        currency:
+          type: string
+          example: 'EUR'
         amount_cents:
           type: integer
           example: 1200
         amount_currency:
           type: string
           example: 'EUR'
+          deprecated: false
         total_amount_cents:
           type: integer
           example: 1400
         total_amount_currency:
           type: string
           example: 'EUR'
+          deprecated: false
+        taxes_amount_cents:
+          type: integer
+          example: 200
         vat_amount_cents:
           type: integer
           example: 200
+          deprecated: false
         vat_amount_currency:
           type: string
           example: 'EUR'
+          deprecated: false
         charges_usage:
           type: array
           items:
@@ -5592,6 +5600,9 @@ components:
           type: string
           format: 'uuid'
           example: '1a901a90-1a90-1a90-1a90-1a901a901a90'
+        base_amount_cents:
+          type: integer
+          example: 100
     CreditNoteObject:
       type: object
       required:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3698,6 +3698,40 @@ components:
           type: string
           format: 'date-time'
           example: '2022-09-14T16:35:31Z'
+    BaseAppliedTax:
+      type: object
+      properties:
+        lago_id:
+          type: string
+          format: 'uuid'
+          example: '1a901a90-1a90-1a90-1a90-1a901a901a90'
+        lago_tax_id:
+          type: string
+          format: 'uuid'
+          example: '1a901a90-1a90-1a90-1a90-1a901a901a90'
+        tax_name:
+          type: string
+          example: 'example name'
+        tax_code:
+          type: string
+          example: 'example_code'
+        tax_rate:
+          type: string
+          format: "^[0-9]+.?[0-9]*$"
+          example: "25.00"
+        tax_description:
+          type: string
+          example: 'description'
+        amount_cents:
+          type: integer
+          example: 20
+        amount_currency:
+          type: string
+          example: 'EUR'
+        created_at:
+          type: string
+          format: 'date-time'
+          example: '2022-09-14T16:35:31Z'
     BillingConfigurationOrganization:
       type: object
       properties:
@@ -4804,6 +4838,15 @@ components:
                 - pending
                 - succeeded
                 - failed
+    FeeAppliedTaxObject:
+      allOf:
+        - $ref: '#/components/schemas/BaseAppliedTax'
+      type: object
+      properties:
+        lago_fee_id:
+          type: string
+          format: 'uuid'
+          example: '1a901a90-1a90-1a90-1a90-1a901a901a90'
     FeeObject:
       type: object
       required:
@@ -4811,10 +4854,10 @@ components:
         - item
         - amount_cents
         - amount_currency
-        - vat_amount_cents
-        - vat_amount_currency
         - units
         - payment_status
+        - taxes_amount_cents
+        - taxes_rate
         - created_at
       properties:
         lago_id:
@@ -4846,12 +4889,21 @@ components:
         amount_currency:
           type: string
           example: 'EUR'
+        taxes_amount_cents:
+          type: integer
+          example: 20
+        taxes_rate:
+          type: string
+          format: "^[0-9]+.?[0-9]*$"
+          example: '20.0'
         vat_amount_cents:
           type: integer
           example: 200
+          deprecated: true
         vat_amount_currency:
           type: string
           example: 'EUR'
+          deprecated: true
         units:
           type: string
           example: "2.5"
@@ -4935,6 +4987,19 @@ components:
                 - BillableMetric
                 - Subscription
                 - WalletTransaction
+        applied_taxes:
+          type: array
+          items:
+            $ref: '#/components/schemas/FeeAppliedTaxObject'
+    InvoiceAppliedTaxObject:
+      allOf:
+        - $ref: '#/components/schemas/BaseAppliedTax'
+      type: object
+      properties:
+        lago_invoice_id:
+          type: string
+          format: 'uuid'
+          example: '1a901a90-1a90-1a90-1a90-1a901a901a90'
     InvoiceMetadataObject:
       type: object
       properties:
@@ -4966,20 +5031,12 @@ components:
         - fees_amount_cents
         - coupons_amount_cents
         - credit_notes_amount_cents
-        - sub_total_vat_excluded_amount_cents
-        - vat_amount_cents
-        - sub_total_vat_included_amount_cents
+        - sub_total_excluding_taxes_amount_cents
+        - sub_total_including_taxes_amount_cents
         - prepaid_credit_amount_cents
         - total_amount_cents
         - version_number
         - customer
-        - legacy
-        - amount_cents
-        - credit_amount_cents
-        - amount_currency
-        - total_amount_currency
-        - credit_amount_currency
-        - vat_amount_currency
       properties:
         lago_id:
           type: string
@@ -5028,12 +5085,26 @@ components:
         sub_total_vat_excluded_amount_cents:
           type: integer
           example: 20
+          deprecated: true
+        sub_total_excluding_taxes_amount_cents:
+          type: integer
+          example: 20
+          deprecated: true
+        sub_total_including_taxes_amount_cents:
+          type: integer
+          example: 20
+          deprecated: true
+        taxes_amount_cents:
+          type: integer
+          example: 20
         vat_amount_cents:
           type: integer
           example: 20
+          deprecated: true
         sub_total_vat_included_amount_cents:
           type: integer
           example: 20
+          deprecated: true
         prepaid_credit_amount_cents:
           type: integer
           example: 20
@@ -5080,6 +5151,10 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/InvoiceMetadataObject'
+        applied_taxes:
+          type: array
+          items:
+            $ref: '#/components/schemas/InvoiceAppliedTaxObject'
     InvoiceObjectExtended:
       allOf:
         - $ref: '#/components/schemas/InvoiceObject'

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3963,6 +3963,11 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/CustomerMetadataObject'
+        taxes:
+          description: List of customer taxes
+          type: array
+          items:
+            $ref: '#/components/schemas/TaxObject'
     Customer:
       type: object
       required:


### PR DESCRIPTION
## Roadmap Task

👉  [https://getlago.canny.io/feature-requests/p/create-several-tax-rates](https://getlago.canny.io/feature-requests/p/create-several-tax-rates)

## Context

Currently, tax can be set individually either on the customer or the organization level. However, it’s not possible to define a global tax tag that can be reusable everywhere.

## Description

The goal of this PR is to add:
- The Tax object
- The relation between taxes and organization
- The relation between taxes and customers
- The relation between taxes and invoices
- The relation between taxes and fees
- The relation between taxes and credit notes