### PR TITLE
fix(types): Change FeeObject.units type from number to string

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -4489,8 +4489,8 @@ components:
           type: string
           example: 'EUR'
         units:
-          type: number
-          example: 2.5
+          type: string
+          example: "2.5"
         total_amount_cents:
           type: integer
           example: 1200


### PR DESCRIPTION
I didn't open an issue so I will explain here. FeeObject's `units` property is a string and not a number. The string contains a decimal number and the type string is used for good reason. However this will fail JSON schema tools because from their scope this is invalid.

As an enhancement we can consider a regexp string validation in this PR or another.
```json
{
  	"type": "string",
        "pattern": "^[0-9]+.?[0-9]*$"
}
```