### PR TITLE
feat(coupon): Add coupon resources

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -40,16 +40,16 @@ tags:
     externalDocs:
       description: Find out more
       url: 'https://doc.getlago.com/docs/api/organizations/organization-object'
-  - name: add_ons
-    description: Everything about Add-on collection
-    externalDocs:
-      description: Find out more
-      url: 'https://doc.getlago.com/docs/api/add_ons/add-on-object'
   - name: coupons
     description: Everything about Coupon collection
     externalDocs:
       description: Find out more
       url: 'https://doc.getlago.com/docs/api/coupons/coupon-object'
+  - name: add_ons
+    description: Everything about Add-on collection
+    externalDocs:
+      description: Find out more
+      url: 'https://doc.getlago.com/docs/api/add_ons/add-on-object'
   - name: plans
     description: Everything about Plan collection
     externalDocs:
@@ -224,6 +224,72 @@ paths:
           $ref: '#/paths/~1plans/post/responses/404'
         '422':
           $ref: '#/paths/~1fees/get/responses/422'
+  /applied_coupons:
+    post:
+      tags:
+        - coupons
+      summary: Apply a coupon to a customer
+      description: 'This endpoint is used to apply a specific coupon to a customer, before or during a subscription.'
+      operationId: applyCoupon
+      requestBody:
+        description: Apply coupon payload
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AppliedCouponInput'
+        required: true
+      responses:
+        '200':
+          description: Coupon applied
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AppliedCoupon'
+        '400':
+          $ref: '#/paths/~1plans/post/responses/400'
+        '401':
+          $ref: '#/paths/~1fees/get/responses/401'
+        '404':
+          $ref: '#/paths/~1plans/post/responses/404'
+        '422':
+          $ref: '#/paths/~1fees/get/responses/422'
+    get:
+      tags:
+        - coupons
+      summary: List all applied coupons
+      description: This endpoint is used to list all applied coupons. You can filter by coupon status and by customer.
+      operationId: findAllAppliedCoupons
+      parameters:
+        - $ref: '#/paths/~1fees/get/parameters/0'
+        - $ref: '#/paths/~1fees/get/parameters/1'
+        - name: status
+          in: query
+          description: The status of the coupon. Can be either `active` or `terminated`.
+          required: false
+          explode: true
+          schema:
+            type: string
+            enum:
+              - active
+              - terminated
+            example: active
+        - name: external_customer_id
+          in: query
+          description: The customer external unique identifier (provided by your own application)
+          required: false
+          explode: true
+          schema:
+            type: string
+            example: 5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba
+      responses:
+        '200':
+          description: Applied Coupons
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AppliedCouponsPaginated'
+        '401':
+          $ref: '#/paths/~1fees/get/responses/401'
   /billable_metrics:
     post:
       tags:
@@ -383,6 +449,122 @@ paths:
                   total_count: 2
         '401':
           $ref: '#/paths/~1fees/get/responses/401'
+  /coupons:
+    post:
+      tags:
+        - coupons
+      summary: Create a coupon
+      description: This endpoint is used to create a coupon that can be then attached to a customer to create a discount.
+      operationId: createCoupon
+      requestBody:
+        description: Coupon payload
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CouponCreateInput'
+        required: true
+      responses:
+        '200':
+          description: Coupon created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Coupon'
+        '400':
+          $ref: '#/paths/~1plans/post/responses/400'
+        '401':
+          $ref: '#/paths/~1fees/get/responses/401'
+        '422':
+          $ref: '#/paths/~1fees/get/responses/422'
+    get:
+      tags:
+        - coupons
+      summary: List all coupons
+      description: This endpoint is used to list all existing coupons.
+      operationId: findAllCoupons
+      parameters:
+        - $ref: '#/paths/~1fees/get/parameters/0'
+        - $ref: '#/paths/~1fees/get/parameters/1'
+      responses:
+        '200':
+          description: Coupons
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CouponsPaginated'
+        '401':
+          $ref: '#/paths/~1fees/get/responses/401'
+  '/coupons/{code}':
+    parameters:
+      - name: code
+        in: path
+        description: Unique code used to identify the coupon.
+        required: true
+        schema:
+          type: string
+          example: startup_deal
+    put:
+      tags:
+        - coupons
+      summary: Update a coupon
+      description: This endpoint is used to update a coupon that can be then attached to a customer to create a discount.
+      operationId: updateCoupon
+      requestBody:
+        description: Coupon payload
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CouponUpdateInput'
+        required: true
+      responses:
+        '200':
+          description: Coupon updated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Coupon'
+        '400':
+          $ref: '#/paths/~1plans/post/responses/400'
+        '401':
+          $ref: '#/paths/~1fees/get/responses/401'
+        '404':
+          $ref: '#/paths/~1plans/post/responses/404'
+        '422':
+          $ref: '#/paths/~1fees/get/responses/422'
+    get:
+      tags:
+        - coupons
+      summary: Retrieve a coupon
+      description: This endpoint is used to retrieve a specific coupon.
+      operationId: findCoupon
+      responses:
+        '200':
+          description: Coupon
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Coupon'
+        '401':
+          $ref: '#/paths/~1fees/get/responses/401'
+        '404':
+          $ref: '#/paths/~1plans/post/responses/404'
+    delete:
+      tags:
+        - coupons
+      summary: Delete a coupon
+      description: This endpoint is used to delete a coupon.
+      operationId: destroyCoupon
+      responses:
+        '200':
+          description: Coupon deleted
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Coupon'
+        '401':
+          $ref: '#/paths/~1fees/get/responses/401'
+        '404':
+          $ref: '#/paths/~1plans/post/responses/404'
   /customers:
     post:
       tags:
@@ -467,6 +649,42 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Customer'
+        '401':
+          $ref: '#/paths/~1fees/get/responses/401'
+        '404':
+          $ref: '#/paths/~1plans/post/responses/404'
+  '/customers/{external_customer_id}/applied_coupons/{applied_coupon_id}':
+    delete:
+      tags:
+        - coupons
+        - customers
+      summary: Delete an applied coupon
+      description: This endpoint is used to delete a specific coupon that has been applied to a customer.
+      parameters:
+        - name: external_customer_id
+          in: path
+          description: The customer external unique identifier (provided by your own application)
+          required: true
+          schema:
+            type: string
+            example: 5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba
+        - name: applied_coupon_id
+          in: path
+          description: 'Unique identifier of the applied coupon, created by Lago.'
+          required: true
+          explode: true
+          schema:
+            type: string
+            format: uuid
+            example: 1a901a90-1a90-1a90-1a90-1a901a901a90
+      operationId: deleteAppliedCoupon
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AppliedCoupon'
         '401':
           $ref: '#/paths/~1fees/get/responses/401'
         '404':
@@ -768,222 +986,6 @@ paths:
           $ref: '#/paths/~1plans/post/responses/404'
         '405':
           $ref: '#/paths/~1wallets~1%7Bid%7D/delete/responses/405'
-  /coupons:
-    post:
-      tags:
-        - coupons
-      summary: Create a new coupon
-      description: Create a new coupon
-      operationId: createCoupon
-      requestBody:
-        description: Coupon payload
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/CouponInput'
-        required: true
-      responses:
-        '200':
-          description: Successful response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Coupon'
-        '400':
-          $ref: '#/paths/~1plans/post/responses/400'
-        '401':
-          $ref: '#/paths/~1fees/get/responses/401'
-        '422':
-          $ref: '#/paths/~1fees/get/responses/422'
-    get:
-      tags:
-        - coupons
-      summary: Find Coupons
-      description: Find all coupons in certain organisation
-      operationId: findAllCoupons
-      parameters:
-        - $ref: '#/paths/~1fees/get/parameters/0'
-        - $ref: '#/paths/~1fees/get/parameters/1'
-      responses:
-        '200':
-          description: Successful response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/CouponsPaginated'
-        '401':
-          $ref: '#/paths/~1fees/get/responses/401'
-  '/coupons/{code}':
-    parameters:
-      - name: code
-        in: path
-        description: Code of the existing coupon
-        required: true
-        schema:
-          type: string
-          example: example_code
-    put:
-      tags:
-        - coupons
-      summary: Update an existing coupon
-      description: Update an existing coupon by code
-      operationId: updateCoupon
-      requestBody:
-        description: Update an existing coupon
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/CouponInput'
-        required: true
-      responses:
-        '200':
-          description: Successful response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Coupon'
-        '400':
-          $ref: '#/paths/~1plans/post/responses/400'
-        '401':
-          $ref: '#/paths/~1fees/get/responses/401'
-        '404':
-          $ref: '#/paths/~1plans/post/responses/404'
-        '422':
-          $ref: '#/paths/~1fees/get/responses/422'
-    get:
-      tags:
-        - coupons
-      summary: Find coupon by code
-      description: Return a single coupon
-      operationId: findCoupon
-      responses:
-        '200':
-          description: Successful response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Coupon'
-        '401':
-          $ref: '#/paths/~1fees/get/responses/401'
-        '404':
-          $ref: '#/paths/~1plans/post/responses/404'
-    delete:
-      tags:
-        - coupons
-      summary: Delete a coupon
-      description: Delete a coupon
-      operationId: destroyCoupon
-      responses:
-        '200':
-          description: Successful response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Coupon'
-        '401':
-          $ref: '#/paths/~1fees/get/responses/401'
-        '404':
-          $ref: '#/paths/~1plans/post/responses/404'
-  /applied_coupons:
-    post:
-      tags:
-        - coupons
-      summary: Apply a coupon to a customer
-      description: Apply a coupon to a customer
-      operationId: applyCoupon
-      requestBody:
-        description: Apply coupon payload
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/AppliedCouponInput'
-        required: true
-      responses:
-        '200':
-          description: Successful response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/AppliedCoupon'
-        '400':
-          $ref: '#/paths/~1plans/post/responses/400'
-        '401':
-          $ref: '#/paths/~1fees/get/responses/401'
-        '404':
-          $ref: '#/paths/~1plans/post/responses/404'
-        '422':
-          $ref: '#/paths/~1fees/get/responses/422'
-    get:
-      tags:
-        - coupons
-      summary: Find Applied Coupons
-      description: Find all applied coupons
-      operationId: findAllAppliedCoupons
-      parameters:
-        - $ref: '#/paths/~1fees/get/parameters/0'
-        - $ref: '#/paths/~1fees/get/parameters/1'
-        - name: status
-          in: query
-          description: Applied coupon status
-          required: false
-          explode: true
-          schema:
-            type: string
-            description: Status
-            enum:
-              - active
-              - terminated
-        - name: external_customer_id
-          in: query
-          description: External customer ID
-          required: false
-          explode: true
-          schema:
-            type: string
-            example: '12345'
-      responses:
-        '200':
-          description: Successful response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/AppliedCouponsPaginated'
-        '401':
-          $ref: '#/paths/~1fees/get/responses/401'
-  '/customers/{external_customer_id}/applied_coupons/{applied_coupon_id}':
-    delete:
-      tags:
-        - customers
-      summary: Delete customer's appplied coupon
-      parameters:
-        - name: external_customer_id
-          in: path
-          description: External ID of the existing customer
-          required: true
-          schema:
-            type: string
-            example: '12345'
-        - name: applied_coupon_id
-          in: path
-          description: Applied Coupon Lago ID
-          required: true
-          explode: true
-          schema:
-            type: string
-            example: '54321'
-      description: Delete customer's appplied coupon
-      operationId: deleteAppliedCoupon
-      responses:
-        '200':
-          description: Successful response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/AppliedCoupon'
-        '401':
-          $ref: '#/paths/~1fees/get/responses/401'
-        '404':
-          $ref: '#/paths/~1plans/post/responses/404'
   /events/estimate_fees:
     post:
       tags:
@@ -2288,6 +2290,198 @@ components:
           type: string
           format: date-time
           example: '2022-09-14T16:35:31Z'
+    AppliedCoupon:
+      type: object
+      required:
+        - applied_coupon
+      properties:
+        applied_coupon:
+          $ref: '#/components/schemas/AppliedCouponObject'
+    AppliedCouponInput:
+      type: object
+      required:
+        - applied_coupon
+      properties:
+        applied_coupon:
+          type: object
+          required:
+            - external_customer_id
+            - coupon_code
+          properties:
+            external_customer_id:
+              type: string
+              description: The customer external unique identifier (provided by your own application)
+              example: 5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba
+            coupon_code:
+              type: string
+              description: Unique code used to identify the coupon.
+              example: startup_deal
+            frequency:
+              type: string
+              enum:
+                - once
+                - recurring
+              nullable: true
+              description: |-
+                The type of frequency for the coupon. It can have three possible values: `once`, `recurring` or `forever`.
+
+                - If set to `once`, the coupon is applicable only for a single use.
+                - If set to `recurring`, the coupon can be used multiple times for recurring billing periods.
+                - If set to `forever`, the coupon has unlimited usage and can be applied indefinitely.
+              example: recurring
+            frequency_duration:
+              type: integer
+              nullable: true
+              description: Specifies the number of billing periods to which the coupon applies. This field is required only for coupons with a `recurring` frequency type
+              example: 3
+            amount_cents:
+              type: integer
+              nullable: true
+              description: The amount of the coupon in cents. This field is required only for coupon with `fixed_amount` type.
+              example: 2000
+            amount_currency:
+              allOf:
+                - $ref: '#/components/schemas/Currency'
+                - nullable: true
+                  description: The currency of the coupon. This field is required only for coupon with `fixed_amount` type.
+                  example: EUR
+            percentage_rate:
+              type: string
+              format: '^[0-9]+.?[0-9]*$'
+              nullable: true
+              description: The percentage rate of the coupon. This field is required only for coupons with a `percentage` coupon type.
+              example: null
+    AppliedCouponObject:
+      type: object
+      required:
+        - lago_id
+        - lago_coupon_id
+        - coupon_code
+        - coupon_name
+        - external_customer_id
+        - lago_customer_id
+        - status
+        - frequency
+        - created_at
+      properties:
+        lago_id:
+          type: string
+          format: uuid
+          description: 'Unique identifier of the applied coupon, created by Lago.'
+          example: 1a901a90-1a90-1a90-1a90-1a901a901a90
+        lago_coupon_id:
+          type: string
+          format: uuid
+          description: 'Unique identifier of the coupon, created by Lago.'
+          example: 1a901a90-1a90-1a90-1a90-1a901a901a90
+        coupon_code:
+          type: string
+          description: Unique code used to identify the coupon.
+          example: startup_deal
+        coupon_name:
+          type: string
+          description: The name of the coupon.
+          example: Startup Deal
+        lago_customer_id:
+          type: string
+          format: uuid
+          description: 'Unique identifier of the customer, created by Lago.'
+          example: 1a901a90-1a90-1a90-1a90-1a901a901a90
+        external_customer_id:
+          type: string
+          description: The customer external unique identifier (provided by your own application)
+          example: 5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba
+        status:
+          type: string
+          enum:
+            - active
+            - terminated
+          description: The status of the coupon. Can be either `active` or `terminated`.
+          example: active
+        amount_cents:
+          type: integer
+          nullable: true
+          description: The amount of the coupon in cents. This field is required only for coupon with `fixed_amount` type.
+          example: 2000
+        amount_cents_remaining:
+          type: integer
+          nullable: true
+          description: The remaining amount in cents for a `fixed_amount` coupon with a frequency set to `once`. This field indicates the remaining balance or value that can still be utilized from the coupon.
+          example: 50
+        amount_currency:
+          allOf:
+            - $ref: '#/components/schemas/Currency'
+            - nullable: true
+              description: The currency of the coupon. This field is required only for coupon with `fixed_amount` type.
+              example: EUR
+        percentage_rate:
+          type: string
+          format: '^[0-9]+.?[0-9]*$'
+          nullable: true
+          description: The percentage rate of the coupon. This field is required only for coupons with a `percentage` coupon type.
+          example: null
+        frequency:
+          type: string
+          enum:
+            - once
+            - recurring
+          description: |-
+            The type of frequency for the coupon. It can have three possible values: `once`, `recurring` or `forever`.
+
+            - If set to `once`, the coupon is applicable only for a single use.
+            - If set to `recurring`, the coupon can be used multiple times for recurring billing periods.
+            - If set to `forever`, the coupon has unlimited usage and can be applied indefinitely.
+          example: recurring
+        frequency_duration:
+          type: integer
+          nullable: true
+          description: Specifies the number of billing periods to which the coupon applies. This field is required only for coupons with a `recurring` frequency type
+          example: 3
+        frequency_duration_remaining:
+          type: integer
+          nullable: true
+          description: The remaining number of billing periods to which the coupon is applicable. This field determines the remaining usage or availability of the coupon based on the remaining billing periods.
+          example: 1
+        expiration_at:
+          type: string
+          format: date-time
+          nullable: true
+          description: 'The date and time after which the coupon will stop applying to customer''s invoices. Once the expiration date is reached, the coupon will no longer be applicable, and any further invoices generated for the customer will not include the coupon discount.'
+          example: '2022-04-29T08:59:51Z'
+        created_at:
+          type: string
+          format: date-time
+          description: The date and time when the coupon was assigned to a customer. It is expressed in UTC format according to the ISO 8601 datetime standard.
+          example: '2022-04-29T08:59:51Z'
+        terminated_at:
+          type: string
+          format: date-time
+          nullable: true
+          description: This field indicates the specific moment when the coupon amount is fully utilized or when the coupon is removed from the customer's coupon list. It is expressed in UTC format according to the ISO 8601 datetime standard.
+          example: '2022-04-29T08:59:51Z'
+    AppliedCouponObjectExtended:
+      allOf:
+        - $ref: '#/components/schemas/AppliedCouponObject'
+        - type: object
+          required:
+            - credits
+          properties:
+            credits:
+              type: array
+              items:
+                $ref: '#/components/schemas/CreditObject'
+    AppliedCouponsPaginated:
+      type: object
+      required:
+        - applied_coupons
+        - meta
+      properties:
+        applied_coupons:
+          type: array
+          items:
+            $ref: '#/components/schemas/AppliedCouponObjectExtended'
+        meta:
+          $ref: '#/components/schemas/PaginationMeta'
     BillableMetric:
       type: object
       required:
@@ -2461,6 +2655,324 @@ components:
             $ref: '#/components/schemas/BillableMetricObject'
         meta:
           $ref: '#/components/schemas/PaginationMeta'
+    Coupon:
+      type: object
+      required:
+        - coupon
+      properties:
+        coupon:
+          $ref: '#/components/schemas/CouponObject'
+    CouponBaseInput:
+      type: object
+      properties:
+        name:
+          type: string
+          description: The name of the coupon.
+          example: Startup Deal
+        code:
+          type: string
+          description: Unique code used to identify the coupon.
+          example: startup_deal
+        coupon_type:
+          type: string
+          enum:
+            - fixed_amount
+            - percentage
+          description: |-
+            The type of the coupon. It can have two possible values: `fixed_amount` or `percentage`.
+
+            - If set to `fixed_amount`, the coupon represents a fixed amount discount.
+            - If set to `percentage`, the coupon represents a percentage-based discount.
+          example: fixed_amount
+        amount_cents:
+          type: integer
+          nullable: true
+          description: The amount of the coupon in cents. This field is required only for coupon with `fixed_amount` type.
+          example: 5000
+        amount_currency:
+          allOf:
+            - $ref: '#/components/schemas/Currency'
+            - description: The currency of the coupon. This field is required only for coupon with `fixed_amount` type.
+              nullable: true
+              example: USD
+        reusable:
+          type: boolean
+          description: 'Indicates whether the coupon can be reused or not. If set to `true`, the coupon is reusable, meaning it can be applied multiple times to the same customer. If set to `false`, the coupon can only be used once and is not reusable. If not specified, this field is set to `true` by default.'
+          example: false
+        percentage_rate:
+          type: string
+          format: '^[0-9]+.?[0-9]*$'
+          nullable: true
+          description: The percentage rate of the coupon. This field is required only for coupons with a `percentage` coupon type.
+          example: null
+        frequency:
+          type: string
+          enum:
+            - once
+            - recurring
+          description: |-
+            The type of frequency for the coupon. It can have three possible values: `once`, `recurring` or `forever`.
+
+            - If set to `once`, the coupon is applicable only for a single use.
+            - If set to `recurring`, the coupon can be used multiple times for recurring billing periods.
+            - If set to `forever`, the coupon has unlimited usage and can be applied indefinitely.
+          example: recurring
+        frequency_duration:
+          type: integer
+          nullable: true
+          description: Specifies the number of billing periods to which the coupon applies. This field is required only for coupons with a `recurring` frequency type
+          example: 6
+        expiration:
+          type: string
+          enum:
+            - no_expiration
+            - time_limit
+          description: |-
+            Specifies the type of expiration for the coupon. It can have two possible values: `time_limit` or `no_expiration`.
+
+            - If set to `time_limit`, the coupon has an expiration based on a specified time limit.
+            - If set to `no_expiration`, the coupon does not have an expiration date and remains valid indefinitely.
+          example: time_limit
+        expiration_at:
+          type: string
+          format: date-time
+          nullable: true
+          description: The expiration date and time of the coupon. This field is required only for coupons with `expiration` set to `time_limit`. The expiration date and time should be specified in UTC format according to the ISO 8601 datetime standard. It indicates the exact moment when the coupon will expire and is no longer valid.
+          example: '2022-08-08T23:59:59Z'
+        applies_to:
+          type: object
+          description: Set coupon limitations to plans or specific metrics.
+          nullable: true
+          properties:
+            plan_codes:
+              type: array
+              nullable: true
+              items:
+                type: string
+              description: 'An array of plan codes to which the coupon is applicable. By specifying the plan codes in this field, you can restrict the coupon''s usage to specific plans only.'
+              example:
+                - startup_plan
+            billable_metric_codes:
+              type: array
+              nullable: true
+              items:
+                type: string
+              description: 'An array of billable metric codes to which the coupon is applicable. By specifying the billable metric codes in this field, you can restrict the coupon''s usage to specific metrics only.'
+              example: []
+    CouponCreateInput:
+      type: object
+      required:
+        - coupon
+      properties:
+        coupon:
+          allOf:
+            - $ref: '#/components/schemas/CouponBaseInput'
+            - required:
+                - name
+                - code
+                - coupon_type
+                - frequency
+    CouponObject:
+      type: object
+      required:
+        - lago_id
+        - name
+        - code
+        - expiration
+        - coupon_type
+        - frequency
+        - created_at
+        - reusable
+        - limited_plans
+        - limited_billable_metrics
+      properties:
+        lago_id:
+          type: string
+          format: uuid
+          description: 'Unique identifier of the coupon, created by Lago.'
+          example: 1a901a90-1a90-1a90-1a90-1a901a901a90
+        name:
+          type: string
+          description: The name of the coupon.
+          example: Startup Deal
+        code:
+          type: string
+          description: Unique code used to identify the coupon.
+          example: startup_deal
+        coupon_type:
+          type: string
+          enum:
+            - fixed_amount
+            - percentage
+          description: |-
+            The type of the coupon. It can have two possible values: `fixed_amount` or `percentage`.
+
+            - If set to `fixed_amount`, the coupon represents a fixed amount discount.
+            - If set to `percentage`, the coupon represents a percentage-based discount.
+          example: fixed_amount
+        amount_cents:
+          type: integer
+          nullable: true
+          description: The amount of the coupon in cents. This field is required only for coupon with `fixed_amount` type.
+          example: 5000
+        amount_currency:
+          allOf:
+            - $ref: '#/components/schemas/Currency'
+            - nullable: true
+              description: The currency of the coupon. This field is required only for coupon with `fixed_amount` type.
+              example: USD
+        reusable:
+          type: boolean
+          description: 'Indicates whether the coupon can be reused or not. If set to `true`, the coupon is reusable, meaning it can be applied multiple times to the same customer. If set to `false`, the coupon can only be used once and is not reusable. If not specified, this field is set to `true` by default.'
+          example: true
+        limited_plans:
+          type: boolean
+          description: The coupon is limited to specific plans. The possible values can be `true` or `false`.
+          example: true
+        plan_codes:
+          type: array
+          description: 'An array of plan codes to which the coupon is applicable. By specifying the plan codes in this field, you can restrict the coupon''s usage to specific plans only.'
+          items:
+            type: string
+          example:
+            - startup_plan
+        limited_billable_metrics:
+          type: boolean
+          description: The coupon is limited to specific billable metrics. The possible values can be `true` or `false`.
+          example: false
+        billable_metric_codes:
+          type: array
+          description: 'An array of billable metric codes to which the coupon is applicable. By specifying the billable metric codes in this field, you can restrict the coupon''s usage to specific metrics only.'
+          items:
+            type: string
+          example: []
+        percentage_rate:
+          type: string
+          format: '^[0-9]+.?[0-9]*$'
+          nullable: true
+          description: The percentage rate of the coupon. This field is required only for coupons with a `percentage` coupon type.
+          example: null
+        frequency:
+          type: string
+          description: |-
+            The type of frequency for the coupon. It can have three possible values: `once`, `recurring`, or `forever`.
+
+            - If set to `once`, the coupon is applicable only for a single use.
+            - If set to `recurring`, the coupon can be used multiple times for recurring billing periods.
+            - If set to `forever`, the coupon has unlimited usage and can be applied indefinitely.
+          enum:
+            - once
+            - recurring
+          example: recurring
+        frequency_duration:
+          type: integer
+          nullable: true
+          description: Specifies the number of billing periods to which the coupon applies. This field is required only for coupons with a `recurring` frequency type
+          example: 6
+        expiration:
+          type: string
+          description: |-
+            Specifies the type of expiration for the coupon. It can have two possible values: `time_limit` or `no_expiration`.
+
+            - If set to `time_limit`, the coupon has an expiration based on a specified time limit.
+            - If set to `no_expiration`, the coupon does not have an expiration date and remains valid indefinitely.
+          enum:
+            - no_expiration
+            - time_limit
+          example: time_limit
+        expiration_at:
+          type: string
+          format: date-time
+          nullable: true
+          description: The expiration date and time of the coupon. This field is required only for coupons with `expiration` set to `time_limit`. The expiration date and time should be specified in UTC format according to the ISO 8601 datetime standard. It indicates the exact moment when the coupon will expire and is no longer valid.
+          example: '2022-08-08T23:59:59Z'
+        created_at:
+          type: string
+          format: date-time
+          description: The date and time when the coupon was created. It is expressed in UTC format according to the ISO 8601 datetime standard. This field provides the timestamp for the exact moment when the coupon was initially created.
+          example: '2022-04-29T08:59:51Z'
+    CouponsPaginated:
+      type: object
+      required:
+        - coupons
+        - meta
+      properties:
+        coupons:
+          type: array
+          items:
+            $ref: '#/components/schemas/CouponObject'
+        meta:
+          $ref: '#/components/schemas/PaginationMeta'
+    CouponUpdateInput:
+      type: object
+      required:
+        - coupon
+      properties:
+        coupon:
+          allOf:
+            - $ref: '#/components/schemas/CouponBaseInput'
+    CreditObject:
+      type: object
+      required:
+        - lago_id
+        - item
+        - amount_cents
+        - amount_currency
+        - invoice
+        - before_vat
+      properties:
+        lago_id:
+          type: string
+          format: uuid
+          example: 1a901a90-1a90-1a90-1a90-1a901a901a90
+        amount_cents:
+          type: integer
+          example: 1200
+        amount_currency:
+          allOf:
+            - $ref: '#/components/schemas/Currency'
+            - example: EUR
+        before_vat:
+          type: boolean
+          example: false
+        item:
+          type: object
+          required:
+            - lago_id
+            - type
+            - code
+            - name
+          properties:
+            lago_id:
+              type: string
+              format: uuid
+              example: 1a901a90-1a90-1a90-1a90-1a901a901a90
+            type:
+              type: string
+              example: coupon
+            code:
+              type: string
+              example: startup_deal
+            name:
+              type: string
+              example: Startup Deal
+        invoice:
+          type: object
+          required:
+            - lago_id
+            - payment_status
+          properties:
+            lago_id:
+              type: string
+              format: uuid
+              example: 1a901a90-1a90-1a90-1a90-1a901a901a90
+            payment_status:
+              type: string
+              enum:
+                - pending
+                - succeeded
+                - failed
+              example: succeeded
     Currency:
       type: string
       example: USD
@@ -3856,306 +4368,6 @@ components:
         - Pacific/Pago_Pago
         - Pacific/Port_Moresby
         - Pacific/Tongatapu
-    CouponObject:
-      type: object
-      required:
-        - lago_id
-        - name
-        - code
-        - expiration
-        - coupon_type
-        - frequency
-        - created_at
-      properties:
-        lago_id:
-          type: string
-          format: uuid
-          example: 1a901a90-1a90-1a90-1a90-1a901a901a90
-        name:
-          type: string
-          example: coupon1
-        code:
-          type: string
-          example: example_code
-        coupon_type:
-          type: string
-          description: Coupon type
-          enum:
-            - fixed_amount
-            - percentage
-        amount_cents:
-          type: integer
-          example: 1200
-        amount_currency:
-          type: string
-          example: EUR
-        reusable:
-          type: boolean
-          example: true
-        limited_plans:
-          type: boolean
-          example: true
-        plan_codes:
-          type: array
-          items:
-            type: string
-            example: code1
-        limited_billable_metrics:
-          type: boolean
-          example: true
-        billable_metric_codes:
-          type: array
-          items:
-            type: string
-            example: code2
-        created_at:
-          type: string
-          format: date-time
-          example: '2022-09-14T16:35:31Z'
-        percentage_rate:
-          type: number
-          example: 25
-        frequency:
-          type: string
-          description: Frequency type
-          enum:
-            - once
-            - recurring
-        frequency_duration:
-          type: integer
-          example: 3
-        expiration_at:
-          type: string
-          format: date-time
-          example: '2022-09-14T23:59:59Z'
-        expiration:
-          type: string
-          description: Expiration type
-          enum:
-            - no_expiration
-            - time_limit
-    Coupon:
-      type: object
-      required:
-        - coupon
-      properties:
-        coupon:
-          $ref: '#/components/schemas/CouponObject'
-    CouponsPaginated:
-      type: object
-      required:
-        - coupons
-        - meta
-      properties:
-        coupons:
-          type: array
-          items:
-            $ref: '#/components/schemas/CouponObject'
-        meta:
-          $ref: '#/components/schemas/PaginationMeta'
-    CouponInput:
-      type: object
-      required:
-        - coupon
-      properties:
-        coupon:
-          type: object
-          properties:
-            name:
-              type: string
-              example: coupon1
-            code:
-              type: string
-              example: example_code
-            coupon_type:
-              type: string
-              description: Coupon type
-              enum:
-                - fixed_amount
-                - percentage
-            amount_cents:
-              type: integer
-              example: 1200
-            amount_currency:
-              type: string
-              example: EUR
-            reusable:
-              type: boolean
-              example: true
-            percentage_rate:
-              type: number
-              example: 25
-            frequency:
-              type: string
-              description: Frequency type
-              enum:
-                - once
-                - recurring
-            frequency_duration:
-              type: integer
-              example: 3
-            expiration_at:
-              type: string
-              format: date-time
-              example: '2022-09-14T23:59:59Z'
-            expiration:
-              type: string
-              description: Expiration type
-              enum:
-                - no_expiration
-                - time_limit
-            applies_to:
-              type: object
-              properties:
-                plan_codes:
-                  type: array
-                  items:
-                    type: string
-                    example: code1
-                billable_metric_codes:
-                  type: array
-                  items:
-                    type: string
-                    example: code2
-    AppliedCouponObject:
-      type: object
-      required:
-        - lago_id
-        - lago_coupon_id
-        - coupon_code
-        - external_customer_id
-        - lago_customer_id
-        - status
-        - amount_cents
-        - amount_currency
-        - frequency
-        - created_at
-      properties:
-        lago_id:
-          type: string
-          format: uuid
-          example: 1a901a90-1a90-1a90-1a90-1a901a901a90
-        lago_coupon_id:
-          type: string
-          format: uuid
-          example: 1a901a90-1a90-1a90-1a90-1a901a901a90
-        coupon_code:
-          type: string
-          example: example_code
-        lago_customer_id:
-          type: string
-          format: uuid
-          example: 1a901a90-1a90-1a90-1a90-1a901a901a90
-        external_customer_id:
-          type: string
-          example: '123456'
-        status:
-          type: string
-          description: Status
-          enum:
-            - active
-            - terminated
-        amount_cents:
-          type: integer
-          example: 1200
-        amount_cents_remaining:
-          type: integer
-          example: 800
-        amount_currency:
-          type: string
-          example: EUR
-        percentage_rate:
-          type: number
-          example: 25
-        frequency:
-          type: string
-          description: Frequency type
-          enum:
-            - once
-            - recurring
-        frequency_duration:
-          type: integer
-          example: 3
-        frequency_duration_remaining:
-          type: integer
-          example: 2
-        expiration_at:
-          type: string
-          format: date-time
-          example: '2022-09-14T23:59:59Z'
-        created_at:
-          type: string
-          format: date-time
-          example: '2022-09-14T16:35:31Z'
-        terminated_at:
-          type: string
-          format: date-time
-          example: '2022-09-14T16:35:31Z'
-    AppliedCouponObjectExtended:
-      allOf:
-        - $ref: '#/components/schemas/AppliedCouponObject'
-        - type: object
-          required:
-            - credits
-          properties:
-            credits:
-              type: array
-              items:
-                $ref: '#/components/schemas/CreditObject'
-    AppliedCoupon:
-      type: object
-      required:
-        - applied_coupon
-      properties:
-        applied_coupon:
-          $ref: '#/components/schemas/AppliedCouponObject'
-    AppliedCouponsPaginated:
-      type: object
-      required:
-        - applied_coupons
-        - meta
-      properties:
-        applied_coupons:
-          type: array
-          items:
-            $ref: '#/components/schemas/AppliedCouponObjectExtended'
-        meta:
-          $ref: '#/components/schemas/PaginationMeta'
-    AppliedCouponInput:
-      type: object
-      required:
-        - applied_coupon
-      properties:
-        applied_coupon:
-          type: object
-          required:
-            - external_customer_id
-            - coupon_code
-          properties:
-            external_customer_id:
-              type: string
-              example: '123456'
-            coupon_code:
-              type: string
-              example: example_code
-            frequency:
-              type: string
-              description: Frequency type
-              enum:
-                - once
-                - recurring
-            frequency_duration:
-              type: integer
-              example: 3
-            amount_cents:
-              type: integer
-              example: 1200
-            amount_currency:
-              type: string
-              example: EUR
-            percentage_rate:
-              type: number
-              example: 25
     EventEstimateFeesInput:
       type: object
       required:
@@ -4435,66 +4647,6 @@ components:
                           example: '123456'
                         values:
                           type: object
-    CreditObject:
-      type: object
-      required:
-        - lago_id
-        - item
-        - amount_cents
-        - amount_currency
-        - invoice
-        - before_vat
-      properties:
-        lago_id:
-          type: string
-          format: uuid
-          example: 1a901a90-1a90-1a90-1a90-1a901a901a90
-        amount_cents:
-          type: integer
-          example: 1200
-        amount_currency:
-          type: string
-          example: EUR
-        before_vat:
-          type: boolean
-          example: false
-        item:
-          type: object
-          required:
-            - lago_id
-            - type
-            - code
-            - name
-          properties:
-            lago_id:
-              type: string
-              format: uuid
-              example: 1a901a90-1a90-1a90-1a90-1a901a901a90
-            type:
-              type: string
-              example: coupon
-            code:
-              type: string
-              example: code
-            name:
-              type: string
-              example: name
-        invoice:
-          type: object
-          required:
-            - lago_id
-            - payment_status
-          properties:
-            lago_id:
-              type: string
-              format: uuid
-              example: 1a901a90-1a90-1a90-1a90-1a901a901a90
-            payment_status:
-              type: string
-              enum:
-                - pending
-                - succeeded
-                - failed
     FeeObject:
       type: object
       required:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2673,6 +2673,11 @@ components:
           type: string
           description: Unique code used to identify the coupon.
           example: startup_deal
+        description:
+          type: string
+          nullable: true
+          description: Description of the coupon.
+          example: I am a coupon description
         coupon_type:
           type: string
           enum:
@@ -2799,6 +2804,11 @@ components:
           type: string
           description: Unique code used to identify the coupon.
           example: startup_deal
+        description:
+          type: string
+          nullable: true
+          description: Description of the coupon.
+          example: I am a coupon description
         coupon_type:
           type: string
           enum:

--- a/src/openapi.yaml
+++ b/src/openapi.yaml
@@ -41,16 +41,16 @@ tags:
     externalDocs:
       description: Find out more
       url: https://doc.getlago.com/docs/api/organizations/organization-object
-  - name: add_ons
-    description: Everything about Add-on collection
-    externalDocs:
-      description: Find out more
-      url: https://doc.getlago.com/docs/api/add_ons/add-on-object
   - name: coupons
     description: Everything about Coupon collection
     externalDocs:
       description: Find out more
       url: https://doc.getlago.com/docs/api/coupons/coupon-object
+  - name: add_ons
+    description: Everything about Add-on collection
+    externalDocs:
+      description: Find out more
+      url: https://doc.getlago.com/docs/api/add_ons/add-on-object
   - name: plans
     description: Everything about Plan collection
     externalDocs:
@@ -85,16 +85,24 @@ paths:
     $ref: './resources/add_on.yaml'
   /applied_add_ons:
     $ref: './resources/applied_add_ons.yaml'
+  /applied_coupons:
+    $ref: './resources/applied_coupons.yaml'
   /billable_metrics:
     $ref: './resources/billable_metrics.yaml'
   /billable_metrics/{code}:
     $ref: './resources/billable_metric.yaml'
   /billable_metrics/{code}/groups:
     $ref: './resources/billable_metric_groups.yaml'
+  /coupons:
+    $ref: './resources/coupons.yaml'
+  /coupons/{code}:
+    $ref: './resources/coupon.yaml'
   /customers:
     $ref: './resources/customers.yaml'
   /customers/{external_id}:
     $ref: './resources/customer.yaml'
+  /customers/{external_customer_id}/applied_coupons/{applied_coupon_id}:
+    $ref: './resources/customer_applied_coupon.yaml'
   /customers/{external_customer_id}/portal_url:
     $ref: './resources/customer_portal_url.yaml'
   /customers/{external_customer_id}/current_usage:
@@ -114,222 +122,6 @@ paths:
 
 
   # TODO: split requests into multiple files
-  /coupons:
-    post:
-      tags:
-        - coupons
-      summary: Create a new coupon
-      description: Create a new coupon
-      operationId: createCoupon
-      requestBody:
-        description: Coupon payload
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/CouponInput'
-        required: true
-      responses:
-        '200':
-          description: Successful response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Coupon'
-        '400':
-          $ref: './responses/BadRequest.yaml'
-        '401':
-          $ref: './responses/Unauthorized.yaml'
-        '422':
-          $ref: './responses/UnprocessableEntity.yaml'
-    get:
-      tags:
-        - coupons
-      summary: Find Coupons
-      description: Find all coupons in certain organisation
-      operationId: findAllCoupons
-      parameters:
-        - $ref: './parameters/page.yaml'
-        - $ref: './parameters/per_page.yaml'
-      responses:
-        '200':
-          description: Successful response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/CouponsPaginated'
-        '401':
-          $ref: './responses/Unauthorized.yaml'
-  /coupons/{code}:
-    parameters:
-      - name: code
-        in: path
-        description: Code of the existing coupon
-        required: true
-        schema:
-          type: string
-          example: 'example_code'
-    put:
-      tags:
-        - coupons
-      summary: Update an existing coupon
-      description: Update an existing coupon by code
-      operationId: updateCoupon
-      requestBody:
-        description: Update an existing coupon
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/CouponInput'
-        required: true
-      responses:
-        '200':
-          description: Successful response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Coupon'
-        '400':
-          $ref: './responses/BadRequest.yaml'
-        '401':
-          $ref: './responses/Unauthorized.yaml'
-        '404':
-          $ref: './responses/NotFound.yaml'
-        '422':
-          $ref: './responses/UnprocessableEntity.yaml'
-    get:
-      tags:
-        - coupons
-      summary: Find coupon by code
-      description: Return a single coupon
-      operationId: findCoupon
-      responses:
-        '200':
-          description: Successful response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Coupon'
-        '401':
-          $ref: './responses/Unauthorized.yaml'
-        '404':
-          $ref: './responses/NotFound.yaml'
-    delete:
-      tags:
-        - coupons
-      summary: Delete a coupon
-      description: Delete a coupon
-      operationId: destroyCoupon
-      responses:
-        '200':
-          description: Successful response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Coupon'
-        '401':
-          $ref: './responses/Unauthorized.yaml'
-        '404':
-          $ref: './responses/NotFound.yaml'
-  /applied_coupons:
-    post:
-      tags:
-        - coupons
-      summary: Apply a coupon to a customer
-      description: Apply a coupon to a customer
-      operationId: applyCoupon
-      requestBody:
-        description: Apply coupon payload
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/AppliedCouponInput'
-        required: true
-      responses:
-        '200':
-          description: Successful response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/AppliedCoupon'
-        '400':
-          $ref: './responses/BadRequest.yaml'
-        '401':
-          $ref: './responses/Unauthorized.yaml'
-        '404':
-          $ref: './responses/NotFound.yaml'
-        '422':
-          $ref: './responses/UnprocessableEntity.yaml'
-    get:
-      tags:
-        - coupons
-      summary: Find Applied Coupons
-      description: Find all applied coupons
-      operationId: findAllAppliedCoupons
-      parameters:
-        - $ref: './parameters/page.yaml'
-        - $ref: './parameters/per_page.yaml'
-        - name: status
-          in: query
-          description: Applied coupon status
-          required: false
-          explode: true
-          schema:
-            type: string
-            description: Status
-            enum:
-              - active
-              - terminated
-        - name: external_customer_id
-          in: query
-          description: External customer ID
-          required: false
-          explode: true
-          schema:
-            type: string
-            example: '12345'
-      responses:
-        '200':
-          description: Successful response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/AppliedCouponsPaginated'
-        '401':
-          $ref: './responses/Unauthorized.yaml'
-  /customers/{external_customer_id}/applied_coupons/{applied_coupon_id}:
-    delete:
-      tags:
-        - customers
-      summary: Delete customer's appplied coupon
-      parameters:
-        - name: external_customer_id
-          in: path
-          description: External ID of the existing customer
-          required: true
-          schema:
-            type: string
-            example: '12345'
-        - name: applied_coupon_id
-          in: path
-          description: Applied Coupon Lago ID
-          required: true
-          explode: true
-          schema:
-            type: string
-            example: '54321'
-      description: Delete customer's appplied coupon
-      operationId: deleteAppliedCoupon
-      responses:
-        '200':
-          description: Successful response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/AppliedCoupon'
-        '401':
-          $ref: './responses/Unauthorized.yaml'
-        '404':
-          $ref: './responses/NotFound.yaml'
   /events/estimate_fees:
     post:
       tags:

--- a/src/resources/applied_coupons.yaml
+++ b/src/resources/applied_coupons.yaml
@@ -1,0 +1,65 @@
+post:
+  tags:
+    - coupons
+  summary: Apply a coupon to a customer
+  description: This endpoint is used to apply a specific coupon to a customer, before or during a subscription.
+  operationId: applyCoupon
+  requestBody:
+    description: Apply coupon payload
+    content:
+      application/json:
+        schema:
+          $ref: '../schemas/AppliedCouponInput.yaml'
+    required: true
+  responses:
+    '200':
+      description: Coupon applied
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/AppliedCoupon.yaml'
+    '400':
+      $ref: '../responses/BadRequest.yaml'
+    '401':
+      $ref: '../responses/Unauthorized.yaml'
+    '404':
+      $ref: '../responses/NotFound.yaml'
+    '422':
+      $ref: '../responses/UnprocessableEntity.yaml'
+get:
+  tags:
+    - coupons
+  summary: List all applied coupons
+  description: This endpoint is used to list all applied coupons. You can filter by coupon status and by customer.
+  operationId: findAllAppliedCoupons
+  parameters:
+    - $ref: '../parameters/page.yaml'
+    - $ref: '../parameters/per_page.yaml'
+    - name: status
+      in: query
+      description: The status of the coupon. Can be either `active` or `terminated`.
+      required: false
+      explode: true
+      schema:
+        type: string
+        enum:
+          - active
+          - terminated
+        example: active
+    - name: external_customer_id
+      in: query
+      description: The customer external unique identifier (provided by your own application)
+      required: false
+      explode: true
+      schema:
+        type: string
+        example: '5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba'
+  responses:
+    '200':
+      description: Applied Coupons
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/AppliedCouponsPaginated.yaml'
+    '401':
+      $ref: '../responses/Unauthorized.yaml'

--- a/src/resources/coupon.yaml
+++ b/src/resources/coupon.yaml
@@ -1,0 +1,70 @@
+parameters:
+  - name: code
+    in: path
+    description: Unique code used to identify the coupon.
+    required: true
+    schema:
+      type: string
+      example: 'startup_deal'
+put:
+  tags:
+    - coupons
+  summary: Update a coupon
+  description: This endpoint is used to update a coupon that can be then attached to a customer to create a discount.
+  operationId: updateCoupon
+  requestBody:
+    description: Coupon payload
+    content:
+      application/json:
+        schema:
+          $ref: '../schemas/CouponUpdateInput.yaml'
+    required: true
+  responses:
+    '200':
+      description: Coupon updated
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/Coupon.yaml'
+    '400':
+      $ref: '../responses/BadRequest.yaml'
+    '401':
+      $ref: '../responses/Unauthorized.yaml'
+    '404':
+      $ref: '../responses/NotFound.yaml'
+    '422':
+      $ref: '../responses/UnprocessableEntity.yaml'
+get:
+  tags:
+    - coupons
+  summary: Retrieve a coupon
+  description: This endpoint is used to retrieve a specific coupon.
+  operationId: findCoupon
+  responses:
+    '200':
+      description: Coupon
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/Coupon.yaml'
+    '401':
+      $ref: '../responses/Unauthorized.yaml'
+    '404':
+      $ref: '../responses/NotFound.yaml'
+delete:
+  tags:
+    - coupons
+  summary: Delete a coupon
+  description: This endpoint is used to delete a coupon.
+  operationId: destroyCoupon
+  responses:
+    '200':
+      description: Coupon deleted
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/Coupon.yaml'
+    '401':
+      $ref: '../responses/Unauthorized.yaml'
+    '404':
+      $ref: '../responses/NotFound.yaml'

--- a/src/resources/coupons.yaml
+++ b/src/resources/coupons.yaml
@@ -1,0 +1,44 @@
+post:
+  tags:
+    - coupons
+  summary: Create a coupon
+  description: This endpoint is used to create a coupon that can be then attached to a customer to create a discount.
+  operationId: createCoupon
+  requestBody:
+    description: Coupon payload
+    content:
+      application/json:
+        schema:
+          $ref: '../schemas/CouponCreateInput.yaml'
+    required: true
+  responses:
+    '200':
+      description: Coupon created
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/Coupon.yaml'
+    '400':
+      $ref: '../responses/BadRequest.yaml'
+    '401':
+      $ref: '../responses/Unauthorized.yaml'
+    '422':
+      $ref: '../responses/UnprocessableEntity.yaml'
+get:
+  tags:
+    - coupons
+  summary: List all coupons
+  description: This endpoint is used to list all existing coupons.
+  operationId: findAllCoupons
+  parameters:
+    - $ref: '../parameters/page.yaml'
+    - $ref: '../parameters/per_page.yaml'
+  responses:
+    '200':
+      description: Coupons
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/CouponsPaginated.yaml'
+    '401':
+      $ref: '../responses/Unauthorized.yaml'

--- a/src/resources/customer_applied_coupon.yaml
+++ b/src/resources/customer_applied_coupon.yaml
@@ -1,0 +1,35 @@
+delete:
+  tags:
+    - coupons
+    - customers
+  summary: Delete an applied coupon
+  description: This endpoint is used to delete a specific coupon that has been applied to a customer.
+  parameters:
+    - name: external_customer_id
+      in: path
+      description: The customer external unique identifier (provided by your own application)
+      required: true
+      schema:
+        type: string
+        example: '5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba'
+    - name: applied_coupon_id
+      in: path
+      description: Unique identifier of the applied coupon, created by Lago.
+      required: true
+      explode: true
+      schema:
+        type: string
+        format: 'uuid'
+        example: '1a901a90-1a90-1a90-1a90-1a901a901a90'
+  operationId: deleteAppliedCoupon
+  responses:
+    '200':
+      description: Successful response
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/AppliedCoupon.yaml'
+    '401':
+      $ref: '../responses/Unauthorized.yaml'
+    '404':
+      $ref: '../responses/NotFound.yaml'

--- a/src/schemas/AppliedCoupon.yaml
+++ b/src/schemas/AppliedCoupon.yaml
@@ -1,0 +1,6 @@
+type: object
+required:
+  - applied_coupon
+properties:
+  applied_coupon:
+    $ref: './AppliedCouponObject.yaml'

--- a/src/schemas/AppliedCouponInput.yaml
+++ b/src/schemas/AppliedCouponInput.yaml
@@ -1,0 +1,53 @@
+type: object
+required:
+  - applied_coupon
+properties:
+  applied_coupon:
+    type: object
+    required:
+      - external_customer_id
+      - coupon_code
+    properties:
+      external_customer_id:
+        type: string
+        description: The customer external unique identifier (provided by your own application)
+        example: '5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba'
+      coupon_code:
+        type: string
+        description: Unique code used to identify the coupon.
+        example: 'startup_deal'
+      frequency:
+        type: string
+        enum:
+          - once
+          - recurring
+        nullable: true
+        description: |-
+          The type of frequency for the coupon. It can have three possible values: `once`, `recurring` or `forever`.
+
+          - If set to `once`, the coupon is applicable only for a single use.
+          - If set to `recurring`, the coupon can be used multiple times for recurring billing periods.
+          - If set to `forever`, the coupon has unlimited usage and can be applied indefinitely.
+        example: recurring
+      frequency_duration:
+        type: integer
+        nullable: true
+        description: Specifies the number of billing periods to which the coupon applies. This field is required only for coupons with a `recurring` frequency type
+        example: 3
+      amount_cents:
+        type: integer
+        nullable: true
+        description: The amount of the coupon in cents. This field is required only for coupon with `fixed_amount` type.
+        example: 2000
+      amount_currency:
+        allOf:
+          - $ref: './Currency.yaml'
+          - nullable: true
+            description: The currency of the coupon. This field is required only for coupon with `fixed_amount` type.
+            example: 'EUR'
+      percentage_rate:
+        type: string
+        format: '^[0-9]+.?[0-9]*$'
+        nullable: true
+        description: The percentage rate of the coupon. This field is required only for coupons with a `percentage` coupon type.
+        example: null

--- a/src/schemas/AppliedCouponObject.yaml
+++ b/src/schemas/AppliedCouponObject.yaml
@@ -1,0 +1,107 @@
+type: object
+required:
+  - lago_id
+  - lago_coupon_id
+  - coupon_code
+  - coupon_name
+  - external_customer_id
+  - lago_customer_id
+  - status
+  - frequency
+  - created_at
+properties:
+  lago_id:
+    type: string
+    format: 'uuid'
+    description: Unique identifier of the applied coupon, created by Lago.
+    example: '1a901a90-1a90-1a90-1a90-1a901a901a90'
+  lago_coupon_id:
+    type: string
+    format: 'uuid'
+    description: Unique identifier of the coupon, created by Lago.
+    example: '1a901a90-1a90-1a90-1a90-1a901a901a90'
+  coupon_code:
+    type: string
+    description: Unique code used to identify the coupon.
+    example: 'startup_deal'
+  coupon_name:
+    type: string
+    description: The name of the coupon.
+    example: Startup Deal
+  lago_customer_id:
+    type: string
+    format: 'uuid'
+    description: Unique identifier of the customer, created by Lago.
+    example: '1a901a90-1a90-1a90-1a90-1a901a901a90'
+  external_customer_id:
+    type: string
+    description: The customer external unique identifier (provided by your own application)
+    example: '5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba'
+  status:
+    type: string
+    enum:
+      - active
+      - terminated
+    description: The status of the coupon. Can be either `active` or `terminated`.
+    example: active
+  amount_cents:
+    type: integer
+    nullable: true
+    description: The amount of the coupon in cents. This field is required only for coupon with `fixed_amount` type.
+    example: 2000
+  amount_cents_remaining:
+    type: integer
+    nullable: true
+    description: The remaining amount in cents for a `fixed_amount` coupon with a frequency set to `once`. This field indicates the remaining balance or value that can still be utilized from the coupon.
+    example: 50
+  amount_currency:
+    allOf:
+      - $ref: './Currency.yaml'
+      - nullable: true
+        description: The currency of the coupon. This field is required only for coupon with `fixed_amount` type.
+        example: 'EUR'
+  percentage_rate:
+    type: string
+    format: '^[0-9]+.?[0-9]*$'
+    nullable: true
+    description: The percentage rate of the coupon. This field is required only for coupons with a `percentage` coupon type.
+    example: null
+  frequency:
+    type: string
+    enum:
+      - once
+      - recurring
+    description: |-
+      The type of frequency for the coupon. It can have three possible values: `once`, `recurring` or `forever`.
+
+      - If set to `once`, the coupon is applicable only for a single use.
+      - If set to `recurring`, the coupon can be used multiple times for recurring billing periods.
+      - If set to `forever`, the coupon has unlimited usage and can be applied indefinitely.
+    example: recurring
+  frequency_duration:
+    type: integer
+    nullable: true
+    description: Specifies the number of billing periods to which the coupon applies. This field is required only for coupons with a `recurring` frequency type
+    example: 3
+  frequency_duration_remaining:
+    type: integer
+    nullable: true
+    description: The remaining number of billing periods to which the coupon is applicable. This field determines the remaining usage or availability of the coupon based on the remaining billing periods.
+    example: 1
+  expiration_at:
+    type: string
+    format: 'date-time'
+    nullable: true
+    description: The date and time after which the coupon will stop applying to customer's invoices. Once the expiration date is reached, the coupon will no longer be applicable, and any further invoices generated for the customer will not include the coupon discount.
+    example: '2022-04-29T08:59:51Z'
+  created_at:
+    type: string
+    format: 'date-time'
+    description: The date and time when the coupon was assigned to a customer. It is expressed in UTC format according to the ISO 8601 datetime standard.
+    example: '2022-04-29T08:59:51Z'
+  terminated_at:
+    type: string
+    format: 'date-time'
+    nullable: true
+    description: This field indicates the specific moment when the coupon amount is fully utilized or when the coupon is removed from the customer's coupon list. It is expressed in UTC format according to the ISO 8601 datetime standard.
+    example: '2022-04-29T08:59:51Z'

--- a/src/schemas/AppliedCouponObjectExtended.yaml
+++ b/src/schemas/AppliedCouponObjectExtended.yaml
@@ -1,0 +1,10 @@
+allOf:
+  - $ref: './AppliedCouponObject.yaml'
+  - type: object
+    required:
+      - credits
+    properties:
+      credits:
+        type: array
+        items:
+          $ref: './CreditObject.yaml'

--- a/src/schemas/AppliedCouponsPaginated.yaml
+++ b/src/schemas/AppliedCouponsPaginated.yaml
@@ -1,0 +1,11 @@
+type: object
+required:
+  - applied_coupons
+  - meta
+properties:
+  applied_coupons:
+    type: array
+    items:
+      $ref: './AppliedCouponObjectExtended.yaml'
+  meta:
+    $ref: './PaginationMeta.yaml'

--- a/src/schemas/Coupon.yaml
+++ b/src/schemas/Coupon.yaml
@@ -1,0 +1,6 @@
+type: object
+required:
+  - coupon
+properties:
+  coupon:
+    $ref: './CouponObject.yaml'

--- a/src/schemas/CouponBaseInput.yaml
+++ b/src/schemas/CouponBaseInput.yaml
@@ -8,6 +8,11 @@ properties:
     type: string
     description: Unique code used to identify the coupon.
     example: 'startup_deal'
+  description:
+    type: string
+    nullable: true
+    description: Description of the coupon.
+    example: 'I am a coupon description'
   coupon_type:
     type: string
     enum:

--- a/src/schemas/CouponBaseInput.yaml
+++ b/src/schemas/CouponBaseInput.yaml
@@ -1,0 +1,95 @@
+type: object
+properties:
+  name:
+    type: string
+    description: The name of the coupon.
+    example: 'Startup Deal'
+  code:
+    type: string
+    description: Unique code used to identify the coupon.
+    example: 'startup_deal'
+  coupon_type:
+    type: string
+    enum:
+      - fixed_amount
+      - percentage
+    description: |-
+      The type of the coupon. It can have two possible values: `fixed_amount` or `percentage`.
+
+      - If set to `fixed_amount`, the coupon represents a fixed amount discount.
+      - If set to `percentage`, the coupon represents a percentage-based discount.
+    example: fixed_amount
+  amount_cents:
+    type: integer
+    nullable: true
+    description: The amount of the coupon in cents. This field is required only for coupon with `fixed_amount` type.
+    example: 5000
+  amount_currency:
+    allOf:
+      - $ref: './Currency.yaml'
+      - description: The currency of the coupon. This field is required only for coupon with `fixed_amount` type.
+        nullable: true
+        example: 'USD'
+  reusable:
+    type: boolean
+    description: Indicates whether the coupon can be reused or not. If set to `true`, the coupon is reusable, meaning it can be applied multiple times to the same customer. If set to `false`, the coupon can only be used once and is not reusable. If not specified, this field is set to `true` by default.
+    example: false
+  percentage_rate:
+    type: string
+    format: '^[0-9]+.?[0-9]*$'
+    nullable: true
+    description: The percentage rate of the coupon. This field is required only for coupons with a `percentage` coupon type.
+    example: null
+  frequency:
+    type: string
+    enum:
+      - once
+      - recurring
+    description: |-
+      The type of frequency for the coupon. It can have three possible values: `once`, `recurring` or `forever`.
+
+      - If set to `once`, the coupon is applicable only for a single use.
+      - If set to `recurring`, the coupon can be used multiple times for recurring billing periods.
+      - If set to `forever`, the coupon has unlimited usage and can be applied indefinitely.
+    example: 'recurring'
+  frequency_duration:
+    type: integer
+    nullable: true
+    description: Specifies the number of billing periods to which the coupon applies. This field is required only for coupons with a `recurring` frequency type
+    example: 6
+  expiration:
+    type: string
+    enum:
+      - no_expiration
+      - time_limit
+    description: |-
+      Specifies the type of expiration for the coupon. It can have two possible values: `time_limit` or `no_expiration`.
+
+      - If set to `time_limit`, the coupon has an expiration based on a specified time limit.
+      - If set to `no_expiration`, the coupon does not have an expiration date and remains valid indefinitely.
+    example: time_limit
+  expiration_at:
+    type: string
+    format: 'date-time'
+    nullable: true
+    description: The expiration date and time of the coupon. This field is required only for coupons with `expiration` set to `time_limit`. The expiration date and time should be specified in UTC format according to the ISO 8601 datetime standard. It indicates the exact moment when the coupon will expire and is no longer valid.
+    example: '2022-08-08T23:59:59Z'
+  applies_to:
+    type: object
+    description: Set coupon limitations to plans or specific metrics.
+    nullable: true
+    properties:
+      plan_codes:
+        type: array
+        nullable: true
+        items:
+          type: string
+        description: An array of plan codes to which the coupon is applicable. By specifying the plan codes in this field, you can restrict the coupon's usage to specific plans only.
+        example: ['startup_plan']
+      billable_metric_codes:
+        type: array
+        nullable: true
+        items:
+          type: string
+        description: An array of billable metric codes to which the coupon is applicable. By specifying the billable metric codes in this field, you can restrict the coupon's usage to specific metrics only.
+        example: []

--- a/src/schemas/CouponCreateInput.yaml
+++ b/src/schemas/CouponCreateInput.yaml
@@ -1,0 +1,12 @@
+type: object
+required:
+  - coupon
+properties:
+  coupon:
+    allOf:
+    - $ref: './CouponBaseInput.yaml'
+    - required:
+      - name
+      - code
+      - coupon_type
+      - frequency

--- a/src/schemas/CouponObject.yaml
+++ b/src/schemas/CouponObject.yaml
@@ -24,6 +24,11 @@ properties:
     type: string
     description: Unique code used to identify the coupon.
     example: 'startup_deal'
+  description:
+    type: string
+    nullable: true
+    description: Description of the coupon.
+    example: 'I am a coupon description'
   coupon_type:
     type: string
     enum:

--- a/src/schemas/CouponObject.yaml
+++ b/src/schemas/CouponObject.yaml
@@ -1,0 +1,117 @@
+type: object
+required:
+  - lago_id
+  - name
+  - code
+  - expiration
+  - coupon_type
+  - frequency
+  - created_at
+  - reusable
+  - limited_plans
+  - limited_billable_metrics
+properties:
+  lago_id:
+    type: string
+    format: 'uuid'
+    description: Unique identifier of the coupon, created by Lago.
+    example: '1a901a90-1a90-1a90-1a90-1a901a901a90'
+  name:
+    type: string
+    description: The name of the coupon.
+    example: 'Startup Deal'
+  code:
+    type: string
+    description: Unique code used to identify the coupon.
+    example: 'startup_deal'
+  coupon_type:
+    type: string
+    enum:
+      - fixed_amount
+      - percentage
+    description: |-
+      The type of the coupon. It can have two possible values: `fixed_amount` or `percentage`.
+
+      - If set to `fixed_amount`, the coupon represents a fixed amount discount.
+      - If set to `percentage`, the coupon represents a percentage-based discount.
+    example: fixed_amount
+  amount_cents:
+    type: integer
+    nullable: true
+    description: The amount of the coupon in cents. This field is required only for coupon with `fixed_amount` type.
+    example: 5000
+  amount_currency:
+    allOf:
+      - $ref: './Currency.yaml'
+      - nullable: true
+        description: The currency of the coupon. This field is required only for coupon with `fixed_amount` type.
+        example: 'USD'
+  reusable:
+    type: boolean
+    description: Indicates whether the coupon can be reused or not. If set to `true`, the coupon is reusable, meaning it can be applied multiple times to the same customer. If set to `false`, the coupon can only be used once and is not reusable. If not specified, this field is set to `true` by default.
+    example: true
+  limited_plans:
+    type: boolean
+    description: The coupon is limited to specific plans. The possible values can be `true` or `false`.
+    example: true
+  plan_codes:
+    type: array
+    description: An array of plan codes to which the coupon is applicable. By specifying the plan codes in this field, you can restrict the coupon's usage to specific plans only.
+    items:
+      type: string
+    example: ['startup_plan']
+  limited_billable_metrics:
+    type: boolean
+    description: The coupon is limited to specific billable metrics. The possible values can be `true` or `false`.
+    example: false
+  billable_metric_codes:
+    type: array
+    description: An array of billable metric codes to which the coupon is applicable. By specifying the billable metric codes in this field, you can restrict the coupon's usage to specific metrics only.
+    items:
+      type: string
+    example: []
+  percentage_rate:
+    type: string
+    format: '^[0-9]+.?[0-9]*$'
+    nullable: true
+    description: The percentage rate of the coupon. This field is required only for coupons with a `percentage` coupon type.
+    example: null
+  frequency:
+    type: string
+    description: |-
+      The type of frequency for the coupon. It can have three possible values: `once`, `recurring`, or `forever`.
+
+      - If set to `once`, the coupon is applicable only for a single use.
+      - If set to `recurring`, the coupon can be used multiple times for recurring billing periods.
+      - If set to `forever`, the coupon has unlimited usage and can be applied indefinitely.
+    enum:
+      - once
+      - recurring
+    example: 'recurring'
+  frequency_duration:
+    type: integer
+    nullable: true
+    description: Specifies the number of billing periods to which the coupon applies. This field is required only for coupons with a `recurring` frequency type
+    example: 6
+  expiration:
+    type: string
+    description: |-
+      Specifies the type of expiration for the coupon. It can have two possible values: `time_limit` or `no_expiration`.
+
+      - If set to `time_limit`, the coupon has an expiration based on a specified time limit.
+      - If set to `no_expiration`, the coupon does not have an expiration date and remains valid indefinitely.
+    enum:
+      - no_expiration
+      - time_limit
+    example: time_limit
+  expiration_at:
+    type: string
+    format: 'date-time'
+    nullable: true
+    description: The expiration date and time of the coupon. This field is required only for coupons with `expiration` set to `time_limit`. The expiration date and time should be specified in UTC format according to the ISO 8601 datetime standard. It indicates the exact moment when the coupon will expire and is no longer valid.
+    example: '2022-08-08T23:59:59Z'
+  created_at:
+    type: string
+    format: 'date-time'
+    description: The date and time when the coupon was created. It is expressed in UTC format according to the ISO 8601 datetime standard. This field provides the timestamp for the exact moment when the coupon was initially created.
+    example: '2022-04-29T08:59:51Z'

--- a/src/schemas/CouponUpdateInput.yaml
+++ b/src/schemas/CouponUpdateInput.yaml
@@ -1,0 +1,7 @@
+type: object
+required:
+  - coupon
+properties:
+  coupon:
+    allOf:
+    - $ref: './CouponBaseInput.yaml'

--- a/src/schemas/CouponsPaginated.yaml
+++ b/src/schemas/CouponsPaginated.yaml
@@ -1,0 +1,11 @@
+type: object
+required:
+  - coupons
+  - meta
+properties:
+  coupons:
+    type: array
+    items:
+      $ref: './CouponObject.yaml'
+  meta:
+    $ref: './PaginationMeta.yaml'

--- a/src/schemas/CreditObject.yaml
+++ b/src/schemas/CreditObject.yaml
@@ -1,0 +1,61 @@
+type: object
+required:
+  - lago_id
+  - item
+  - amount_cents
+  - amount_currency
+  - invoice
+  - before_vat
+properties:
+  lago_id:
+    type: string
+    format: 'uuid'
+    example: '1a901a90-1a90-1a90-1a90-1a901a901a90'
+  amount_cents:
+    type: integer
+    example: 1200
+  amount_currency:
+    allOf:
+      - $ref: './Currency.yaml'
+      - example: 'EUR'
+  before_vat:
+    type: boolean
+    example: false
+  item:
+    type: object
+    required:
+      - lago_id
+      - type
+      - code
+      - name
+    properties:
+      lago_id:
+        type: string
+        format: 'uuid'
+        example: '1a901a90-1a90-1a90-1a90-1a901a901a90'
+      type:
+        type: string
+        example: 'coupon'
+      code:
+        type: string
+        example: 'startup_deal'
+      name:
+        type: string
+        example: 'Startup Deal'
+  invoice:
+    type: object
+    required:
+      - lago_id
+      - payment_status
+    properties:
+      lago_id:
+        type: string
+        format: 'uuid'
+        example: '1a901a90-1a90-1a90-1a90-1a901a901a90'
+      payment_status:
+        type: string
+        enum:
+          - pending
+          - succeeded
+          - failed
+        example: succeeded

--- a/src/schemas/_index.yaml
+++ b/src/schemas/_index.yaml
@@ -28,6 +28,16 @@ AppliedAddOnInput:
   $ref: './AppliedAddOnInput.yaml'
 AppliedAddOnObject:
   $ref: './AppliedAddOnObject.yaml'
+AppliedCoupon:
+  $ref: './AppliedCoupon.yaml'
+AppliedCouponInput:
+  $ref: './AppliedCouponInput.yaml'
+AppliedCouponObject:
+  $ref: './AppliedCouponObject.yaml'
+AppliedCouponObjectExtended:
+  $ref: './AppliedCouponObjectExtended.yaml'
+AppliedCouponsPaginated:
+  $ref: './AppliedCouponsPaginated.yaml'
 BillableMetric:
   $ref: './BillableMetric.yaml'
 BillableMetricObject:
@@ -42,6 +52,20 @@ BillableMetricGroup:
   $ref: './BillableMetricGroup.yaml'
 BillableMetricsPaginated:
   $ref: './BillableMetricsPaginated.yaml'
+Coupon:
+  $ref: './Coupon.yaml'
+CouponBaseInput:
+  $ref: './CouponBaseInput.yaml'
+CouponCreateInput:
+  $ref: './CouponCreateInput.yaml'
+CouponObject:
+  $ref: './CouponObject.yaml'
+CouponsPaginated:
+  $ref: './CouponsPaginated.yaml'
+CouponUpdateInput:
+  $ref: './CouponUpdateInput.yaml'
+CreditObject:
+  $ref: './CreditObject.yaml'
 Currency:
   $ref: './Currency.yaml'
 Customer:
@@ -98,306 +122,6 @@ Timezone:
   $ref: './Timezone.yaml'
 
 # TODO: split into multiple files
-CouponObject:
-  type: object
-  required:
-    - lago_id
-    - name
-    - code
-    - expiration
-    - coupon_type
-    - frequency
-    - created_at
-  properties:
-    lago_id:
-      type: string
-      format: 'uuid'
-      example: '1a901a90-1a90-1a90-1a90-1a901a901a90'
-    name:
-      type: string
-      example: 'coupon1'
-    code:
-      type: string
-      example: 'example_code'
-    coupon_type:
-      type: string
-      description: Coupon type
-      enum:
-        - fixed_amount
-        - percentage
-    amount_cents:
-      type: integer
-      example: 1200
-    amount_currency:
-      type: string
-      example: 'EUR'
-    reusable:
-      type: boolean
-      example: true
-    limited_plans:
-      type: boolean
-      example: true
-    plan_codes:
-      type: array
-      items:
-        type: string
-        example: 'code1'
-    limited_billable_metrics:
-      type: boolean
-      example: true
-    billable_metric_codes:
-      type: array
-      items:
-        type: string
-        example: 'code2'
-    created_at:
-      type: string
-      format: 'date-time'
-      example: '2022-09-14T16:35:31Z'
-    percentage_rate:
-      type: number
-      example: 25.00
-    frequency:
-      type: string
-      description: Frequency type
-      enum:
-        - once
-        - recurring
-    frequency_duration:
-      type: integer
-      example: 3
-    expiration_at:
-      type: string
-      format: 'date-time'
-      example: '2022-09-14T23:59:59Z'
-    expiration:
-      type: string
-      description: Expiration type
-      enum:
-        - no_expiration
-        - time_limit
-Coupon:
-  type: object
-  required:
-    - coupon
-  properties:
-    coupon:
-      $ref: '#/CouponObject'
-CouponsPaginated:
-  type: object
-  required:
-    - coupons
-    - meta
-  properties:
-    coupons:
-      type: array
-      items:
-        $ref: '#/CouponObject'
-    meta:
-      $ref: '#/PaginationMeta'
-CouponInput:
-  type: object
-  required:
-    - coupon
-  properties:
-    coupon:
-      type: object
-      properties:
-        name:
-          type: string
-          example: 'coupon1'
-        code:
-          type: string
-          example: 'example_code'
-        coupon_type:
-          type: string
-          description: Coupon type
-          enum:
-            - fixed_amount
-            - percentage
-        amount_cents:
-          type: integer
-          example: 1200
-        amount_currency:
-          type: string
-          example: 'EUR'
-        reusable:
-          type: boolean
-          example: true
-        percentage_rate:
-          type: number
-          example: 25.00
-        frequency:
-          type: string
-          description: Frequency type
-          enum:
-            - once
-            - recurring
-        frequency_duration:
-          type: integer
-          example: 3
-        expiration_at:
-          type: string
-          format: 'date-time'
-          example: '2022-09-14T23:59:59Z'
-        expiration:
-          type: string
-          description: Expiration type
-          enum:
-            - no_expiration
-            - time_limit
-        applies_to:
-          type: object
-          properties:
-            plan_codes:
-              type: array
-              items:
-                type: string
-                example: 'code1'
-            billable_metric_codes:
-              type: array
-              items:
-                type: string
-                example: 'code2'
-AppliedCouponObject:
-  type: object
-  required:
-    - lago_id
-    - lago_coupon_id
-    - coupon_code
-    - external_customer_id
-    - lago_customer_id
-    - status
-    - amount_cents
-    - amount_currency
-    - frequency
-    - created_at
-  properties:
-    lago_id:
-      type: string
-      format: 'uuid'
-      example: '1a901a90-1a90-1a90-1a90-1a901a901a90'
-    lago_coupon_id:
-      type: string
-      format: 'uuid'
-      example: '1a901a90-1a90-1a90-1a90-1a901a901a90'
-    coupon_code:
-      type: string
-      example: 'example_code'
-    lago_customer_id:
-      type: string
-      format: 'uuid'
-      example: '1a901a90-1a90-1a90-1a90-1a901a901a90'
-    external_customer_id:
-      type: string
-      example: '123456'
-    status:
-      type: string
-      description: Status
-      enum:
-        - active
-        - terminated
-    amount_cents:
-      type: integer
-      example: 1200
-    amount_cents_remaining:
-      type: integer
-      example: 800
-    amount_currency:
-      type: string
-      example: 'EUR'
-    percentage_rate:
-      type: number
-      example: 25.00
-    frequency:
-      type: string
-      description: Frequency type
-      enum:
-        - once
-        - recurring
-    frequency_duration:
-      type: integer
-      example: 3
-    frequency_duration_remaining:
-      type: integer
-      example: 2
-    expiration_at:
-      type: string
-      format: 'date-time'
-      example: '2022-09-14T23:59:59Z'
-    created_at:
-      type: string
-      format: 'date-time'
-      example: '2022-09-14T16:35:31Z'
-    terminated_at:
-      type: string
-      format: 'date-time'
-      example: '2022-09-14T16:35:31Z'
-AppliedCouponObjectExtended:
-  allOf:
-    - $ref: '#/AppliedCouponObject'
-    - type: object
-      required:
-        - credits
-      properties:
-        credits:
-          type: array
-          items:
-            $ref: '#/CreditObject'
-AppliedCoupon:
-  type: object
-  required:
-    - applied_coupon
-  properties:
-    applied_coupon:
-      $ref: '#/AppliedCouponObject'
-AppliedCouponsPaginated:
-  type: object
-  required:
-    - applied_coupons
-    - meta
-  properties:
-    applied_coupons:
-      type: array
-      items:
-        $ref: '#/AppliedCouponObjectExtended'
-    meta:
-      $ref: '#/PaginationMeta'
-AppliedCouponInput:
-  type: object
-  required:
-    - applied_coupon
-  properties:
-    applied_coupon:
-      type: object
-      required:
-        - external_customer_id
-        - coupon_code
-      properties:
-        external_customer_id:
-          type: string
-          example: '123456'
-        coupon_code:
-          type: string
-          example: 'example_code'
-        frequency:
-          type: string
-          description: Frequency type
-          enum:
-            - once
-            - recurring
-        frequency_duration:
-          type: integer
-          example: 3
-        amount_cents:
-          type: integer
-          example: 1200
-        amount_currency:
-          type: string
-          example: 'EUR'
-        percentage_rate:
-          type: number
-          example: 25.00
 EventEstimateFeesInput:
   type: object
   required:
@@ -677,66 +401,6 @@ PlanInput:
                       example: '123456'
                     values:
                       type: object
-CreditObject:
-  type: object
-  required:
-    - lago_id
-    - item
-    - amount_cents
-    - amount_currency
-    - invoice
-    - before_vat
-  properties:
-    lago_id:
-      type: string
-      format: 'uuid'
-      example: '1a901a90-1a90-1a90-1a90-1a901a901a90'
-    amount_cents:
-      type: integer
-      example: 1200
-    amount_currency:
-      type: string
-      example: 'EUR'
-    before_vat:
-      type: boolean
-      example: false
-    item:
-      type: object
-      required:
-        - lago_id
-        - type
-        - code
-        - name
-      properties:
-        lago_id:
-          type: string
-          format: 'uuid'
-          example: '1a901a90-1a90-1a90-1a90-1a901a901a90'
-        type:
-          type: string
-          example: 'coupon'
-        code:
-          type: string
-          example: 'code'
-        name:
-          type: string
-          example: 'name'
-    invoice:
-      type: object
-      required:
-        - lago_id
-        - payment_status
-      properties:
-        lago_id:
-          type: string
-          format: 'uuid'
-          example: '1a901a90-1a90-1a90-1a90-1a901a901a90'
-        payment_status:
-          type: string
-          enum:
-            - pending
-            - succeeded
-            - failed
 FeeObject:
   type: object
   required:


### PR DESCRIPTION
Follows https://github.com/getlago/lago-openapi/pull/80, https://github.com/getlago/lago-openapi/pull/81, https://github.com/getlago/lago-openapi/pull/82, https://github.com/getlago/lago-openapi/pull/84 and https://github.com/getlago/lago-openapi/pull/85 and applies the same splitting logic for coupon resource