### PR TITLE
fix(tax): Tax rates are exposed as number not as string

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2670,10 +2670,9 @@ components:
           description: The code of the tax.
           example: example_code
         tax_rate:
-          type: string
-          format: '^[0-9]+.?[0-9]*$'
+          type: number
           description: The rate of the tax.
-          example: '25.0'
+          example: 25
         tax_description:
           type: string
           description: The description of the tax.
@@ -3775,10 +3774,9 @@ components:
           description: 'The tax amount of the credit note, expressed in cents.'
           example: 20
         taxes_rate:
-          type: string
-          format: '^[0-9]+.?[0-9]*$'
+          type: number
           description: The tax rate associated with this specific credit note.
-          example: '20.0'
+          example: 20
         sub_total_excluding_taxes_amount_cents:
           type: integer
           description: 'The subtotal of the credit note excluding any applicable taxes, expressed in cents.'
@@ -4928,10 +4926,9 @@ components:
           description: The cost of the tax associated with this specific fee.
           example: 20
         taxes_rate:
-          type: string
-          format: '^[0-9]+.?[0-9]*$'
+          type: number
           description: The tax rate associated with this specific fee.
-          example: '20.0'
+          example: 20
         units:
           type: string
           description: The number of units used to charge the customer. This field indicates the quantity or count of units consumed or utilized in the context of the charge. It helps in determining the basis for calculating the fee or cost associated with the usage of the service or product provided to the customer.

--- a/src/schemas/BaseAppliedTax.yaml
+++ b/src/schemas/BaseAppliedTax.yaml
@@ -19,10 +19,9 @@ properties:
     description: The code of the tax.
     example: 'example_code'
   tax_rate:
-    type: string
-    format: '^[0-9]+.?[0-9]*$'
+    type: number
     description: The rate of the tax.
-    example: "25.0"
+    example: 25.0
   tax_description:
     type: string
     description: The description of the tax.

--- a/src/schemas/CreditNoteObject.yaml
+++ b/src/schemas/CreditNoteObject.yaml
@@ -106,10 +106,9 @@ properties:
     description: The tax amount of the credit note, expressed in cents.
     example: 20
   taxes_rate:
-    type: string
-    format: '^[0-9]+.?[0-9]*$'
+    type: number
     description: The tax rate associated with this specific credit note.
-    example: '20.0'
+    example: 20.0
   sub_total_excluding_taxes_amount_cents:
     type: integer
     description: The subtotal of the credit note excluding any applicable taxes, expressed in cents.

--- a/src/schemas/FeeObject.yaml
+++ b/src/schemas/FeeObject.yaml
@@ -79,10 +79,9 @@ properties:
     description: The cost of the tax associated with this specific fee.
     example: 20
   taxes_rate:
-    type: string
-    format: '^[0-9]+.?[0-9]*$'
+    type: number
     description: The tax rate associated with this specific fee.
-    example: '20.0'
+    example: 20.0
   units:
     type: string
     description: The number of units used to charge the customer. This field indicates the quantity or count of units consumed or utilized in the context of the charge. It helps in determining the basis for calculating the fee or cost associated with the usage of the service or product provided to the customer.

--- a/src/schemas/TaxObject.yaml
+++ b/src/schemas/TaxObject.yaml
@@ -25,10 +25,9 @@ properties:
     description: Description of the tax.
     example: 'description'
   rate:
-    type: string
-    format: '^[0-9]+.?[0-9]*$'
+    type: number
     description: The rate of the tax
-    example: '25.0'
+    example: 25.0
   applied_to_organization:
     type: boolean
     example: true


### PR DESCRIPTION
Today, all tax rates are exposed as `float` in Lago API but the current openapi file define them as `string`. 

The current PR fixes it by defining fields as `number`