### PR TITLE
fix(tax): Make sure customer taxes only appears on customer routes

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -4591,11 +4591,6 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/CustomerMetadata'
-        taxes:
-          description: List of customer taxes
-          type: array
-          items:
-            $ref: '#/components/schemas/TaxObject'
     CustomerObjectExtended:
       allOf:
         - $ref: '#/components/schemas/CustomerObject'
@@ -4605,6 +4600,11 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/CustomerMetadata'
+            taxes:
+              description: List of customer taxes
+              type: array
+              items:
+                $ref: '#/components/schemas/TaxObject'
     CustomersPaginated:
       type: object
       required:

--- a/src/schemas/CustomerObject.yaml
+++ b/src/schemas/CustomerObject.yaml
@@ -122,8 +122,3 @@ properties:
     type: array
     items:
       $ref: './CustomerMetadata.yaml'
-  taxes:
-    description: List of customer taxes
-    type: array
-    items:
-      $ref: './TaxObject.yaml'

--- a/src/schemas/CustomerObjectExtended.yaml
+++ b/src/schemas/CustomerObjectExtended.yaml
@@ -6,3 +6,8 @@ allOf:
         type: array
         items:
           $ref: './CustomerMetadata.yaml'
+      taxes:
+        description: List of customer taxes
+        type: array
+        items:
+          $ref: './TaxObject.yaml'


### PR DESCRIPTION
### Issue

1. I’m adding taxes to a customer
2. I’m adding a subscription generating a invoice
3. When I GET this invoice, the response do not displays invoice.customer.taxes; BUT
4. In the documentation on [`[Retrieve an invoice](https://docs.getlago.com/api-reference/invoices/get-specific)`](https://docs.getlago.com/api-reference/invoices/get-specific) we display this information 

### Expected behaviour

1. I’m adding taxes to a customer
2. I’m adding a subscription generating a invoice
3. When I GET this invoice, the response do not displays invoice.customer.taxes; BUT
4. In the documentation on [`[Retrieve an invoice](https://docs.getlago.com/api-reference/invoices/get-specific)`](https://docs.getlago.com/api-reference/invoices/get-specific) we should not display this information