### PR TITLE
feat(tax): Add taxes to add ons

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -5533,6 +5533,13 @@ components:
                     nullable: true
                     example: 'The description of the fee line item in the invoice. By default, the description of the add-on is used.'
                     description: This is a description
+                  tax_codes:
+                    type: array
+                    items:
+                      type: string
+                    description: List of unique code used to identify the taxes.
+                    example:
+                      - french_standard_vat
     InvoicesPaginated:
       type: object
       required:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2340,6 +2340,13 @@ components:
           nullable: true
           description: The description of the add-on.
           example: Implementation fee for new customers.
+        tax_codes:
+          type: array
+          items:
+            type: string
+          description: List of unique code used to identify the taxes.
+          example:
+            - french_standard_vat
     AddOnCreateInput:
       type: object
       required:
@@ -2395,6 +2402,11 @@ components:
           format: date-time
           description: The date and time when the add-on was created. It is expressed in UTC format according to the ISO 8601 datetime standard. This field provides the timestamp for the exact moment when the add-on was initially created.
           example: '2022-04-29T08:59:51Z'
+        taxes:
+          type: array
+          description: All taxes applied to the add-on.
+          items:
+            $ref: '#/components/schemas/TaxObject'
     AddOn:
       type: object
       required:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -6696,6 +6696,10 @@ components:
           type: boolean
           description: Set to `true` if the tax is used as one of the organization's default
           example: true
+        add_ons_count:
+          type: integer
+          description: Number of add-ons this tax is applied to.
+          example: 0
         charges_count:
           type: integer
           description: Number of charges this tax is applied to.

--- a/src/schemas/AddOnBaseInput.yaml
+++ b/src/schemas/AddOnBaseInput.yaml
@@ -22,3 +22,9 @@ properties:
     nullable: true
     description: The description of the add-on.
     example: 'Implementation fee for new customers.'
+  tax_codes:
+    type: array
+    items:
+      type: string
+    description: List of unique code used to identify the taxes.
+    example: [french_standard_vat]

--- a/src/schemas/AddOnObject.yaml
+++ b/src/schemas/AddOnObject.yaml
@@ -39,3 +39,8 @@ properties:
     format: 'date-time'
     description: The date and time when the add-on was created. It is expressed in UTC format according to the ISO 8601 datetime standard. This field provides the timestamp for the exact moment when the add-on was initially created.
     example: '2022-04-29T08:59:51Z'
+  taxes:
+    type: array
+    description: All taxes applied to the add-on.
+    items:
+      $ref: './TaxObject.yaml'

--- a/src/schemas/InvoiceOneOffCreateInput.yaml
+++ b/src/schemas/InvoiceOneOffCreateInput.yaml
@@ -44,3 +44,9 @@ properties:
               nullable: true
               example: 'The description of the fee line item in the invoice. By default, the description of the add-on is used.'
               description: 'This is a description'
+            tax_codes:
+              type: array
+              items:
+                type: string
+              description: List of unique code used to identify the taxes.
+              example: [french_standard_vat]

--- a/src/schemas/TaxObject.yaml
+++ b/src/schemas/TaxObject.yaml
@@ -33,6 +33,10 @@ properties:
     type: boolean
     description: Set to `true` if the tax is used as one of the organization's default
     example: true
+  add_ons_count:
+    type: integer
+    description: Number of add-ons this tax is applied to.
+    example: 0
   charges_count:
     type: integer
     description: Number of charges this tax is applied to.


### PR DESCRIPTION
## Roadmap Task

👉  [https://getlago.canny.io/feature-requests/p/create-several-tax-rates](https://getlago.canny.io/feature-requests/p/create-several-tax-rates)

## Context

After the delivery of the "multiple taxes" feature https://github.com/getlago/lago-api/pull/1104, we now want to be able to define taxes at add ons level.

## Description

This PR adds the ability to assign taxes on add on create/update.