### PR TITLE
feat: expose new net-payment and payment_due_date attributes

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -4507,6 +4507,11 @@ components:
               example: '91364'
               description: The zipcode of the customer's billing address
               nullable: true
+            net_payment_term:
+              type: integer
+              example: 30
+              description: 'The net payment term, expressed in days, specifies the duration within which a customer is expected to remit payment after the invoice is finalized.'
+              nullable: true
             billing_configuration:
               $ref: '#/components/schemas/CustomerBillingConfiguration'
             metadata:
@@ -4681,6 +4686,11 @@ components:
           type: string
           example: '91364'
           description: The zipcode of the customer's billing address
+          nullable: true
+        net_payment_term:
+          type: integer
+          example: 30
+          description: 'The net payment term, expressed in days, specifies the duration within which a customer is expected to remit payment after the invoice is finalized.'
           nullable: true
         created_at:
           type: string
@@ -5354,6 +5364,15 @@ components:
           format: date
           description: The date when the invoice was issued. It is provided in the ISO 8601 date format.
           example: '2022-04-30'
+        payment_due_date:
+          type: string
+          format: date
+          description: 'The payment due date for the invoice, specified in the ISO 8601 date format.'
+          example: '2022-04-30'
+        net_payment_term:
+          type: integer
+          example: 30
+          description: 'The net payment term, expressed in days, specifies the duration within which a customer is expected to remit payment after the invoice is finalized.'
         invoice_type:
           type: string
           enum:
@@ -5671,6 +5690,10 @@ components:
           example: null
           description: The legal number of your organization.
           nullable: true
+        net_payment_term:
+          type: integer
+          example: 30
+          description: 'The net payment term, expressed in days, specifies the duration within which a customer is expected to remit payment after the invoice is finalized.'
         tax_identification_number:
           type: string
           example: US123456789
@@ -5748,6 +5771,10 @@ components:
               example: null
               description: The legal number of your organization.
               nullable: true
+            net_payment_term:
+              type: integer
+              example: 30
+              description: 'The net payment term, expressed in days, specifies the duration within which a customer is expected to remit payment after the invoice is finalized.'
             tax_identification_number:
               type: string
               example: US123456789

--- a/src/schemas/CustomerCreateInput.yaml
+++ b/src/schemas/CustomerCreateInput.yaml
@@ -99,6 +99,11 @@ properties:
         example: '91364'
         description: The zipcode of the customer's billing address
         nullable: true
+      net_payment_term:
+        type: integer
+        example: 30
+        description: The net payment term, expressed in days, specifies the duration within which a customer is expected to remit payment after the invoice is finalized.
+        nullable: true
       billing_configuration:
         $ref: './CustomerBillingConfiguration.yaml'
       metadata:

--- a/src/schemas/CustomerObject.yaml
+++ b/src/schemas/CustomerObject.yaml
@@ -111,6 +111,11 @@ properties:
     example: '91364'
     description: The zipcode of the customer's billing address
     nullable: true
+  net_payment_term:
+    type: integer
+    example: 30
+    description: The net payment term, expressed in days, specifies the duration within which a customer is expected to remit payment after the invoice is finalized.
+    nullable: true
   created_at:
     type: string
     format: 'date-time'

--- a/src/schemas/InvoiceObject.yaml
+++ b/src/schemas/InvoiceObject.yaml
@@ -36,6 +36,15 @@ properties:
     format: 'date'
     description: The date when the invoice was issued. It is provided in the ISO 8601 date format.
     example: '2022-04-30'
+  payment_due_date:
+    type: string
+    format: 'date'
+    description: The payment due date for the invoice, specified in the ISO 8601 date format.
+    example: '2022-04-30'
+  net_payment_term:
+    type: integer
+    example: 30
+    description: The net payment term, expressed in days, specifies the duration within which a customer is expected to remit payment after the invoice is finalized.
   invoice_type:
     type: string
     enum:

--- a/src/schemas/OrganizationObject.yaml
+++ b/src/schemas/OrganizationObject.yaml
@@ -82,6 +82,10 @@ properties:
     example: null
     description: The legal number of your organization.
     nullable: true
+  net_payment_term:
+    type: integer
+    example: 30
+    description: The net payment term, expressed in days, specifies the duration within which a customer is expected to remit payment after the invoice is finalized.
   tax_identification_number:
     type: string
     example: 'US123456789'

--- a/src/schemas/OrganizationUpdateInput.yaml
+++ b/src/schemas/OrganizationUpdateInput.yaml
@@ -57,6 +57,10 @@ properties:
         example: null
         description: The legal number of your organization.
         nullable: true
+      net_payment_term:
+        type: integer
+        example: 30
+        description: The net payment term, expressed in days, specifies the duration within which a customer is expected to remit payment after the invoice is finalized.
       tax_identification_number:
         type: string
         example: 'US123456789'


### PR DESCRIPTION
This PR updated the openapi schema for 3 models

Invoice
- New net_payment_term attribute (read)
- New payment_due_date attribute (read) 

Customer
- New net_payment_term attribute (write and read)

Organization
- New net_payment_term attribute (write and read)