### PR TITLE
feat(charge): Document min/max per transaction amount for percentage charge model

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3245,6 +3245,18 @@ components:
           description: The transaction amount that is not impacted by the `percentage` rate and fixed fee in a percentage charge model. This field indicates the portion of the transaction amount that is exempt from the calculation of charges based on the specified percentage rate and fixed fee.
           nullable: true
           example: '500'
+        per_transaction_max_amount:
+          type: string
+          format: '^[0-9]+.?[0-9]*$'
+          description: Specifies the maximum allowable spending for a single transaction. Working as a transaction cap.
+          nullable: true
+          example: '3.75'
+        per_transaction_min_amount:
+          type: string
+          format: '^[0-9]+.?[0-9]*$'
+          description: Specifies the minimum allowable spending for a single transaction. Working as a transaction floor.
+          nullable: true
+          example: '1.75'
         volume_ranges:
           type: array
           description: 'Volume ranges, sorted from bottom to top tiers, used for a `volume` charge model.'

--- a/src/schemas/ChargeProperties.yaml
+++ b/src/schemas/ChargeProperties.yaml
@@ -112,6 +112,18 @@ properties:
     description: The transaction amount that is not impacted by the `percentage` rate and fixed fee in a percentage charge model. This field indicates the portion of the transaction amount that is exempt from the calculation of charges based on the specified percentage rate and fixed fee.
     nullable: true
     example: '500'
+  per_transaction_max_amount:
+    type: string
+    format: '^[0-9]+.?[0-9]*$'
+    description: Specifies the maximum allowable spending for a single transaction. Working as a transaction cap.
+    nullable: true
+    example: '3.75'
+  per_transaction_min_amount:
+    type: string
+    format: '^[0-9]+.?[0-9]*$'
+    description: Specifies the minimum allowable spending for a single transaction. Working as a transaction floor.
+    nullable: true
+    example: '1.75'
 
   # Volume charge model
   volume_ranges:


### PR DESCRIPTION
## Roadmap Task

👉  https://getlago.canny.io/feature-requests/p/apply-price-floorcap-on-transactions

## Context

Fintech users want to be able to cap a transaction to a maximum amount or to flour it to a minimum amount.

This feature will apply this logic to the `percentage` charge model.

## Description

This PR documents the `per_transaction_max_amount`/`per_transaction_min_amount` fields for charge model properties