### PR TITLE
fix: event additional properties for client generation

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.3
 info:
   title: Lago API documentation
   description: Lago API allows your application to push customer information and metrics (events) from your application to the billing application.
-  version: 0.46.0-beta
+  version: 0.46.1-beta
   license:
     name: AGPLv3
   contact:
@@ -5038,7 +5038,6 @@ components:
         properties:
           type: object
           description: 'This field represents additional properties associated with the event, which are utilized in the calculation of the final fee. This object becomes mandatory when the targeted billable metric employs a `sum_agg`, `max_agg`, or `unique_count_agg` aggregation method. However, when using a simple `count_agg`, this object is not required.'
-          additionalProperties: true
           properties:
             operation_type:
               type: string
@@ -5046,6 +5045,8 @@ components:
               enum:
                 - add
                 - remove
+          additionalProperties:
+            type: string
           example:
             gb: 10
         lago_subscription_id:

--- a/src/openapi.yaml
+++ b/src/openapi.yaml
@@ -3,7 +3,7 @@ info:
   title: Lago API documentation
   description: |-
     Lago API allows your application to push customer information and metrics (events) from your application to the billing application.
-  version: 0.46.0-beta
+  version: 0.46.1-beta
   license:
     name: AGPLv3
   contact:

--- a/src/schemas/EventObject.yaml
+++ b/src/schemas/EventObject.yaml
@@ -40,7 +40,6 @@ properties:
   properties:
     type: object
     description: This field represents additional properties associated with the event, which are utilized in the calculation of the final fee. This object becomes mandatory when the targeted billable metric employs a `sum_agg`, `max_agg`, or `unique_count_agg` aggregation method. However, when using a simple `count_agg`, this object is not required.
-    additionalProperties: true
     properties:
       operation_type:
         type: string
@@ -48,6 +47,8 @@ properties:
         enum:
           - add
           - remove
+    additionalProperties:
+      type: string
     example:
       gb: 10
   lago_subscription_id:


### PR DESCRIPTION
An issue with the generated ruby client has been identified in the event payload.
The generated code was not accepting additional attributes in the properties payload.

This PR is an attempt to fix it by defining the type of accepted additional property keys