### PR TITLE
fix: event input properties

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -4869,7 +4869,6 @@ components:
             properties:
               type: object
               description: 'This field represents additional properties associated with the event, which are utilized in the calculation of the final fee. This object becomes mandatory when the targeted billable metric employs a `sum_agg`, `max_agg`, or `unique_count_agg` aggregation method. However, when using a simple `count_agg`, this object is not required.'
-              additionalProperties: true
               properties:
                 operation_type:
                   type: string
@@ -4877,6 +4876,8 @@ components:
                   enum:
                     - add
                     - remove
+              additionalProperties:
+                type: string
               example:
                 gb: 10
     EventObject:

--- a/src/schemas/EventInput.yaml
+++ b/src/schemas/EventInput.yaml
@@ -31,7 +31,6 @@ properties:
       properties:
         type: object
         description: This field represents additional properties associated with the event, which are utilized in the calculation of the final fee. This object becomes mandatory when the targeted billable metric employs a `sum_agg`, `max_agg`, or `unique_count_agg` aggregation method. However, when using a simple `count_agg`, this object is not required.
-        additionalProperties: true
         properties:
           operation_type:
             type: string
@@ -39,5 +38,7 @@ properties:
             enum:
               - add
               - remove
+        additionalProperties:
+          type: string
         example:
           gb: 10


### PR DESCRIPTION
Similar to https://github.com/getlago/lago-openapi/pull/144

An issue with the generated ruby client has been identified in the event payload.
The generated code was not accepting additional attributes in the properties payload.

This PR is an attempt to fix it by defining the type of accepted additional property keys
