### PR TITLE
fix: event payload issue

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -4869,13 +4869,6 @@ components:
             properties:
               type: object
               description: 'This field represents additional properties associated with the event, which are utilized in the calculation of the final fee. This object becomes mandatory when the targeted billable metric employs a `sum_agg`, `max_agg`, or `unique_count_agg` aggregation method. However, when using a simple `count_agg`, this object is not required.'
-              properties:
-                operation_type:
-                  type: string
-                  description: 'The `operation_type` field is only necessary when adding or removing a specific unit when the targeted billable metric adopts a `unique_count_agg` aggregation method. In other cases, the `operation_type` field is not required. The valid values for the `operation_type` field are `add` or `remove`, which indicate whether the unit is being added or removed from the unique count aggregation, respectively.'
-                  enum:
-                    - add
-                    - remove
               additionalProperties:
                 type: string
               example:

--- a/src/schemas/EventInput.yaml
+++ b/src/schemas/EventInput.yaml
@@ -31,13 +31,6 @@ properties:
       properties:
         type: object
         description: This field represents additional properties associated with the event, which are utilized in the calculation of the final fee. This object becomes mandatory when the targeted billable metric employs a `sum_agg`, `max_agg`, or `unique_count_agg` aggregation method. However, when using a simple `count_agg`, this object is not required.
-        properties:
-          operation_type:
-            type: string
-            description: The `operation_type` field is only necessary when adding or removing a specific unit when the targeted billable metric adopts a `unique_count_agg` aggregation method. In other cases, the `operation_type` field is not required. The valid values for the `operation_type` field are `add` or `remove`, which indicate whether the unit is being added or removed from the unique count aggregation, respectively.
-            enum:
-              - add
-              - remove
         additionalProperties:
           type: string
         example:


### PR DESCRIPTION
Similar to https://github.com/getlago/lago-openapi/pull/144

An issue with the generated ruby client has been identified in the event payload.
The generated code was not accepting additional attributes in the properties payload.

This PR is an attempt to fix it by defining the type of accepted additional property keys