### PR TITLE
feat(weighted-sum): Document milisecond timestamp and weighted sum aggregation

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2824,6 +2824,14 @@ components:
             - sum_agg
             - max_agg
             - unique_count_agg
+            - weighted_sum_agg
+        weighted_interval:
+          type: string
+          enum:
+            - seconds
+          nullable: true
+          example: seconds
+          description: Weight interval used for weighted sum aggregation. Mandatory when `aggregation_type` is `weighted_sum_agg`
         group:
           $ref: '#/components/schemas/BillableMetricGroup'
         active_subscriptions_count:
@@ -2877,6 +2885,14 @@ components:
             - sum_agg
             - max_agg
             - unique_count_agg
+            - weighted_sum_agg
+        weighted_interval:
+          type: string
+          enum:
+            - seconds
+          nullable: true
+          example: seconds
+          description: Weight interval used for weighted sum aggregation. Mandatory when `aggregation_type` is `weighted_sum_agg`
         group:
           $ref: '#/components/schemas/BillableMetricGroup'
     BillableMetricCreateInput:
@@ -4863,9 +4879,14 @@ components:
               example: storage
               description: 'The code that identifies a targeted billable metric. It is essential that this code matches the `code` property of one of your active billable metrics. If the provided code does not correspond to any active billable metric, it will be ignored during the process.'
             timestamp:
-              type: integer
-              example: 1651240791
-              description: 'This field captures the Unix timestamp in seconds indicating the occurrence of the event in Coordinated Universal Time (UTC). If this timestamp is not provided, the API will automatically set it to the time of event reception.'
+              anyOf:
+                - type: integer
+                - type: string
+              example: '1651240791.123'
+              description: |
+                This field captures the Unix timestamp in seconds indicating the occurrence of the event in Coordinated Universal Time (UTC).
+                If this timestamp is not provided, the API will automatically set it to the time of event reception.
+                You can also provide miliseconds precision by appending decimals to the timestamp.
             properties:
               type: object
               description: 'This field represents additional properties associated with the event, which are utilized in the calculation of the final fee. This object becomes mandatory when the targeted billable metric employs a `sum_agg`, `max_agg`, or `unique_count_agg` aggregation method. However, when using a simple `count_agg`, this object is not required.'
@@ -4911,7 +4932,7 @@ components:
         timestamp:
           type: string
           format: date-time
-          example: '2022-04-29T08:59:51Z'
+          example: '2022-04-29T08:59:51.123Z'
           description: 'This field captures the Unix timestamp in seconds indicating the occurrence of the event in Coordinated Universal Time (UTC). If this timestamp is not provided, the API will automatically set it to the time of event reception.'
         properties:
           type: object

--- a/src/schemas/BillableMetricBaseInput.yaml
+++ b/src/schemas/BillableMetricBaseInput.yaml
@@ -18,7 +18,7 @@ properties:
     example: false
     description: |-
       Defines if the billable metric is persisted billing period over billing period.
-      
+
       - If set to `true`: the accumulated number of units calculated from the previous billing period is persisted to the next billing period.
       - If set to `false`: the accumulated number of units is reset to 0 at the end of the billing period.
       - If not defined in the request, default value is `false`.
@@ -36,5 +36,13 @@ properties:
       - sum_agg
       - max_agg
       - unique_count_agg
+      - weighted_sum_agg
+  weighted_interval:
+    type: string
+    enum:
+      - seconds
+    nullable: true
+    example: 'seconds'
+    description: 'Weight interval used for weighted sum aggregation. Mandatory when `aggregation_type` is `weighted_sum_agg`'
   group:
     $ref: './BillableMetricGroup.yaml'

--- a/src/schemas/BillableMetricObject.yaml
+++ b/src/schemas/BillableMetricObject.yaml
@@ -33,7 +33,7 @@ properties:
     example: false
     description: |-
       Defines if the billable metric is persisted billing period over billing period.
-      
+
       - If set to `true`: the accumulated number of units calculated from the previous billing period is persisted to the next billing period.
       - If set to `false`: the accumulated number of units is reset to 0 at the end of the billing period.
       - If not defined in the request, default value is `false`.
@@ -56,6 +56,14 @@ properties:
       - sum_agg
       - max_agg
       - unique_count_agg
+      - weighted_sum_agg
+  weighted_interval:
+    type: string
+    enum:
+      - seconds
+    nullable: true
+    example: 'seconds'
+    description: 'Weight interval used for weighted sum aggregation. Mandatory when `aggregation_type` is `weighted_sum_agg`'
   group:
     $ref: './BillableMetricGroup.yaml'
   active_subscriptions_count:

--- a/src/schemas/EventInput.yaml
+++ b/src/schemas/EventInput.yaml
@@ -25,9 +25,14 @@ properties:
         example: 'storage'
         description: The code that identifies a targeted billable metric. It is essential that this code matches the `code` property of one of your active billable metrics. If the provided code does not correspond to any active billable metric, it will be ignored during the process.
       timestamp:
-        type: integer
-        example: 1651240791
-        description: This field captures the Unix timestamp in seconds indicating the occurrence of the event in Coordinated Universal Time (UTC). If this timestamp is not provided, the API will automatically set it to the time of event reception.
+        anyOf:
+          - type: integer
+          - type: string
+        example: '1651240791.123'
+        description: |
+          This field captures the Unix timestamp in seconds indicating the occurrence of the event in Coordinated Universal Time (UTC).
+          If this timestamp is not provided, the API will automatically set it to the time of event reception.
+          You can also provide miliseconds precision by appending decimals to the timestamp.
       properties:
         type: object
         description: This field represents additional properties associated with the event, which are utilized in the calculation of the final fee. This object becomes mandatory when the targeted billable metric employs a `sum_agg`, `max_agg`, or `unique_count_agg` aggregation method. However, when using a simple `count_agg`, this object is not required.

--- a/src/schemas/EventObject.yaml
+++ b/src/schemas/EventObject.yaml
@@ -35,7 +35,7 @@ properties:
   timestamp:
     type: string
     format: 'date-time'
-    example: '2022-04-29T08:59:51Z'
+    example: '2022-04-29T08:59:51.123Z'
     description: This field captures the Unix timestamp in seconds indicating the occurrence of the event in Coordinated Universal Time (UTC). If this timestamp is not provided, the API will automatically set it to the time of event reception.
   properties:
     type: object


### PR DESCRIPTION
## Context

For metrics that are charged upon a time frame, Lago is not able to calculate correctly the charge. For instance, imagine you want to price the number of GB/seconds used by a server. Currently, you can either calculate the number of seconds used, or the number of Gigabytes used, but not both at the same time.

## Description

This PR documents:
- the new `Event#timestamp` format with miliseconds precision
- The new `weighted_sum_agg` aggregation value in the `BillableMetric#aggregation_type` enumeation
- The new `BillableMetric#weighted_interval` aggregation
