### PR TITLE
fix(coupon): Add missing coupons#terminated_at

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3589,6 +3589,11 @@ components:
           format: date-time
           description: The date and time when the coupon was created. It is expressed in UTC format according to the ISO 8601 datetime standard. This field provides the timestamp for the exact moment when the coupon was initially created.
           example: '2022-04-29T08:59:51Z'
+        terminated_at:
+          type: string
+          format: date-time
+          description: 'This field indicates if the coupon has been terminated and is no longer usable. If it''s not null, it won''t be removed for existing customers using it, but it prevents the coupon from being applied in the future.'
+          example: '2022-08-08T23:59:59Z'
     CouponsPaginated:
       type: object
       required:

--- a/src/schemas/CouponObject.yaml
+++ b/src/schemas/CouponObject.yaml
@@ -120,3 +120,8 @@ properties:
     format: 'date-time'
     description: The date and time when the coupon was created. It is expressed in UTC format according to the ISO 8601 datetime standard. This field provides the timestamp for the exact moment when the coupon was initially created.
     example: '2022-04-29T08:59:51Z'
+  terminated_at:
+    type: string
+    format: 'date-time'
+    description: This field indicates if the coupon has been terminated and is no longer usable. If it's not null, it won't be removed for existing customers using it, but it prevents the coupon from being applied in the future.
+    example: '2022-08-08T23:59:59Z'


### PR DESCRIPTION
## Context

Call to `GET /v1/api/coupons/:code` is missing the `terminated_at` value

## Description

This PR is adding the missing field in the `CouponObject`