### PR TITLE
feat(invoice_display_name) Add invoice display name

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2232,6 +2232,10 @@ components:
           type: string
           description: The name of the add-on.
           example: Setup Fee
+        invoice_display_name:
+          type: string
+          description: 'Specifies the name that will be displayed on an invoice. If no value is set for this field, the name of the actual charge will be used as the default display name.'
+          example: Setup Fee (SF1)
         code:
           type: string
           description: Unique code used to identify the add-on.
@@ -2289,6 +2293,10 @@ components:
           type: string
           description: The name of the add-on.
           example: Setup Fee
+        invoice_display_name:
+          type: string
+          description: 'Specifies the name that will be displayed on an invoice. If no value is set for this field, the name of the actual charge will be used as the default display name.'
+          example: Setup Fee (SF1)
         code:
           type: string
           description: Unique code used to identify the add-on.
@@ -2890,6 +2898,10 @@ components:
           type: string
           description: Unique code identifying a billable metric.
           example: requests
+        invoice_display_name:
+          type: string
+          description: 'Specifies the name that will be displayed on an invoice. If no value is set for this field, the name of the actual charge will be used as the default display name.'
+          example: Setup
         created_at:
           type: string
           format: date-time
@@ -5062,6 +5074,10 @@ components:
               type: string
               description: 'The name of the fee item. It can be the name of the `add-on`, the name of the `charge`, the name of the `credit` or the name of the `subscription`.'
               example: Startup
+            invoice_display_name:
+              type: string
+              description: 'Specifies the name that will be displayed on an invoice. If no value is set for this field, the name of the actual charge will be used as the default display name.'
+              example: Setup Fee (SF1)
             lago_item_id:
               type: string
               example: 1a901a90-1a90-1a90-1a90-1a901a901a90
@@ -5149,6 +5165,10 @@ components:
           format: uuid
           description: 'Unique identifier of a billable metric group, created by Lago.'
           example: 1a901a90-1a90-1a90-1a90-1a901a901a90
+        invoice_display_name:
+          type: string
+          description: 'Specifies the name that will be displayed on an invoice. If no value is set for this field, the name of the actual group will be used as the default display name.'
+          example: AWS
         values:
           allOf:
             - $ref: '#/components/schemas/ChargeProperties'
@@ -5401,6 +5421,10 @@ components:
                     type: string
                     description: The code of the add-on used as invoice item.
                     example: setup_fee
+                  invoice_display_name:
+                    type: string
+                    description: 'Specifies the name that will be displayed on an invoice. If no value is set for this field, the name of the actual charge will be used as the default display name.'
+                    example: Setup Fee (SF1)
                   unit_amount_cents:
                     type: integer
                     nullable: true
@@ -5735,6 +5759,10 @@ components:
               type: string
               example: Startup
               description: The name of the plan.
+            invoice_display_name:
+              type: string
+              example: Startup plan
+              description: 'Specifies the name that will be displayed on an invoice. If no value is set for this field, the name of the plan will be used as the default display name.'
             code:
               type: string
               example: startup
@@ -5941,6 +5969,10 @@ components:
               type: string
               example: Startup
               description: The name of the plan.
+            invoice_display_name:
+              type: string
+              example: Startup plan
+              description: 'Specifies the name that will be displayed on an invoice. If no value is set for this field, the name of the plan will be used as the default display name.'
             code:
               type: string
               example: startup
@@ -6162,6 +6194,10 @@ components:
           type: string
           description: The name of the plan.
           example: Startup
+        invoice_display_name:
+          type: string
+          description: 'Specifies the name that will be displayed on an invoice. If no value is set for this field, the name of the plan will be used as the default display name.'
+          example: Startup plan
         created_at:
           type: string
           format: date-time

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -4955,6 +4955,10 @@ components:
           nullable: true
           description: Unique identifier assigned to the subscription in your application. This field is specifically displayed when the fee type is charge and the payment for the fee is made in advance (`pay_in_advance` is set to true).
           example: external_id
+        invoice_display_name:
+          type: string
+          description: 'Specifies the name that will be displayed on an invoice. If no value is set for this field, the name of the actual charge will be used as the default display name.'
+          example: Setup Fee (SF1)
         amount_cents:
           type: integer
           description: 'The cost of this specific fee, excluding any applicable taxes.'
@@ -5839,6 +5843,10 @@ components:
                     type: boolean
                     description: 'This field specifies whether the charge should be included in a proper invoice. If set to false, no invoice will be issued for this charge. You can only set it to `false` when `pay_in_advance` is `true`.'
                     example: true
+                  invoice_display_name:
+                    type: string
+                    description: 'Specifies the name that will be displayed on an invoice. If no value is set for this field, the name of the actual charge will be used as the default display name.'
+                    example: Setup
                   prorated:
                     type: boolean
                     example: false
@@ -5884,6 +5892,7 @@ components:
                 - billable_metric_id: 1a901a90-1a90-1a90-1a90-1a901a901a91
                   charge_model: package
                   invoiceable: true
+                  invoice_display_name: Setup
                   pay_in_advance: false
                   prorated: false
                   min_amount_cents: 3000
@@ -5897,6 +5906,7 @@ components:
                 - billable_metric_id: 1a901a90-1a90-1a90-1a90-1a901a901a92
                   charge_model: graduated
                   invoiceable: true
+                  invoice_display_name: Setup
                   pay_in_advance: false
                   prorated: false
                   min_amount_cents: 0
@@ -5914,23 +5924,28 @@ components:
                 - billable_metric_id: 1a901a90-1a90-1a90-1a90-1a901a901a93
                   charge_model: standard
                   invoiceable: true
+                  invoice_display_name: Setup
                   pay_in_advance: true
                   prorated: false
                   min_amount_cents: 0
                   properties: {}
                   group_properties:
                     - group_id: 1a901a90-1a90-1a90-1a90-1a901a901a01
+                      invoice_display_name: Europe
                       values:
                         amount: '10'
                     - group_id: 1a901a90-1a90-1a90-1a90-1a901a901a02
+                      invoice_display_name: USA
                       values:
                         amount: '5'
                     - group_id: 1a901a90-1a90-1a90-1a90-1a901a901a03
+                      invoice_display_name: Africa
                       values:
                         amount: '8'
                 - billable_metric_id: 1a901a90-1a90-1a90-1a90-1a901a901a94
                   charge_model: volume
                   invoiceable: true
+                  invoice_display_name: Setup
                   pay_in_advance: false
                   prorated: false
                   min_amount_cents: 0
@@ -5948,6 +5963,7 @@ components:
                 - billable_metric_id: 1a901a90-1a90-1a90-1a90-1a901a901a95
                   charge_model: percentage
                   invoiceable: false
+                  invoice_display_name: Setup
                   pay_in_advance: true
                   prorated: false
                   min_amount_cents: 0
@@ -6054,6 +6070,10 @@ components:
                     type: boolean
                     description: 'This field specifies whether the charge should be included in a proper invoice. If set to false, no invoice will be issued for this charge. You can only set it to `false` when `pay_in_advance` is `true`.'
                     example: true
+                  invoice_display_name:
+                    type: string
+                    description: 'Specifies the name that will be displayed on an invoice. If no value is set for this field, the name of the actual charge will be used as the default display name.'
+                    example: Setup
                   prorated:
                     type: boolean
                     example: false
@@ -6099,6 +6119,7 @@ components:
                 - billable_metric_id: 1a901a90-1a90-1a90-1a90-1a901a901a91
                   charge_model: package
                   invoiceable: true
+                  invoice_display_name: Setup
                   pay_in_advance: false
                   prorated: false
                   min_amount_cents: 3000
@@ -6112,6 +6133,7 @@ components:
                 - billable_metric_id: 1a901a90-1a90-1a90-1a90-1a901a901a92
                   charge_model: graduated
                   invoiceable: true
+                  invoice_display_name: Setup
                   pay_in_advance: false
                   prorated: false
                   min_amount_cents: 0
@@ -6129,23 +6151,28 @@ components:
                 - billable_metric_id: 1a901a90-1a90-1a90-1a90-1a901a901a93
                   charge_model: standard
                   invoiceable: true
+                  invoice_display_name: Setup
                   pay_in_advance: true
                   prorated: false
                   min_amount_cents: 0
                   properties: {}
                   group_properties:
                     - group_id: 1a901a90-1a90-1a90-1a90-1a901a901a01
+                      invoice_display_name: Europe
                       values:
                         amount: '10'
                     - group_id: 1a901a90-1a90-1a90-1a90-1a901a901a02
+                      invoice_display_name: USA
                       values:
                         amount: '5'
                     - group_id: 1a901a90-1a90-1a90-1a90-1a901a901a03
+                      invoice_display_name: Africa
                       values:
                         amount: '8'
                 - billable_metric_id: 1a901a90-1a90-1a90-1a90-1a901a901a94
                   charge_model: volume
                   invoiceable: true
+                  invoice_display_name: Setup
                   pay_in_advance: false
                   prorated: false
                   min_amount_cents: 0
@@ -6163,6 +6190,7 @@ components:
                 - billable_metric_id: 1a901a90-1a90-1a90-1a90-1a901a901a95
                   charge_model: percentage
                   invoiceable: false
+                  invoice_display_name: Setup
                   pay_in_advance: true
                   prorated: false
                   min_amount_cents: 0
@@ -6262,6 +6290,7 @@ components:
               created_at: '2023-06-27T19:43:42Z'
               charge_model: package
               invoiceable: true
+              invoice_display_name: Setup
               pay_in_advance: false
               prorated: false
               min_amount_cents: 3000
@@ -6276,6 +6305,7 @@ components:
               created_at: '2023-06-27T19:43:42Z'
               charge_model: graduated
               invoiceable: true
+              invoice_display_name: Setup
               pay_in_advance: false
               prorated: false
               min_amount_cents: 0
@@ -6296,18 +6326,22 @@ components:
               created_at: '2023-06-27T19:43:42Z'
               charge_model: standard
               invoiceable: true
+              invoice_display_name: Setup
               pay_in_advance: true
               prorated: false
               min_amount_cents: 0
               properties: {}
               group_properties:
                 - group_id: 1a901a90-1a90-1a90-1a90-1a901a901a01
+                  invoice_display_name: Europe
                   values:
                     amount: '10'
                 - group_id: 1a901a90-1a90-1a90-1a90-1a901a901a02
+                  invoice_display_name: USA
                   values:
                     amount: '5'
                 - group_id: 1a901a90-1a90-1a90-1a90-1a901a901a03
+                  invoice_display_name: Africa
                   values:
                     amount: '8'
             - lago_id: 1a901a90-1a90-1a90-1a90-1a901a901a94
@@ -6316,6 +6350,7 @@ components:
               created_at: '2023-06-27T19:43:42Z'
               charge_model: volume
               invoiceable: true
+              invoice_display_name: Setup
               pay_in_advance: false
               prorated: false
               min_amount_cents: 0
@@ -6336,6 +6371,7 @@ components:
               created_at: '2023-06-27T19:43:42Z'
               charge_model: percentage
               invoiceable: false
+              invoice_display_name: Setup
               pay_in_advance: true
               prorated: false
               min_amount_cents: 0

--- a/src/schemas/AddOnBaseInput.yaml
+++ b/src/schemas/AddOnBaseInput.yaml
@@ -4,6 +4,10 @@ properties:
     type: string
     description: The name of the add-on.
     example: 'Setup Fee'
+  invoice_display_name:
+    type: string
+    description: Specifies the name that will be displayed on an invoice. If no value is set for this field, the name of the actual charge will be used as the default display name.
+    example: 'Setup Fee (SF1)'
   code:
     type: string
     description: Unique code used to identify the add-on.

--- a/src/schemas/AddOnObject.yaml
+++ b/src/schemas/AddOnObject.yaml
@@ -16,6 +16,10 @@ properties:
     type: string
     description: The name of the add-on.
     example: 'Setup Fee'
+  invoice_display_name:
+    type: string
+    description: Specifies the name that will be displayed on an invoice. If no value is set for this field, the name of the actual charge will be used as the default display name.
+    example: 'Setup Fee (SF1)'
   code:
     type: string
     description: Unique code used to identify the add-on.

--- a/src/schemas/ChargeObject.yaml
+++ b/src/schemas/ChargeObject.yaml
@@ -20,6 +20,10 @@ properties:
     type: string
     description: Unique code identifying a billable metric.
     example: 'requests'
+  invoice_display_name:
+    type: string
+    description: Specifies the name that will be displayed on an invoice. If no value is set for this field, the name of the actual charge will be used as the default display name.
+    example: 'Setup'
   created_at:
     type: string
     format: 'date-time'

--- a/src/schemas/FeeObject.yaml
+++ b/src/schemas/FeeObject.yaml
@@ -184,6 +184,10 @@ properties:
         type: string
         description: The name of the fee item. It can be the name of the `add-on`, the name of the `charge`, the name of the `credit` or the name of the `subscription`.
         example: 'Startup'
+      invoice_display_name:
+        type: string
+        description: Specifies the name that will be displayed on an invoice. If no value is set for this field, the name of the actual charge will be used as the default display name.
+        example: 'Setup Fee (SF1)'
       lago_item_id:
         type: string
         example: '1a901a90-1a90-1a90-1a90-1a901a901a90'

--- a/src/schemas/FeeObject.yaml
+++ b/src/schemas/FeeObject.yaml
@@ -65,6 +65,10 @@ properties:
     nullable: true
     description: Unique identifier assigned to the subscription in your application. This field is specifically displayed when the fee type is charge and the payment for the fee is made in advance (`pay_in_advance` is set to true).
     example: 'external_id'
+  invoice_display_name:
+    type: string
+    description: Specifies the name that will be displayed on an invoice. If no value is set for this field, the name of the actual charge will be used as the default display name.
+    example: 'Setup Fee (SF1)'
   amount_cents:
     type: integer
     description: The cost of this specific fee, excluding any applicable taxes.

--- a/src/schemas/GroupPropertiesObject.yaml
+++ b/src/schemas/GroupPropertiesObject.yaml
@@ -8,6 +8,10 @@ properties:
     format: uuid
     description: Unique identifier of a billable metric group, created by Lago.
     example: '1a901a90-1a90-1a90-1a90-1a901a901a90'
+  invoice_display_name:
+    type: string
+    description: Specifies the name that will be displayed on an invoice. If no value is set for this field, the name of the actual group will be used as the default display name.
+    example: 'AWS'
   values:
     allOf:
       - $ref: './ChargeProperties.yaml'

--- a/src/schemas/InvoiceOneOffCreateInput.yaml
+++ b/src/schemas/InvoiceOneOffCreateInput.yaml
@@ -28,6 +28,10 @@ properties:
               type: string
               description: The code of the add-on used as invoice item.
               example: 'setup_fee'
+            invoice_display_name:
+              type: string
+              description: Specifies the name that will be displayed on an invoice. If no value is set for this field, the name of the actual charge will be used as the default display name.
+              example: 'Setup Fee (SF1)'
             unit_amount_cents:
               type: integer
               nullable: true

--- a/src/schemas/PlanCreateInput.yaml
+++ b/src/schemas/PlanCreateInput.yaml
@@ -9,6 +9,10 @@ properties:
         type: string
         example: 'Startup'
         description: The name of the plan.
+      invoice_display_name:
+        type: string
+        example: 'Startup plan'
+        description: Specifies the name that will be displayed on an invoice. If no value is set for this field, the name of the plan will be used as the default display name.
       code:
         type: string
         example: 'startup'

--- a/src/schemas/PlanCreateInput.yaml
+++ b/src/schemas/PlanCreateInput.yaml
@@ -88,6 +88,10 @@ properties:
               type: boolean
               description: This field specifies whether the charge should be included in a proper invoice. If set to false, no invoice will be issued for this charge. You can only set it to `false` when `pay_in_advance` is `true`.
               example: true
+            invoice_display_name:
+              type: string
+              description: Specifies the name that will be displayed on an invoice. If no value is set for this field, the name of the actual charge will be used as the default display name.
+              example: 'Setup'
             prorated:
               type: boolean
               example: false
@@ -132,6 +136,7 @@ properties:
           - billable_metric_id: '1a901a90-1a90-1a90-1a90-1a901a901a91'
             charge_model: 'package'
             invoiceable: true
+            invoice_display_name: 'Setup'
             pay_in_advance: false
             prorated: false
             min_amount_cents: 3000
@@ -144,6 +149,7 @@ properties:
           - billable_metric_id: '1a901a90-1a90-1a90-1a90-1a901a901a92'
             charge_model: 'graduated'
             invoiceable: true
+            invoice_display_name: 'Setup'
             pay_in_advance: false
             prorated: false
             min_amount_cents: 0
@@ -161,23 +167,28 @@ properties:
           - billable_metric_id: '1a901a90-1a90-1a90-1a90-1a901a901a93'
             charge_model: 'standard'
             invoiceable: true
+            invoice_display_name: 'Setup'
             pay_in_advance: true
             prorated: false
             min_amount_cents: 0
             properties: {}
             group_properties:
               - group_id: '1a901a90-1a90-1a90-1a90-1a901a901a01'
+                invoice_display_name: 'Europe'
                 values:
                   amount: '10'
               - group_id: '1a901a90-1a90-1a90-1a90-1a901a901a02'
+                invoice_display_name: 'USA'
                 values:
                   amount: '5'
               - group_id: '1a901a90-1a90-1a90-1a90-1a901a901a03'
+                invoice_display_name: 'Africa'
                 values:
                   amount: '8'
           - billable_metric_id: '1a901a90-1a90-1a90-1a90-1a901a901a94'
             charge_model: 'volume'
             invoiceable: true
+            invoice_display_name: 'Setup'
             pay_in_advance: false
             prorated: false
             min_amount_cents: 0
@@ -195,6 +206,7 @@ properties:
           - billable_metric_id: '1a901a90-1a90-1a90-1a90-1a901a901a95'
             charge_model: 'percentage'
             invoiceable: false
+            invoice_display_name: 'Setup'
             pay_in_advance: true
             prorated: false
             min_amount_cents: 0

--- a/src/schemas/PlanObject.yaml
+++ b/src/schemas/PlanObject.yaml
@@ -87,6 +87,7 @@ properties:
         created_at: '2023-06-27T19:43:42Z'
         charge_model: 'package'
         invoiceable: true
+        invoice_display_name: 'Setup'
         pay_in_advance: false
         prorated: false
         min_amount_cents: 3000
@@ -101,6 +102,7 @@ properties:
         created_at: '2023-06-27T19:43:42Z'
         charge_model: 'graduated'
         invoiceable: true
+        invoice_display_name: 'Setup'
         pay_in_advance: false
         prorated: false
         min_amount_cents: 0
@@ -121,18 +123,22 @@ properties:
         created_at: '2023-06-27T19:43:42Z'
         charge_model: 'standard'
         invoiceable: true
+        invoice_display_name: 'Setup'
         pay_in_advance: true
         prorated: false
         min_amount_cents: 0
         properties: {}
         group_properties:
           - group_id: '1a901a90-1a90-1a90-1a90-1a901a901a01'
+            invoice_display_name: 'Europe'
             values:
               amount: '10'
           - group_id: '1a901a90-1a90-1a90-1a90-1a901a901a02'
+            invoice_display_name: 'USA'
             values:
               amount: '5'
           - group_id: '1a901a90-1a90-1a90-1a90-1a901a901a03'
+            invoice_display_name: 'Africa'
             values:
               amount: '8'
       - lago_id: '1a901a90-1a90-1a90-1a90-1a901a901a94'
@@ -141,6 +147,7 @@ properties:
         created_at: '2023-06-27T19:43:42Z'
         charge_model: 'volume'
         invoiceable: true
+        invoice_display_name: 'Setup'
         pay_in_advance: false
         prorated: false
         min_amount_cents: 0
@@ -161,6 +168,7 @@ properties:
         created_at: '2023-06-27T19:43:42Z'
         charge_model: 'percentage'
         invoiceable: false
+        invoice_display_name: 'Setup'
         pay_in_advance: true
         prorated: false
         min_amount_cents: 0

--- a/src/schemas/PlanObject.yaml
+++ b/src/schemas/PlanObject.yaml
@@ -19,6 +19,10 @@ properties:
     type: string
     description: The name of the plan.
     example: 'Startup'
+  invoice_display_name:
+    type: string
+    description: Specifies the name that will be displayed on an invoice. If no value is set for this field, the name of the plan will be used as the default display name.
+    example: 'Startup plan'
   created_at:
     type: string
     format: 'date-time'

--- a/src/schemas/PlanUpdateInput.yaml
+++ b/src/schemas/PlanUpdateInput.yaml
@@ -93,6 +93,10 @@ properties:
               type: boolean
               description: This field specifies whether the charge should be included in a proper invoice. If set to false, no invoice will be issued for this charge. You can only set it to `false` when `pay_in_advance` is `true`.
               example: true
+            invoice_display_name:
+              type: string
+              description: Specifies the name that will be displayed on an invoice. If no value is set for this field, the name of the actual charge will be used as the default display name.
+              example: 'Setup'
             prorated:
               type: boolean
               example: false
@@ -137,6 +141,7 @@ properties:
           - billable_metric_id: '1a901a90-1a90-1a90-1a90-1a901a901a91'
             charge_model: 'package'
             invoiceable: true
+            invoice_display_name: 'Setup'
             pay_in_advance: false
             prorated: false
             min_amount_cents: 3000
@@ -149,6 +154,7 @@ properties:
           - billable_metric_id: '1a901a90-1a90-1a90-1a90-1a901a901a92'
             charge_model: 'graduated'
             invoiceable: true
+            invoice_display_name: 'Setup'
             pay_in_advance: false
             prorated: false
             min_amount_cents: 0
@@ -166,23 +172,28 @@ properties:
           - billable_metric_id: '1a901a90-1a90-1a90-1a90-1a901a901a93'
             charge_model: 'standard'
             invoiceable: true
+            invoice_display_name: 'Setup'
             pay_in_advance: true
             prorated: false
             min_amount_cents: 0
             properties: {}
             group_properties:
               - group_id: '1a901a90-1a90-1a90-1a90-1a901a901a01'
+                invoice_display_name: 'Europe'
                 values:
                   amount: '10'
               - group_id: '1a901a90-1a90-1a90-1a90-1a901a901a02'
+                invoice_display_name: 'USA'
                 values:
                   amount: '5'
               - group_id: '1a901a90-1a90-1a90-1a90-1a901a901a03'
+                invoice_display_name: 'Africa'
                 values:
                   amount: '8'
           - billable_metric_id: '1a901a90-1a90-1a90-1a90-1a901a901a94'
             charge_model: 'volume'
             invoiceable: true
+            invoice_display_name: 'Setup'
             pay_in_advance: false
             prorated: false
             min_amount_cents: 0
@@ -200,6 +211,7 @@ properties:
           - billable_metric_id: '1a901a90-1a90-1a90-1a90-1a901a901a95'
             charge_model: 'percentage'
             invoiceable: false
+            invoice_display_name: 'Setup'
             pay_in_advance: true
             prorated: false
             min_amount_cents: 0

--- a/src/schemas/PlanUpdateInput.yaml
+++ b/src/schemas/PlanUpdateInput.yaml
@@ -9,6 +9,10 @@ properties:
         type: string
         example: 'Startup'
         description: The name of the plan.
+      invoice_display_name:
+        type: string
+        example: 'Startup plan'
+        description: Specifies the name that will be displayed on an invoice. If no value is set for this field, the name of the plan will be used as the default display name.
       code:
         type: string
         example: 'startup'


### PR DESCRIPTION
## Context

Add a custom name to display on invoice for subscription fee and charges

## Description

When generating an invoice, don't display the name of the plan or the name of the billable metrics to the customer.