### PR TITLE
feat(override-plan): Ability to fetch a single subscription

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1646,6 +1646,23 @@ paths:
         schema:
           type: string
           example: 5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba
+    get:
+      tags:
+        - subscriptions
+      summary: Retrieve a subscription
+      description: This endpoint retrieves a specific subscription.
+      operationId: findSubscription
+      responses:
+        '200':
+          description: Subscription
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Subscription'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
     put:
       tags:
         - subscriptions

--- a/src/resources/subscription.yaml
+++ b/src/resources/subscription.yaml
@@ -6,6 +6,23 @@ parameters:
     schema:
       type: string
       example: '5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba'
+get:
+  tags:
+    - subscriptions
+  summary: Retrieve a subscription
+  description: This endpoint retrieves a specific subscription.
+  operationId: findSubscription
+  responses:
+    '200':
+      description: Subscription
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/Subscription.yaml'
+    '401':
+      $ref: '../responses/Unauthorized.yaml'
+    '404':
+      $ref: '../responses/NotFound.yaml'
 put:
   tags:
     - subscriptions


### PR DESCRIPTION
## Context

We want to improve the way we are overriding a plan. Without working as a duplicate, by adding the logic for managing parent and children of plans.

## Description

The goal of this PR is to add the endpoint `GET /api/v1/subscriptions/:external_id`.