### PR TITLE
misc(event): Deprecate batch route

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -930,6 +930,7 @@ paths:
           $ref: '#/components/responses/UnprocessableEntity'
   /events/batch:
     post:
+      deprecated: true
       tags:
         - events
       summary: Batch multiple events

--- a/src/resources/events_batch.yaml
+++ b/src/resources/events_batch.yaml
@@ -1,4 +1,5 @@
 post:
+  deprecated: true
   tags:
     - events
   summary: Batch multiple events


### PR DESCRIPTION
## Context

Lago route `POST /api/v1/events/batch` is a misleading route as it does not offers a real batch feature but instead offers a way to send and event for simultaneous subscriptions.

It appears that this route is not used at all on the Lago cloud instance. Lago teams decided to deprecate this route in favor of a future batch route allowing users to send multiple events at the same time.

## Description

This PR simply mark the route as `deprecated`. It will be removed in a future PR.
