### PR TITLE
Update openapi.yaml to make sure ending_at is always serialized in request

### DIFF
--- a/src/schemas/SubscriptionUpdateInput.yaml
+++ b/src/schemas/SubscriptionUpdateInput.yaml
@@ -12,7 +12,7 @@ properties:
   subscription:
     type: object
     required:
-    - ending_at
+      - ending_at
     properties:
       name:
         type: string

--- a/src/schemas/SubscriptionUpdateInput.yaml
+++ b/src/schemas/SubscriptionUpdateInput.yaml
@@ -11,6 +11,8 @@ properties:
     description: If the field is not defined and multiple `active` and `pending` subscriptions exists, Lago will update the `active` subscription. However, if you wish to update a `pending` subscription, please ensure that you include the `status` attribute with the `pending` value in your request body.
   subscription:
     type: object
+    required:
+    - ending_at
     properties:
       name:
         type: string
@@ -21,6 +23,7 @@ properties:
         type: string
         format: "date-time"
         example: "2022-10-08T00:00:00Z"
+        nullable: true
         description: The effective end date of the subscription. If this field is set to null, the subscription will automatically renew. This date should be provided in ISO 8601 datetime format, and use Coordinated Universal Time (UTC).
       subscription_at:
         type: string


### PR DESCRIPTION
Imagine you are updating a subscription and want to remove the `ends_at` date.

Right now this doesn't work correctly: Settings `ends_at` to null in Java code will omit `ends_at` from the request all together. The cause is that generated client specifies `@JsonInclude(Include.USE_DEFAULTS)` on the field, which will by default omit any null values from the request.

We need to override this for this specific field. Setting it to required in the spec will change the annotation to `@JsonInclude(Include.ALWAYS)` , which will cause it be serialised in the request, even if it's value is null.
