### PR TITLE
feat(grouped-by): Add documentation

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1195,7 +1195,7 @@ paths:
       tags:
         - events
       summary: Batch multiple events
-      description: This endpoint is used for transmitting a batch of usage measurement.
+      description: This endpoint is used to send a batch of usage records.
       operationId: createBatchEvents
       requestBody:
         description: Batch events payload
@@ -3388,6 +3388,13 @@ components:
           description: Specifies the minimum allowable spending for a single transaction. Working as a transaction floor.
           nullable: true
           example: '1.75'
+        grouped_by:
+          type: array
+          description: The list of event properties that are used to group the events on the invoice for a `standard` charge model.
+          items:
+            type: string
+          example:
+            - agent_name
         volume_ranges:
           type: array
           description: 'Volume ranges, sorted from bottom to top tiers, used for a `volume` charge model.'
@@ -4670,6 +4677,77 @@ components:
           example:
             - card
             - sepa_debit
+    CustomerChargeGroupedUsageObject:
+      type: array
+      description: 'Array of aggregated fees, grouped by the event properties defined in a `standard` charge model.'
+      required:
+        - amount_cents
+        - events_count
+        - units
+        - grouped_by
+        - groups
+      items:
+        type: object
+        properties:
+          amount_cents:
+            type: integer
+            example: 1000
+            description: 'The amount in cents, tax excluded, consumed for a specific group related to a charge item.'
+          events_count:
+            type: integer
+            example: 10
+            description: The quantity of usage events that have been recorded for a particular charge during the specified time period. These events may also be referred to as the number of transactions in some contexts.
+          units:
+            type: string
+            pattern: '^[0-9]+.?[0-9]*$'
+            example: '0.9'
+            description: The number of units consumed for a specific group related to a charge item.
+          grouped_by:
+            type: object
+            description: Key value list of event properties aggregated by the charge model
+            additionalProperties:
+              type: string
+          groups:
+            $ref: '#/components/schemas/CustomerChargeGroupsUsageObject'
+    CustomerChargeGroupsUsageObject:
+      type: array
+      description: 'Array of group object, representing multiple dimensions for a charge item.'
+      required:
+        - lago_id
+        - value
+        - units
+        - events_count
+        - amount_cents
+      items:
+        type: object
+        properties:
+          lago_id:
+            type: string
+            format: uuid
+            example: 1a901a90-1a90-1a90-1a90-1a901a901a90
+            description: Unique identifier assigned to the group within the Lago application. This ID is exclusively created by Lago and serves as a unique identifier for the group record within the Lago system.
+          key:
+            type: string
+            example: null
+            description: 'The group key, only returned for groups with two dimensions.'
+            nullable: true
+          value:
+            type: string
+            example: europe
+            description: The group value.
+          units:
+            type: string
+            pattern: '^[0-9]+.?[0-9]*$'
+            example: '0.9'
+            description: The number of units consumed for a specific group related to a charge item.
+          events_count:
+            type: integer
+            example: 10
+            description: The quantity of usage events that have been recorded for a particular charge during the specified time period. These events may also be referred to as the number of transactions in some contexts.
+          amount_cents:
+            type: integer
+            example: 1000
+            description: 'The amount in cents, tax excluded, consumed for a specific group related to a charge item.'
     CustomerChargeUsageObject:
       type: object
       required:
@@ -4757,44 +4835,9 @@ components:
                 - unique_count_agg
               example: sum_agg
         groups:
-          type: array
-          description: 'Array of group object, representing multiple dimensions for a charge item.'
-          required:
-            - lago_id
-            - value
-            - units
-            - events_count
-            - amount_cents
-          items:
-            type: object
-            properties:
-              lago_id:
-                type: string
-                format: uuid
-                example: 1a901a90-1a90-1a90-1a90-1a901a901a90
-                description: Unique identifier assigned to the group within the Lago application. This ID is exclusively created by Lago and serves as a unique identifier for the group record within the Lago system.
-              key:
-                type: string
-                example: null
-                description: 'The group key, only returned for groups with two dimensions.'
-                nullable: true
-              value:
-                type: string
-                example: europe
-                description: The group value.
-              units:
-                type: string
-                pattern: '^[0-9]+.?[0-9]*$'
-                example: '0.9'
-                description: The number of units consumed for a specific group related to a charge item.
-              events_count:
-                type: integer
-                example: 10
-                description: The quantity of usage events that have been recorded for a particular charge during the specified time period. These events may also be referred to as the number of transactions in some contexts.
-              amount_cents:
-                type: integer
-                example: 1000
-                description: 'The amount in cents, tax excluded, consumed for a specific group related to a charge item.'
+          $ref: '#/components/schemas/CustomerChargeGroupsUsageObject'
+        grouped_usage:
+          $ref: '#/components/schemas/CustomerChargeGroupedUsageObject'
     CustomerCreateInput:
       type: object
       required:
@@ -5766,6 +5809,11 @@ components:
                 - WalletTransaction
               description: 'The type of the fee item. Possible values are `AddOn`, `BillableMetric`, `WalletTransaction` or `Subscription`.'
               example: Subscription
+            grouped_by:
+              type: object
+              description: Key value list of event properties aggregated by the charge model
+              additionalProperties:
+                type: string
         applied_taxes:
           type: array
           description: List of fee applied taxes

--- a/src/schemas/ChargeProperties.yaml
+++ b/src/schemas/ChargeProperties.yaml
@@ -26,14 +26,14 @@ properties:
           example: 10
         flat_amount:
           type: string
-          pattern: '^[0-9]+.?[0-9]*$'
+          pattern: "^[0-9]+.?[0-9]*$"
           description: The flat amount for a whole tier, excluding tax, for a `graduated` charge model. It is expressed as a decimal value.
-          example: '10'
+          example: "10"
         per_unit_amount:
           type: string
-          pattern: '^[0-9]+.?[0-9]*$'
+          pattern: "^[0-9]+.?[0-9]*$"
           description: The unit price, excluding tax, for a specific tier of a `graduated` charge model. It is expressed as a decimal value.
-          example: '0.5'
+          example: "0.5"
 
   # Graduated percentage charge model
   graduated_percentage_ranges:
@@ -61,23 +61,23 @@ properties:
           example: 10
         rate:
           type: string
-          format: '^[0-9]+.?[0-9]*$'
+          format: "^[0-9]+.?[0-9]*$"
           description: The percentage rate that is applied to the amount of each transaction in the tier for a `graduated_percentage` charge model. It is expressed as a decimal value.
-          example: '1'
+          example: "1"
         flat_amount:
           type: string
-          format: '^[0-9]+.?[0-9]*$'
+          format: "^[0-9]+.?[0-9]*$"
           description: The flat amount for a whole tier, excluding tax, for a `graduated_percentage` charge model. It is expressed as a decimal value.
-          example: '10'
+          example: "10"
 
-  # Package & charge model
+  # Package & Standard charge model
   amount:
     type: string
-    pattern: '^[0-9]+.?[0-9]*$'
+    pattern: "^[0-9]+.?[0-9]*$"
     description: |-
       - The unit price, excluding tax, for a `standard` charge model. It is expressed as a decimal value.
       - The amount, excluding tax, for a complete set of units in a `package` charge model. It is expressed as a decimal value.
-    example: '30'
+    example: "30"
 
   # Package only charge model
   free_units:
@@ -92,14 +92,14 @@ properties:
   # Percentage charge model
   rate:
     type: string
-    pattern: '^[0-9]+.?[0-9]*$'
+    pattern: "^[0-9]+.?[0-9]*$"
     description: The percentage rate that is applied to the amount of each transaction for a `percentage` charge model. It is expressed as a decimal value.
-    example: '1'
+    example: "1"
   fixed_amount:
     type: string
-    pattern: '^[0-9]+.?[0-9]*$'
+    pattern: "^[0-9]+.?[0-9]*$"
     description: The fixed fee that is applied to each transaction for a `percentage` charge model. It is expressed as a decimal value.
-    example: '0.5'
+    example: "0.5"
   free_units_per_events:
     type: integer
     description: The count of transactions that are not impacted by the `percentage` rate and fixed fee in a percentage charge model. This field indicates the number of transactions that are exempt from the calculation of charges based on the specified percentage rate and fixed fee.
@@ -107,22 +107,30 @@ properties:
     example: 5
   free_units_per_total_aggregation:
     type: string
-    pattern: '^[0-9]+.?[0-9]*$'
+    pattern: "^[0-9]+.?[0-9]*$"
     description: The transaction amount that is not impacted by the `percentage` rate and fixed fee in a percentage charge model. This field indicates the portion of the transaction amount that is exempt from the calculation of charges based on the specified percentage rate and fixed fee.
     nullable: true
-    example: '500'
+    example: "500"
   per_transaction_max_amount:
     type: string
-    format: '^[0-9]+.?[0-9]*$'
+    format: "^[0-9]+.?[0-9]*$"
     description: Specifies the maximum allowable spending for a single transaction. Working as a transaction cap.
     nullable: true
-    example: '3.75'
+    example: "3.75"
   per_transaction_min_amount:
     type: string
-    format: '^[0-9]+.?[0-9]*$'
+    format: "^[0-9]+.?[0-9]*$"
     description: Specifies the minimum allowable spending for a single transaction. Working as a transaction floor.
     nullable: true
-    example: '1.75'
+    example: "1.75"
+
+  # Standard only charge model
+  grouped_by:
+    type: array
+    description: The list of event properties that are used to group the events on the invoice for a `standard` charge model.
+    items:
+      type: string
+    example: ["agent_name"]
 
   # Volume charge model
   volume_ranges:
@@ -150,11 +158,11 @@ properties:
           example: 10
         flat_amount:
           type: string
-          pattern: '^[0-9]+.?[0-9]*$'
+          pattern: "^[0-9]+.?[0-9]*$"
           description: The unit price, excluding tax, for a specific tier of a `volume` charge model. It is expressed as a decimal value.
-          example: '10'
+          example: "10"
         per_unit_amount:
           type: string
-          pattern: '^[0-9]+.?[0-9]*$'
+          pattern: "^[0-9]+.?[0-9]*$"
           description: The flat amount for a whole tier, excluding tax, for a `volume` charge model. It is expressed as a decimal value.
-          example: '0.5'
+          example: "0.5"

--- a/src/schemas/CustomerChargeGroupedUsageObject.yaml
+++ b/src/schemas/CustomerChargeGroupedUsageObject.yaml
@@ -1,0 +1,31 @@
+type: array
+description: Array of aggregated fees, grouped by the event properties defined in a `standard` charge model.
+required:
+  - amount_cents
+  - events_count
+  - units
+  - grouped_by
+  - groups
+items:
+  type: object
+  properties:
+    amount_cents:
+      type: integer
+      example: 1000
+      description: The amount in cents, tax excluded, consumed for a specific group related to a charge item.
+    events_count:
+      type: integer
+      example: 10
+      description: The quantity of usage events that have been recorded for a particular charge during the specified time period. These events may also be referred to as the number of transactions in some contexts.
+    units:
+      type: string
+      pattern: "^[0-9]+.?[0-9]*$"
+      example: "0.9"
+      description: The number of units consumed for a specific group related to a charge item.
+    grouped_by:
+      type: object
+      description: Key value list of event properties aggregated by the charge model
+      additionalProperties:
+        type: string
+    groups:
+      $ref: "./CustomerChargeGroupsUsageObject.yaml"

--- a/src/schemas/CustomerChargeGroupsUsageObject.yaml
+++ b/src/schemas/CustomerChargeGroupsUsageObject.yaml
@@ -1,0 +1,38 @@
+type: array
+description: Array of group object, representing multiple dimensions for a charge item.
+required:
+  - lago_id
+  - value
+  - units
+  - events_count
+  - amount_cents
+items:
+  type: object
+  properties:
+    lago_id:
+      type: string
+      format: "uuid"
+      example: "1a901a90-1a90-1a90-1a90-1a901a901a90"
+      description: Unique identifier assigned to the group within the Lago application. This ID is exclusively created by Lago and serves as a unique identifier for the group record within the Lago system.
+    key:
+      type: string
+      example: null
+      description: The group key, only returned for groups with two dimensions.
+      nullable: true
+    value:
+      type: string
+      example: "europe"
+      description: The group value.
+    units:
+      type: string
+      pattern: "^[0-9]+.?[0-9]*$"
+      example: "0.9"
+      description: The number of units consumed for a specific group related to a charge item.
+    events_count:
+      type: integer
+      example: 10
+      description: The quantity of usage events that have been recorded for a particular charge during the specified time period. These events may also be referred to as the number of transactions in some contexts.
+    amount_cents:
+      type: integer
+      example: 1000
+      description: The amount in cents, tax excluded, consumed for a specific group related to a charge item.

--- a/src/schemas/CustomerChargeUsageObject.yaml
+++ b/src/schemas/CustomerChargeUsageObject.yaml
@@ -10,8 +10,8 @@ required:
 properties:
   units:
     type: string
-    pattern: '^[0-9]+.?[0-9]*$'
-    example: '1.0'
+    pattern: "^[0-9]+.?[0-9]*$"
+    example: "1.0"
     description: The number of units consumed by the customer for a specific charge item.
   events_count:
     type: integer
@@ -23,9 +23,9 @@ properties:
     description: The amount in cents, tax excluded, consumed by the customer for a specific charge item.
   amount_currency:
     allOf:
-      - $ref: './Currency.yaml'
+      - $ref: "./Currency.yaml"
       - description: The currency of a usage item consumed by the customer.
-        example: 'EUR'
+        example: "EUR"
   charge:
     type: object
     description: Object listing all the properties for a specific charge item.
@@ -35,8 +35,8 @@ properties:
     properties:
       lago_id:
         type: string
-        format: 'uuid'
-        example: '1a901a90-1a90-1a90-1a90-1a901a901a90'
+        format: "uuid"
+        example: "1a901a90-1a90-1a90-1a90-1a901a901a90"
         description: Unique identifier assigned to the charge within the Lago application. This ID is exclusively created by Lago and serves as a unique identifier for the charge’s record within the Lago system.
       charge_model:
         type: string
@@ -63,16 +63,16 @@ properties:
     properties:
       lago_id:
         type: string
-        format: 'uuid'
-        example: '1a901a90-1a90-1a90-1a90-1a901a901a90'
+        format: "uuid"
+        example: "1a901a90-1a90-1a90-1a90-1a901a901a90"
         description: Unique identifier assigned to the billable metric within the Lago application. This ID is exclusively created by Lago and serves as a unique identifier for the billable metric’s record within the Lago system.
       name:
         type: string
-        example: 'Storage'
+        example: "Storage"
         description: The name of the billable metric used for this charge.
       code:
         type: string
-        example: 'storage'
+        example: "storage"
         description: The code of the billable metric used for this charge.
       aggregation_type:
         type: string
@@ -84,41 +84,6 @@ properties:
           - unique_count_agg
         example: sum_agg
   groups:
-    type: array
-    description: Array of group object, representing multiple dimensions for a charge item.
-    required:
-      - lago_id
-      - value
-      - units
-      - events_count
-      - amount_cents
-    items:
-      type: object
-      properties:
-        lago_id:
-          type: string
-          format: 'uuid'
-          example: '1a901a90-1a90-1a90-1a90-1a901a901a90'
-          description: Unique identifier assigned to the group within the Lago application. This ID is exclusively created by Lago and serves as a unique identifier for the group record within the Lago system.
-        key:
-          type: string
-          example: null
-          description: The group key, only returned for groups with two dimensions.
-          nullable: true
-        value:
-          type: string
-          example: 'europe'
-          description: The group value.
-        units:
-          type: string
-          pattern: '^[0-9]+.?[0-9]*$'
-          example: '0.9'
-          description: The number of units consumed for a specific group related to a charge item.
-        events_count:
-          type: integer
-          example: 10
-          description: The quantity of usage events that have been recorded for a particular charge during the specified time period. These events may also be referred to as the number of transactions in some contexts.
-        amount_cents:
-          type: integer
-          example: 1000
-          description: The amount in cents, tax excluded, consumed for a specific group related to a charge item.
+    $ref: "./CustomerChargeGroupsUsageObject.yaml"
+  grouped_usage:
+    $ref: "./CustomerChargeGroupedUsageObject.yaml"

--- a/src/schemas/FeeObject.yaml
+++ b/src/schemas/FeeObject.yaml
@@ -15,69 +15,69 @@ required:
 properties:
   lago_id:
     type: string
-    format: 'uuid'
+    format: "uuid"
     nullable: true
     description: Unique identifier assigned to the fee within the Lago application. This ID is exclusively created by Lago and serves as a unique identifier for the fee’s record within the Lago system.
-    example: '1a901a90-1a90-1a90-1a90-1a901a901a90'
+    example: "1a901a90-1a90-1a90-1a90-1a901a901a90"
   lago_group_id:
     type: string
-    format: 'uuid'
+    format: "uuid"
     nullable: true
     description: Unique identifier assigned to the group that the fee belongs to
-    example: '1a901a90-1a90-1a90-1a90-1a901a901a90'
+    example: "1a901a90-1a90-1a90-1a90-1a901a901a90"
   lago_invoice_id:
     type: string
     format: uuid
     nullable: true
     description: Unique identifier assigned to the invoice that the fee belongs to
-    example: '1a901a90-1a90-1a90-1a90-1a901a901a90'
+    example: "1a901a90-1a90-1a90-1a90-1a901a901a90"
   lago_true_up_fee_id:
     type: string
     format: uuid
     nullable: true
     description: Unique identifier assigned to the true-up fee when a minimum has been set to the charge. This identifier helps to distinguish and manage the true-up fee associated with the charge, which may be applicable when a minimum threshold or limit is set for the charge amount.
-    example: '1a901a90-1a90-1a90-1a90-1a901a901a90'
+    example: "1a901a90-1a90-1a90-1a90-1a901a901a90"
   lago_true_up_parent_fee_id:
     type: string
     format: uuid
     nullable: true
     description: Unique identifier assigned to the parent fee on which the true-up fee is assigned. This identifier establishes the relationship between the parent fee and the associated true-up fee.
-    example: '1a901a90-1a90-1a90-1a90-1a901a901a90'
+    example: "1a901a90-1a90-1a90-1a90-1a901a901a90"
   lago_subscription_id:
     type: string
     format: uuid
     nullable: true
     description: Unique identifier assigned to the subscription, created by Lago. This field is specifically displayed when the fee type is charge or subscription.
-    example: '1a901a90-1a90-1a90-1a90-1a901a901a90'
+    example: "1a901a90-1a90-1a90-1a90-1a901a901a90"
   lago_customer_id:
     type: string
     format: uuid
     nullable: true
     description: Unique identifier assigned to the customer, created by Lago. This field is specifically displayed when the fee type is charge or subscription.
-    example: '1a901a90-1a90-1a90-1a90-1a901a901a90'
+    example: "1a901a90-1a90-1a90-1a90-1a901a901a90"
   external_customer_id:
     type: string
     nullable: true
     description: Unique identifier assigned to the customer in your application. This field is specifically displayed when the fee type is charge or subscription.
-    example: 'external_id'
+    example: "external_id"
   external_subscription_id:
     type: string
     nullable: true
     description: Unique identifier assigned to the subscription in your application. This field is specifically displayed when the fee type is charge or subscription.
-    example: 'external_id'
+    example: "external_id"
   invoice_display_name:
     type: string
     description: Specifies the name that will be displayed on an invoice. If no value is set for this field, the name of the actual charge will be used as the default display name.
-    example: 'Setup Fee (SF1)'
+    example: "Setup Fee (SF1)"
   amount_cents:
     type: integer
     description: The cost of this specific fee, excluding any applicable taxes.
     example: 100
   amount_currency:
     allOf:
-      - $ref: './Currency.yaml'
+      - $ref: "./Currency.yaml"
       - description: The currency of this specific fee. It indicates the monetary unit in which the fee’s cost is expressed.
-        example: 'EUR'
+        example: "EUR"
   taxes_amount_cents:
     type: integer
     description: The cost of the tax associated with this specific fee.
@@ -89,20 +89,20 @@ properties:
   units:
     type: string
     description: The number of units used to charge the customer. This field indicates the quantity or count of units consumed or utilized in the context of the charge. It helps in determining the basis for calculating the fee or cost associated with the usage of the service or product provided to the customer.
-    example: '0.32'
+    example: "0.32"
   precise_unit_amount:
     type: string
     description: The unit amount of the fee per unit, with precision.
-    example: '312.5'
+    example: "312.5"
   total_amount_cents:
     type: integer
     description: The cost of this specific fee, including any applicable taxes.
     example: 120
   total_amount_currency:
     allOf:
-      - $ref: './Currency.yaml'
+      - $ref: "./Currency.yaml"
       - description: The currency of this specific fee, including any applicable taxes.
-        example: 'EUR'
+        example: "EUR"
   events_count:
     type: integer
     description: The number of events that have been sent and used to charge the customer. This field indicates the count or quantity of events that have been processed and considered in the charging process.
@@ -117,16 +117,16 @@ properties:
     example: true
   from_date:
     type: string
-    format: 'date-time'
+    format: "date-time"
     nullable: true
     description: The beginning date of the period that the fee covers. It is applicable only to `subscription` and `charge` fees. This field indicates the start date of the billing period or subscription period associated with the fee.
-    example: '2022-04-29T08:59:51Z'
+    example: "2022-04-29T08:59:51Z"
   to_date:
     type: string
-    format: 'date-time'
+    format: "date-time"
     nullable: true
     description: The ending date of the period that the fee covers. It is applicable only to `subscription` and `charge` fees. This field indicates the end date of the billing period or subscription period associated with the fee.
-    example: '2022-05-29T08:59:51Z'
+    example: "2022-05-29T08:59:51Z"
   payment_status:
     type: string
     enum:
@@ -135,39 +135,39 @@ properties:
       - failed
       - refunded
     description: Indicates the payment status of the fee. It represents the current status of the payment associated with the fee. The possible values for this field are `pending`, `succeeded`, `failed` and `refunded`.
-    example: 'pending'
+    example: "pending"
   created_at:
     type: string
     format: date-time
     nullable: true
     description: The date and time when the fee was created. It is provided in Coordinated Universal Time (UTC) format.
-    example: '2022-08-24T14:58:59Z'
+    example: "2022-08-24T14:58:59Z"
   succeeded_at:
     type: string
     format: date-time
     nullable: true
     description: The date and time when the payment for the fee was successfully processed. It is provided in Coordinated Universal Time (UTC) format.
-    example: '2022-08-24T14:58:59Z'
+    example: "2022-08-24T14:58:59Z"
   failed_at:
     type: string
     format: date-time
     nullable: true
     description: The date and time when the payment for the fee failed to process. It is provided in Coordinated Universal Time (UTC) format.
-    example: '2022-08-24T14:58:59Z'
+    example: "2022-08-24T14:58:59Z"
   refunded_at:
     type: string
     format: date-time
     nullable: true
     description: The date and time when the payment for the fee was refunded. It is provided in Coordinated Universal Time (UTC) format
-    example: '2022-08-24T14:58:59Z'
+    example: "2022-08-24T14:58:59Z"
   event_transaction_id:
     type: string
     nullable: true
     description: Unique identifier assigned to the transaction. This field is specifically displayed when the fee type is `charge` and the payment for the fee is made in advance (`pay_in_advance` is set to `true`).
-    example: 'transaction_1234567890'
+    example: "transaction_1234567890"
   amount_details:
     allOf:
-      - $ref: './FeeAmountDetails.yaml'
+      - $ref: "./FeeAmountDetails.yaml"
       - description: List of all unit amount details for calculating the fee.
   item:
     type: object
@@ -191,22 +191,22 @@ properties:
       code:
         type: string
         description: The code of the fee item. It can be the code of the `add-o`n, the code of the `charge`, the code of the `credit` or the code of the `subscription`.
-        example: 'startup'
+        example: "startup"
       name:
         type: string
         description: The name of the fee item. It can be the name of the `add-on`, the name of the `charge`, the name of the `credit` or the name of the `subscription`.
-        example: 'Startup'
+        example: "Startup"
       invoice_display_name:
         type: string
         description: Specifies the name that will be displayed on an invoice. If no value is set for this field, the name of the actual charge will be used as the default display name.
-        example: 'Setup Fee (SF1)'
+        example: "Setup Fee (SF1)"
       group_invoice_display_name:
         type: string
         description: Specifies the name that will be displayed on an invoice. If no value is set for this field, the name of the actual charge will be used as the default display name.
-        example: 'Transactions - ACH'
+        example: "Transactions - ACH"
       lago_item_id:
         type: string
-        example: '1a901a90-1a90-1a90-1a90-1a901a901a90'
+        example: "1a901a90-1a90-1a90-1a90-1a901a901a90"
         description: Unique identifier of the fee item, created by Lago. It can be the identifier of the `add-on`, the identifier of the `charge`, the identifier of the `credit` or the identifier of the `subscription`.
         format: uuid
       item_type:
@@ -218,8 +218,13 @@ properties:
           - WalletTransaction
         description: The type of the fee item. Possible values are `AddOn`, `BillableMetric`, `WalletTransaction` or `Subscription`.
         example: Subscription
+      grouped_by:
+        type: object
+        description: Key value list of event properties aggregated by the charge model
+        additionalProperties:
+          type: string
   applied_taxes:
     type: array
     description: List of fee applied taxes
     items:
-      $ref: './FeeAppliedTaxObject.yaml'
+      $ref: "./FeeAppliedTaxObject.yaml"

--- a/src/schemas/_index.yaml
+++ b/src/schemas/_index.yaml
@@ -1,248 +1,252 @@
 AddOnBaseInput:
-  $ref: './AddOnBaseInput.yaml'
+  $ref: "./AddOnBaseInput.yaml"
 AddOnCreateInput:
-  $ref: './AddOnCreateInput.yaml'
+  $ref: "./AddOnCreateInput.yaml"
 AddOnObject:
-  $ref: './AddOnObject.yaml'
+  $ref: "./AddOnObject.yaml"
 AddOn:
-  $ref: './AddOn.yaml'
+  $ref: "./AddOn.yaml"
 AddOnsPaginated:
-  $ref: './AddOnsPaginated.yaml'
+  $ref: "./AddOnsPaginated.yaml"
 AddOnUpdateInput:
-  $ref: './AddOnUpdateInput.yaml'
+  $ref: "./AddOnUpdateInput.yaml"
 ApiErrorBadRequest:
-  $ref: './ApiErrorBadRequest.yaml'
+  $ref: "./ApiErrorBadRequest.yaml"
 ApiErrorForbidden:
-  $ref: './ApiErrorForbidden.yaml'
+  $ref: "./ApiErrorForbidden.yaml"
 ApiErrorUnauthorized:
-  $ref: './ApiErrorUnauthorized.yaml'
+  $ref: "./ApiErrorUnauthorized.yaml"
 ApiErrorUnprocessableEntity:
-  $ref: './ApiErrorUnprocessableEntity.yaml'
+  $ref: "./ApiErrorUnprocessableEntity.yaml"
 ApiErrorNotAllowed:
-  $ref: './ApiErrorNotAllowed.yaml'
+  $ref: "./ApiErrorNotAllowed.yaml"
 ApiErrorNotFound:
-  $ref: './ApiErrorNotFound.yaml'
+  $ref: "./ApiErrorNotFound.yaml"
 AppliedCoupon:
-  $ref: './AppliedCoupon.yaml'
+  $ref: "./AppliedCoupon.yaml"
 AppliedCouponInput:
-  $ref: './AppliedCouponInput.yaml'
+  $ref: "./AppliedCouponInput.yaml"
 AppliedCouponObject:
-  $ref: './AppliedCouponObject.yaml'
+  $ref: "./AppliedCouponObject.yaml"
 AppliedCouponObjectExtended:
-  $ref: './AppliedCouponObjectExtended.yaml'
+  $ref: "./AppliedCouponObjectExtended.yaml"
 AppliedCouponsPaginated:
-  $ref: './AppliedCouponsPaginated.yaml'
+  $ref: "./AppliedCouponsPaginated.yaml"
 BaseAppliedTax:
-  $ref: './BaseAppliedTax.yaml'
+  $ref: "./BaseAppliedTax.yaml"
 BillableMetric:
-  $ref: './BillableMetric.yaml'
+  $ref: "./BillableMetric.yaml"
 BillableMetricObject:
-  $ref: './BillableMetricObject.yaml'
+  $ref: "./BillableMetricObject.yaml"
 BillableMetricBaseInput:
-  $ref: './BillableMetricBaseInput.yaml'
+  $ref: "./BillableMetricBaseInput.yaml"
 BillableMetricCreateInput:
-  $ref: './BillableMetricCreateInput.yaml'
+  $ref: "./BillableMetricCreateInput.yaml"
 BillableMetricUpdateInput:
-  $ref: './BillableMetricUpdateInput.yaml'
+  $ref: "./BillableMetricUpdateInput.yaml"
 BillableMetricGroup:
-  $ref: './BillableMetricGroup.yaml'
+  $ref: "./BillableMetricGroup.yaml"
 BillableMetricsPaginated:
-  $ref: './BillableMetricsPaginated.yaml'
+  $ref: "./BillableMetricsPaginated.yaml"
 ChargeObject:
-  $ref: './ChargeObject.yaml'
+  $ref: "./ChargeObject.yaml"
 ChargeProperties:
-  $ref: './ChargeProperties.yaml'
+  $ref: "./ChargeProperties.yaml"
 Country:
-  $ref: './Country.yaml'
+  $ref: "./Country.yaml"
 Coupon:
-  $ref: './Coupon.yaml'
+  $ref: "./Coupon.yaml"
 CouponBaseInput:
-  $ref: './CouponBaseInput.yaml'
+  $ref: "./CouponBaseInput.yaml"
 CouponCreateInput:
-  $ref: './CouponCreateInput.yaml'
+  $ref: "./CouponCreateInput.yaml"
 CouponObject:
-  $ref: './CouponObject.yaml'
+  $ref: "./CouponObject.yaml"
 CouponsPaginated:
-  $ref: './CouponsPaginated.yaml'
+  $ref: "./CouponsPaginated.yaml"
 CouponUpdateInput:
-  $ref: './CouponUpdateInput.yaml'
+  $ref: "./CouponUpdateInput.yaml"
 CreditNoteEstimateInput:
-  $ref: '../schemas/CreditNoteEstimateInput.yaml'
+  $ref: "../schemas/CreditNoteEstimateInput.yaml"
 CreditNoteEstimated:
-  $ref: '../schemas/CreditNoteEstimated.yaml'
+  $ref: "../schemas/CreditNoteEstimated.yaml"
 CreditObject:
-  $ref: './CreditObject.yaml'
+  $ref: "./CreditObject.yaml"
 CreditNote:
-  $ref: './CreditNote.yaml'
+  $ref: "./CreditNote.yaml"
 CreditNoteAppliedTaxObject:
-  $ref: './CreditNoteAppliedTaxObject.yaml'
+  $ref: "./CreditNoteAppliedTaxObject.yaml"
 CreditNoteItemObject:
-  $ref: './CreditNoteItemObject.yaml'
+  $ref: "./CreditNoteItemObject.yaml"
 CreditNoteObject:
-  $ref: './CreditNoteObject.yaml'
+  $ref: "./CreditNoteObject.yaml"
 CreditNotes:
-  $ref: './CreditNotes.yaml'
+  $ref: "./CreditNotes.yaml"
 CreditNoteCreateInput:
-  $ref: './CreditNoteCreateInput.yaml'
+  $ref: "./CreditNoteCreateInput.yaml"
 CreditNoteUpdateInput:
-  $ref: './CreditNoteUpdateInput.yaml'
+  $ref: "./CreditNoteUpdateInput.yaml"
 Currency:
-  $ref: './Currency.yaml'
+  $ref: "./Currency.yaml"
 Customer:
-  $ref: './Customer.yaml'
+  $ref: "./Customer.yaml"
 CustomerBillingConfiguration:
-  $ref: './CustomerBillingConfiguration.yaml'
+  $ref: "./CustomerBillingConfiguration.yaml"
+CustomerChargeGroupedUsageObject:
+  $ref: "./CustomerChargeGroupedUsageObject.yaml"
+CustomerChargeGroupsUsageObject:
+  $ref: "./CustomerChargeGroupsUsageObject.yaml"
 CustomerChargeUsageObject:
-  $ref: './CustomerChargeUsageObject.yaml'
+  $ref: "./CustomerChargeUsageObject.yaml"
 CustomerCreateInput:
-  $ref: './CustomerCreateInput.yaml'
+  $ref: "./CustomerCreateInput.yaml"
 CustomerMetadata:
-  $ref: './CustomerMetadata.yaml'
+  $ref: "./CustomerMetadata.yaml"
 CustomerObject:
-  $ref: './CustomerObject.yaml'
+  $ref: "./CustomerObject.yaml"
 CustomerObjectExtended:
-  $ref: './CustomerObjectExtended.yaml'
+  $ref: "./CustomerObjectExtended.yaml"
 CustomerPastUsage:
-  $ref: './CustomerPastUsage.yaml'
+  $ref: "./CustomerPastUsage.yaml"
 CustomersPaginated:
-  $ref: './CustomersPaginated.yaml'
+  $ref: "./CustomersPaginated.yaml"
 CustomerUsage:
-  $ref: './CustomerUsage.yaml'
+  $ref: "./CustomerUsage.yaml"
 CustomerUsageObject:
-  $ref: './CustomerUsageObject.yaml'
+  $ref: "./CustomerUsageObject.yaml"
 Event:
-  $ref: './Event.yaml'
+  $ref: "./Event.yaml"
 EventBatchInput:
-  $ref: './EventBatchInput.yaml'
+  $ref: "./EventBatchInput.yaml"
 EventEstimateFeesInput:
-  $ref: './EventEstimateFeesInput.yaml'
+  $ref: "./EventEstimateFeesInput.yaml"
 EventInput:
-  $ref: './EventInput.yaml'
+  $ref: "./EventInput.yaml"
 EventObject:
-  $ref: './EventObject.yaml'
+  $ref: "./EventObject.yaml"
 Fee:
-  $ref: './Fee.yaml'
+  $ref: "./Fee.yaml"
 FeeAppliedTaxObject:
-  $ref: './FeeAppliedTaxObject.yaml'
+  $ref: "./FeeAppliedTaxObject.yaml"
 FeeObject:
-  $ref: './FeeObject.yaml'
+  $ref: "./FeeObject.yaml"
 Fees:
-  $ref: './Fees.yaml'
+  $ref: "./Fees.yaml"
 FeesPaginated:
-  $ref: './FeesPaginated.yaml'
+  $ref: "./FeesPaginated.yaml"
 FeeUpdateInput:
-  $ref: './FeeUpdateInput.yaml'
+  $ref: "./FeeUpdateInput.yaml"
 GrossRevenueObject:
-  $ref: './GrossRevenueObject.yaml'
+  $ref: "./GrossRevenueObject.yaml"
 GrossRevenues:
-  $ref: './GrossRevenues.yaml'
+  $ref: "./GrossRevenues.yaml"
 GroupObject:
-  $ref: './GroupObject.yaml'
+  $ref: "./GroupObject.yaml"
 GroupPropertiesObject:
-  $ref: './GroupPropertiesObject.yaml'
+  $ref: "./GroupPropertiesObject.yaml"
 GroupsPaginated:
-  $ref: './GroupsPaginated.yaml'
+  $ref: "./GroupsPaginated.yaml"
 MrrObject:
-  $ref: './MrrObject.yaml'
+  $ref: "./MrrObject.yaml"
 Mrrs:
-  $ref: './Mrrs.yaml'
+  $ref: "./Mrrs.yaml"
 Invoice:
-  $ref: './Invoice.yaml'
+  $ref: "./Invoice.yaml"
 InvoiceAppliedTaxObject:
-  $ref: './InvoiceAppliedTaxObject.yaml'
+  $ref: "./InvoiceAppliedTaxObject.yaml"
 InvoiceCollectionObject:
-  $ref: './InvoiceCollectionObject.yaml'
+  $ref: "./InvoiceCollectionObject.yaml"
 InvoiceCollections:
-  $ref: './InvoiceCollections.yaml'
+  $ref: "./InvoiceCollections.yaml"
 InvoicedUsageObject:
-  $ref: './InvoicedUsageObject.yaml'
+  $ref: "./InvoicedUsageObject.yaml"
 InvoicedUsages:
-  $ref: './InvoicedUsages.yaml'
+  $ref: "./InvoicedUsages.yaml"
 InvoiceMetadataObject:
-  $ref: './InvoiceMetadataObject.yaml'
+  $ref: "./InvoiceMetadataObject.yaml"
 InvoiceObject:
-  $ref: 'InvoiceObject.yaml'
+  $ref: "InvoiceObject.yaml"
 InvoiceObjectExtended:
-  $ref: './InvoiceObjectExtended.yaml'
+  $ref: "./InvoiceObjectExtended.yaml"
 InvoiceOneOffCreateInput:
-  $ref: './InvoiceOneOffCreateInput.yaml'
+  $ref: "./InvoiceOneOffCreateInput.yaml"
 InvoicesPaginated:
-  $ref: './InvoicesPaginated.yaml'
+  $ref: "./InvoicesPaginated.yaml"
 InvoiceUpdateInput:
-  $ref: './InvoiceUpdateInput.yaml'
+  $ref: "./InvoiceUpdateInput.yaml"
 Organization:
-  $ref: './Organization.yaml'
+  $ref: "./Organization.yaml"
 OrganizationBillingConfiguration:
-  $ref: './OrganizationBillingConfiguration.yaml'
+  $ref: "./OrganizationBillingConfiguration.yaml"
 OrganizationObject:
-  $ref: './OrganizationObject.yaml'
+  $ref: "./OrganizationObject.yaml"
 OrganizationUpdateInput:
-  $ref: './OrganizationUpdateInput.yaml'
+  $ref: "./OrganizationUpdateInput.yaml"
 PaginationMeta:
-  $ref: './PaginationMeta.yaml'
+  $ref: "./PaginationMeta.yaml"
 Plan:
-  $ref: './Plan.yaml'
+  $ref: "./Plan.yaml"
 PlanCreateInput:
-  $ref: './PlanCreateInput.yaml'
+  $ref: "./PlanCreateInput.yaml"
 PlanOverridesObject:
-  $ref: './PlanOverridesObject.yaml'
+  $ref: "./PlanOverridesObject.yaml"
 PlanUpdateInput:
-  $ref: './PlanUpdateInput.yaml'
+  $ref: "./PlanUpdateInput.yaml"
 PlanObject:
-  $ref: './PlanObject.yaml'
+  $ref: "./PlanObject.yaml"
 PlansPaginated:
-  $ref: './PlansPaginated.yaml'
+  $ref: "./PlansPaginated.yaml"
 Subscription:
-  $ref: './Subscription.yaml'
+  $ref: "./Subscription.yaml"
 SubscriptionCreateInput:
-  $ref: './SubscriptionCreateInput.yaml'
+  $ref: "./SubscriptionCreateInput.yaml"
 SubscriptionUpdateInput:
-  $ref: './SubscriptionUpdateInput.yaml'
+  $ref: "./SubscriptionUpdateInput.yaml"
 SubscriptionObject:
-  $ref: './SubscriptionObject.yaml'
+  $ref: "./SubscriptionObject.yaml"
 SubscriptionObjectExtended:
-  $ref: './SubscriptionObjectExtended.yaml'
+  $ref: "./SubscriptionObjectExtended.yaml"
 SubscriptionsPaginated:
-  $ref: './SubscriptionsPaginated.yaml'
+  $ref: "./SubscriptionsPaginated.yaml"
 Tax:
-  $ref: './Tax.yaml'
+  $ref: "./Tax.yaml"
 TaxBaseInput:
-  $ref: './TaxBaseInput.yaml'
+  $ref: "./TaxBaseInput.yaml"
 TaxCreateInput:
-  $ref: './TaxCreateInput.yaml'
+  $ref: "./TaxCreateInput.yaml"
 TaxesPaginated:
-  $ref: './TaxesPaginated.yaml'
+  $ref: "./TaxesPaginated.yaml"
 TaxObject:
-  $ref: './TaxObject.yaml'
+  $ref: "./TaxObject.yaml"
 TaxUpdateInput:
-  $ref: './TaxUpdateInput.yaml'
+  $ref: "./TaxUpdateInput.yaml"
 Timezone:
-  $ref: './Timezone.yaml'
+  $ref: "./Timezone.yaml"
 Wallet:
-  $ref: './Wallet.yaml'
+  $ref: "./Wallet.yaml"
 WalletCreateInput:
-  $ref: './WalletCreateInput.yaml'
+  $ref: "./WalletCreateInput.yaml"
 WalletObject:
-  $ref: './WalletObject.yaml'
+  $ref: "./WalletObject.yaml"
 WalletsPaginated:
-  $ref: './WalletsPaginated.yaml'
+  $ref: "./WalletsPaginated.yaml"
 WalletTransactionCreateInput:
-  $ref: './WalletTransactionCreateInput.yaml'
+  $ref: "./WalletTransactionCreateInput.yaml"
 WalletTransactionObject:
-  $ref: './WalletTransactionObject.yaml'
+  $ref: "./WalletTransactionObject.yaml"
 WalletTransactions:
-  $ref: './WalletTransactions.yaml'
+  $ref: "./WalletTransactions.yaml"
 WalletTransactionsPaginated:
-  $ref: './WalletTransactionsPaginated.yaml'
+  $ref: "./WalletTransactionsPaginated.yaml"
 WalletUpdateInput:
-  $ref: './WalletUpdateInput.yaml'
+  $ref: "./WalletUpdateInput.yaml"
 WebhookEndpoint:
-  $ref: './WebhookEndpoint.yaml'
+  $ref: "./WebhookEndpoint.yaml"
 WebhookEndpointCreateInput:
-  $ref: './WebhookEndpointCreateInput.yaml'
+  $ref: "./WebhookEndpointCreateInput.yaml"
 WebhookEndpointObject:
-  $ref: './WebhookEndpointObject.yaml'
+  $ref: "./WebhookEndpointObject.yaml"
 WebhookEndpointsPaginated:
-  $ref: './WebhookEndpointsPaginated.yaml'
+  $ref: "./WebhookEndpointsPaginated.yaml"
 WebhookEndpointUpdateInput:
-  $ref: './WebhookEndpointUpdateInput.yaml'
+  $ref: "./WebhookEndpointUpdateInput.yaml"


### PR DESCRIPTION
## Context

Some customers have requested a way to group usage fees on an invoice using an event property. The same charge model properties should be applied to each group. The logic will only apply to `standard` charge model.

## Description

This PR adds the OpenAPI documentation for all new fields related to the feature
