### PR TITLE
feat(filter): Filter documentation

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3313,6 +3313,56 @@ components:
             $ref: '#/components/schemas/BillableMetricObject'
         meta:
           $ref: '#/components/schemas/PaginationMeta'
+    ChargeFilterInput:
+      type: object
+      description: Values used to apply differentiated pricing based on additional event properties.
+      properties:
+        invoice_display_name:
+          type: string
+          description: 'Specifies the name that will be displayed on an invoice. If no value is set for this field, the values of the filter will be used as the default display name.'
+          example: AWS
+          nullable: true
+        properties:
+          allOf:
+            - $ref: '#/components/schemas/ChargeProperties'
+            - description: List of all thresholds utilized for calculating the charge.
+        values:
+          type: object
+          description: List of possible filter values. The key and values must match one of the billable metric filters.
+          additionalProperties:
+            type: string
+          example:
+            region: us-east-1
+    ChargeFilterObject:
+      type: object
+      description: Values used to apply differentiated pricing based on additional event properties.
+      required:
+        - lago_id
+        - invoice_display_name
+        - properties
+        - values
+      properties:
+        lago_id:
+          type: string
+          format: uuid
+          example: 1a901a90-1a90-1a90-1a90-1a901a901a90
+          description: Unique identifier of the charge filter created by Lago.
+        invoice_display_name:
+          type: string
+          description: 'Specifies the name that will be displayed on an invoice. If no value is set for this field, the values of the filter will be used as the default display name.'
+          example: AWS
+          nullable: true
+        properties:
+          allOf:
+            - $ref: '#/components/schemas/ChargeProperties'
+            - description: List of all thresholds utilized for calculating the charge.
+        values:
+          type: object
+          description: List of possible filter values. The key and values must match one of the billable metric filters.
+          additionalProperties:
+            type: string
+          example:
+            region: us-east-1
     ChargeObject:
       type: object
       required:
@@ -3380,6 +3430,11 @@ components:
           allOf:
             - $ref: '#/components/schemas/ChargeProperties'
             - description: List of all thresholds utilized for calculating the charge.
+        filters:
+          type: array
+          description: List of filters used to apply differentiated pricing based on additional event properties.
+          items:
+            $ref: '#/components/schemas/ChargeFilterObject'
         group_properties:
           type: array
           description: 'All charge information, sorted by groups.'
@@ -6980,6 +7035,11 @@ components:
                           allOf:
                             - $ref: '#/components/schemas/ChargeProperties'
                             - description: 'List of all thresholds utilized for calculating a charge, scoped by groups used as dimensions for a single charge.'
+                  filters:
+                    type: array
+                    description: List of filters used to apply differentiated pricing based on additional event properties.
+                    items:
+                      $ref: '#/components/schemas/ChargeFilterInput'
                   tax_codes:
                     type: array
                     items:
@@ -7299,6 +7359,11 @@ components:
                           allOf:
                             - $ref: '#/components/schemas/ChargeProperties'
                             - description: 'List of all thresholds utilized for calculating a charge, scoped by groups used as dimensions for a single charge.'
+                  filters:
+                    type: array
+                    description: List of filters used to apply differentiated pricing based on additional event properties.
+                    items:
+                      $ref: '#/components/schemas/ChargeFilterInput'
                   tax_codes:
                     type: array
                     items:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -4851,6 +4851,47 @@ components:
           example:
             - card
             - sepa_debit
+    CustomerChargeFiltersUsageObject:
+      type: array
+      description: 'Array of filter object, representing multiple dimensions for a charge item.'
+      required:
+        - lago_id
+        - values
+        - units
+        - events_count
+        - amount_cents
+      items:
+        type: object
+        properties:
+          lago_id:
+            type: string
+            format: uuid
+            example: 1a901a90-1a90-1a90-1a90-1a901a901a90
+            description: Unique identifier assigned to the charge filter within the Lago application. This ID is exclusively created by Lago and serves as a unique identifier for the charge filter record within the Lago system.
+          units:
+            type: string
+            pattern: '^[0-9]+.?[0-9]*$'
+            example: '0.9'
+            description: The number of units consumed for a specific charge filter related to a charge item.
+          amount_cents:
+            type: integer
+            example: 1000
+            description: 'The amount in cents, tax excluded, consumed for a specific charge filter related to a charge item.'
+          events_count:
+            type: integer
+            example: 10
+            description: The quantity of usage events that have been recorded for a particular charge filter during the specified time period. These events may also be referred to as the number of transactions in some contexts.
+          invoice_display_name:
+            type: string
+            description: Specifies the name that will be displayed on an invoice.
+            example: AWS eu-east-1
+          values:
+            type: object
+            description: List of filter values applied to the usage.
+            additionalProperties:
+              type: string
+            example:
+              region: us-east-1
     CustomerChargeGroupedUsageObject:
       type: array
       description: 'Array of aggregated fees, grouped by the event properties defined in a `standard` charge model.'
@@ -4881,6 +4922,8 @@ components:
             description: Key value list of event properties aggregated by the charge model
             additionalProperties:
               type: string
+          filters:
+            $ref: '#/components/schemas/CustomerChargeFiltersUsageObject'
           groups:
             $ref: '#/components/schemas/CustomerChargeGroupsUsageObject'
     CustomerChargeGroupsUsageObject:
@@ -5008,6 +5051,8 @@ components:
                 - max_agg
                 - unique_count_agg
               example: sum_agg
+        filters:
+          $ref: '#/components/schemas/CustomerChargeFiltersUsageObject'
         groups:
           $ref: '#/components/schemas/CustomerChargeGroupsUsageObject'
         grouped_usage:
@@ -5625,6 +5670,12 @@ components:
           nullable: true
           description: Unique identifier assigned to the group that the fee belongs to
           example: 1a901a90-1a90-1a90-1a90-1a901a901a90
+        lago_charge_filter_id:
+          type: string
+          format: uuid
+          nullable: true
+          description: Unique identifier assigned to the charge filter that the fee belongs to
+          example: 1a901a90-1a90-1a90-1a90-1a901a901a90
         lago_invoice_id:
           type: string
           format: uuid
@@ -5974,6 +6025,10 @@ components:
               type: string
               description: 'Specifies the name that will be displayed on an invoice. If no value is set for this field, the name of the actual charge will be used as the default display name.'
               example: Setup Fee (SF1)
+            filter_invoice_display_name:
+              type: string
+              description: 'Specifies the name that will be displayed on an invoice. If no value is set for this field, the actual charge filter values will be used as the default display name.'
+              example: AWS eu-east-1
             group_invoice_display_name:
               type: string
               description: 'Specifies the name that will be displayed on an invoice. If no value is set for this field, the name of the actual charge will be used as the default display name.'

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3235,15 +3235,9 @@ components:
       type: object
       description: Values used to apply differentiated pricing based on additional event properties.
       required:
-        - lago_id
         - key
         - values
       properties:
-        lago_id:
-          type: string
-          format: uuid
-          example: 1a901a90-1a90-1a90-1a90-1a901a901a90
-          description: Unique identifier of the billable metric filter created by Lago.
         key:
           type: string
           example: region
@@ -3337,16 +3331,10 @@ components:
       type: object
       description: Values used to apply differentiated pricing based on additional event properties.
       required:
-        - lago_id
         - invoice_display_name
         - properties
         - values
       properties:
-        lago_id:
-          type: string
-          format: uuid
-          example: 1a901a90-1a90-1a90-1a90-1a901a901a90
-          description: Unique identifier of the charge filter created by Lago.
         invoice_display_name:
           type: string
           description: 'Specifies the name that will be displayed on an invoice. If no value is set for this field, the values of the filter will be used as the default display name.'
@@ -4855,7 +4843,6 @@ components:
       type: array
       description: 'Array of filter object, representing multiple dimensions for a charge item.'
       required:
-        - lago_id
         - values
         - units
         - events_count
@@ -4863,11 +4850,6 @@ components:
       items:
         type: object
         properties:
-          lago_id:
-            type: string
-            format: uuid
-            example: 1a901a90-1a90-1a90-1a90-1a901a901a90
-            description: Unique identifier assigned to the charge filter within the Lago application. This ID is exclusively created by Lago and serves as a unique identifier for the charge filter record within the Lago system.
           units:
             type: string
             pattern: '^[0-9]+.?[0-9]*$'
@@ -7270,6 +7252,11 @@ components:
                       allOf:
                         - $ref: '#/components/schemas/ChargeProperties'
                         - description: 'List of all thresholds utilized for calculating a charge, scoped by groups used as dimensions for a single charge.'
+              filters:
+                type: array
+                description: List of filters used to apply differentiated pricing based on additional event properties.
+                items:
+                  $ref: '#/components/schemas/ChargeFilterInput'
               tax_codes:
                 type: array
                 items:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3132,6 +3132,10 @@ components:
           description: 'Parameter exclusively utilized in conjunction with the `weighted_sum` aggregation type. It serves to adjust the aggregation result by assigning weights and proration to the result based on time intervals. When this field is not provided, the default time interval is assumed to be in `seconds`.'
         group:
           $ref: '#/components/schemas/BillableMetricGroup'
+        filters:
+          type: array
+          items:
+            $ref: '#/components/schemas/BillableMetricFilterObject'
         active_subscriptions_count:
           type: integer
           example: 4
@@ -3194,6 +3198,10 @@ components:
           description: 'Parameter exclusively utilized in conjunction with the `weighted_sum` aggregation type. It serves to adjust the aggregation result by assigning weights and proration to the result based on time intervals. When this field is not provided, the default time interval is assumed to be in `seconds`.'
         group:
           $ref: '#/components/schemas/BillableMetricGroup'
+        filters:
+          type: array
+          items:
+            $ref: '#/components/schemas/BillableMetricFilterInput'
     BillableMetricCreateInput:
       type: object
       required:
@@ -3206,6 +3214,46 @@ components:
                 - name
                 - code
                 - aggregation_type
+    BillableMetricFilterInput:
+      type: object
+      description: Values used to apply differentiated pricing based on additional event properties.
+      required:
+        - key
+        - values
+      properties:
+        key:
+          type: string
+          example: region
+          description: Filter key to add to the event properties payload
+        values:
+          type: array
+          items:
+            type: string
+            example: us-east-1
+          description: List of possible filter values
+    BillableMetricFilterObject:
+      type: object
+      description: Values used to apply differentiated pricing based on additional event properties.
+      required:
+        - lago_id
+        - key
+        - values
+      properties:
+        lago_id:
+          type: string
+          format: uuid
+          example: 1a901a90-1a90-1a90-1a90-1a901a901a90
+          description: Unique identifier of the billable metric filter created by Lago.
+        key:
+          type: string
+          example: region
+          description: Filter key to add to the event properties payload
+        values:
+          type: array
+          items:
+            type: string
+            example: us-east-1
+          description: List of possible filter values
     BillableMetricUpdateInput:
       type: object
       required:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3324,9 +3324,12 @@ components:
           type: object
           description: List of possible filter values. The key and values must match one of the billable metric filters.
           additionalProperties:
-            type: string
+            type: array
+            items:
+              type: string
           example:
-            region: us-east-1
+            region:
+              - us-east-1
     ChargeFilterObject:
       type: object
       description: Values used to apply differentiated pricing based on additional event properties.
@@ -3348,9 +3351,12 @@ components:
           type: object
           description: List of possible filter values. The key and values must match one of the billable metric filters.
           additionalProperties:
-            type: string
+            type: array
+            items:
+              type: string
           example:
-            region: us-east-1
+            region:
+              - us-east-1
     ChargeObject:
       type: object
       required:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -526,6 +526,7 @@ paths:
         - billable_metrics
       summary: Find a billable metric's groups
       description: This endpoint retrieves all groups for a billable metric.
+      deprecated: true
       operationId: findAllBillableMetricGroups
       parameters:
         - name: code
@@ -3261,6 +3262,7 @@ components:
       required:
         - key
         - values
+      deprecated: true
       properties:
         key:
           type: string
@@ -3432,6 +3434,7 @@ components:
         group_properties:
           type: array
           description: 'All charge information, sorted by groups.'
+          deprecated: true
           items:
             $ref: '#/components/schemas/GroupPropertiesObject'
         taxes:
@@ -4917,6 +4920,7 @@ components:
     CustomerChargeGroupsUsageObject:
       type: array
       description: 'Array of group object, representing multiple dimensions for a charge item.'
+      deprecated: true
       required:
         - lago_id
         - value
@@ -5657,6 +5661,7 @@ components:
           format: uuid
           nullable: true
           description: Unique identifier assigned to the group that the fee belongs to
+          deprecated: true
           example: 1a901a90-1a90-1a90-1a90-1a901a901a90
         lago_charge_filter_id:
           type: string
@@ -6017,9 +6022,17 @@ components:
               type: string
               description: 'Specifies the name that will be displayed on an invoice. If no value is set for this field, the actual charge filter values will be used as the default display name.'
               example: AWS eu-east-1
+            filters:
+              type: object
+              description: Key value list of event properties
+              additionalProperties:
+                type: array
+                items:
+                  type: string
             group_invoice_display_name:
               type: string
               description: 'Specifies the name that will be displayed on an invoice. If no value is set for this field, the name of the actual charge will be used as the default display name.'
+              deprecated: true
               example: Transactions - ACH
             lago_item_id:
               type: string
@@ -7064,6 +7077,7 @@ components:
                   group_properties:
                     type: array
                     description: 'All charge information, sorted by groups.'
+                    deprecated: true
                     items:
                       type: object
                       required:
@@ -7244,6 +7258,7 @@ components:
               group_properties:
                 type: array
                 description: 'All charge information, sorted by groups.'
+                deprecated: true
                 items:
                   type: object
                   required:
@@ -7393,6 +7408,7 @@ components:
                   group_properties:
                     type: array
                     description: 'All charge information, sorted by groups.'
+                    deprecated: true
                     items:
                       type: object
                       required:
@@ -7604,7 +7620,7 @@ components:
                 amount: '30'
                 free_units: 100
                 package_size: 1000
-              group_properties: []
+              filters: []
             - lago_id: 1a901a90-1a90-1a90-1a90-1a901a901a92
               lago_billable_metric_id: 1a901a90-1a90-1a90-1a90-1a901a901a92
               billable_metric_code: cpu
@@ -7625,7 +7641,7 @@ components:
                     to_value: null
                     flat_amount: '0'
                     per_unit_amount: '0.4'
-              group_properties: []
+              filters: []
             - lago_id: 1a901a90-1a90-1a90-1a90-1a901a901a93
               lago_billable_metric_id: 1a901a90-1a90-1a90-1a90-1a901a901a93
               billable_metric_code: seats
@@ -7637,19 +7653,25 @@ components:
               prorated: false
               min_amount_cents: 0
               properties: {}
-              group_properties:
-                - group_id: 1a901a90-1a90-1a90-1a90-1a901a901a01
-                  invoice_display_name: Europe
-                  values:
+              filters:
+                - invoice_display_name: Europe
+                  properties:
                     amount: '10'
-                - group_id: 1a901a90-1a90-1a90-1a90-1a901a901a02
-                  invoice_display_name: USA
                   values:
+                    region:
+                      - Europe
+                - invoice_display_name: USA
+                  properties:
                     amount: '5'
-                - group_id: 1a901a90-1a90-1a90-1a90-1a901a901a03
-                  invoice_display_name: Africa
                   values:
+                    region:
+                      - USA
+                - invoice_display_name: Africa
+                  properties:
                     amount: '8'
+                  values:
+                    region:
+                      - Africa
             - lago_id: 1a901a90-1a90-1a90-1a90-1a901a901a94
               lago_billable_metric_id: 1a901a90-1a90-1a90-1a90-1a901a901a94
               billable_metric_code: storage
@@ -7670,7 +7692,7 @@ components:
                     to_value: null
                     flat_amount: '0'
                     per_unit_amount: '0.5'
-              group_properties: []
+              filters: []
             - lago_id: 1a901a90-1a90-1a90-1a90-1a901a901a95
               lago_billable_metric_id: 1a901a90-1a90-1a90-1a90-1a901a901a95
               billable_metric_code: payments
@@ -7686,7 +7708,7 @@ components:
                 fixed_amount: '0.5'
                 free_units_per_events: 5
                 free_units_per_total_aggregation: '500'
-              group_properties: []
+              filters: []
         taxes:
           type: array
           description: All taxes applied to the plan.

--- a/src/resources/billable_metric_groups.yaml
+++ b/src/resources/billable_metric_groups.yaml
@@ -3,6 +3,7 @@ get:
     - billable_metrics
   summary: Find a billable metric's groups
   description: This endpoint retrieves all groups for a billable metric.
+  deprecated: true
   operationId: findAllBillableMetricGroups
   parameters:
     - name: code
@@ -11,32 +12,32 @@ get:
       required: true
       schema:
         type: string
-        example: 'example_code'
-    - $ref: '../parameters/page.yaml'
-    - $ref: '../parameters/per_page.yaml'
+        example: "example_code"
+    - $ref: "../parameters/page.yaml"
+    - $ref: "../parameters/per_page.yaml"
   responses:
-    '200':
+    "200":
       description: List of billable metric's groups
       content:
         application/json:
           schema:
-            $ref: '../schemas/GroupsPaginated.yaml'
+            $ref: "../schemas/GroupsPaginated.yaml"
           example:
             groups:
-              - lago_id: '1a901a90-1a90-1a90-1a90-1a901a901a90'
-                key: 'region'
-                value: 'us-east-1'
-              - lago_id: '1a901a90-1a90-1a90-1a90-1a901a288d80'
-                key: 'region'
-                value: 'us-east-2'
-              - lago_id: '3b288a90-1a20-1a90-1a90-1a921d921a90'
-                key: 'region'
-                value: 'eu-west-1'
+              - lago_id: "1a901a90-1a90-1a90-1a90-1a901a901a90"
+                key: "region"
+                value: "us-east-1"
+              - lago_id: "1a901a90-1a90-1a90-1a90-1a901a288d80"
+                key: "region"
+                value: "us-east-2"
+              - lago_id: "3b288a90-1a20-1a90-1a90-1a921d921a90"
+                key: "region"
+                value: "eu-west-1"
             meta:
               current_page: 1
               next_page: null
               prev_page: null
               total_pages: 1
               total_count: 2
-    '401':
-      $ref: '../responses/Unauthorized.yaml'
+    "401":
+      $ref: "../responses/Unauthorized.yaml"

--- a/src/schemas/BillableMetricBaseInput.yaml
+++ b/src/schemas/BillableMetricBaseInput.yaml
@@ -2,16 +2,16 @@ type: object
 properties:
   name:
     type: string
-    example: 'Storage'
-    description: 'Name of the billable metric.'
+    example: "Storage"
+    description: "Name of the billable metric."
   code:
     type: string
-    example: 'storage'
-    description: 'Unique code used to identify the billable metric associated with the API request. This code associates each event with the correct metric.'
+    example: "storage"
+    description: "Unique code used to identify the billable metric associated with the API request. This code associates each event with the correct metric."
   description:
     type: string
-    example: 'GB of storage used in my application'
-    description: 'Internal description of the billable metric.'
+    example: "GB of storage used in my application"
+    description: "Internal description of the billable metric."
     nullable: true
   recurring:
     type: boolean
@@ -24,13 +24,13 @@ properties:
       - If not defined in the request, default value is `false`.
   field_name:
     type: string
-    example: 'gb'
-    description: 'Property of the billable metric used for aggregating usage data. This field is not required for `count_agg`.'
+    example: "gb"
+    description: "Property of the billable metric used for aggregating usage data. This field is not required for `count_agg`."
     nullable: true
   aggregation_type:
     type: string
-    example: 'sum_agg'
-    description: 'Aggregation method used to compute usage for this billable metric.'
+    example: "sum_agg"
+    description: "Aggregation method used to compute usage for this billable metric."
     enum:
       - count_agg
       - sum_agg
@@ -43,7 +43,11 @@ properties:
     enum:
       - seconds
     nullable: true
-    example: 'seconds'
-    description: 'Parameter exclusively utilized in conjunction with the `weighted_sum` aggregation type. It serves to adjust the aggregation result by assigning weights and proration to the result based on time intervals. When this field is not provided, the default time interval is assumed to be in `seconds`.'
+    example: "seconds"
+    description: "Parameter exclusively utilized in conjunction with the `weighted_sum` aggregation type. It serves to adjust the aggregation result by assigning weights and proration to the result based on time intervals. When this field is not provided, the default time interval is assumed to be in `seconds`."
   group:
-    $ref: './BillableMetricGroup.yaml'
+    $ref: "./BillableMetricGroup.yaml"
+  filters:
+    type: array
+    items:
+      $ref: "./BillableMetricFilterInput.yaml"

--- a/src/schemas/BillableMetricFilterInput.yaml
+++ b/src/schemas/BillableMetricFilterInput.yaml
@@ -1,0 +1,16 @@
+type: object
+description: "Values used to apply differentiated pricing based on additional event properties."
+required:
+  - key
+  - values
+properties:
+  key:
+    type: string
+    example: "region"
+    description: "Filter key to add to the event properties payload"
+  values:
+    type: array
+    items:
+      type: string
+      example: "us-east-1"
+    description: "List of possible filter values"

--- a/src/schemas/BillableMetricFilterObject.yaml
+++ b/src/schemas/BillableMetricFilterObject.yaml
@@ -1,15 +1,9 @@
 type: object
 description: "Values used to apply differentiated pricing based on additional event properties."
 required:
-  - lago_id
   - key
   - values
 properties:
-  lago_id:
-    type: string
-    format: "uuid"
-    example: "1a901a90-1a90-1a90-1a90-1a901a901a90"
-    description: "Unique identifier of the billable metric filter created by Lago."
   key:
     type: string
     example: "region"

--- a/src/schemas/BillableMetricFilterObject.yaml
+++ b/src/schemas/BillableMetricFilterObject.yaml
@@ -1,0 +1,22 @@
+type: object
+description: "Values used to apply differentiated pricing based on additional event properties."
+required:
+  - lago_id
+  - key
+  - values
+properties:
+  lago_id:
+    type: string
+    format: "uuid"
+    example: "1a901a90-1a90-1a90-1a90-1a901a901a90"
+    description: "Unique identifier of the billable metric filter created by Lago."
+  key:
+    type: string
+    example: "region"
+    description: "Filter key to add to the event properties payload"
+  values:
+    type: array
+    items:
+      type: string
+      example: "us-east-1"
+    description: "List of possible filter values"

--- a/src/schemas/BillableMetricGroup.yaml
+++ b/src/schemas/BillableMetricGroup.yaml
@@ -1,33 +1,34 @@
 type: object
-description: 'Group with one or two dimensions, used to apply differentiated pricing based on additional properties of the billable metric.'
+description: "Group with one or two dimensions, used to apply differentiated pricing based on additional properties of the billable metric."
 required:
   - key
   - values
+deprecated: true
 properties:
   key:
     type: string
-    description: 'Name of the event property used to group values.'
-    example: 'region'
+    description: "Name of the event property used to group values."
+    example: "region"
   values:
     type: array
-    description: 'Array of strings or objects representing all possible values.'
-    example: ['us-east-1', 'us-east-2', 'eu-west-1']
+    description: "Array of strings or objects representing all possible values."
+    example: ["us-east-1", "us-east-2", "eu-west-1"]
     items:
       oneOf:
         - type: string
         - type: object
-          description: 'Second dimension of group.'
+          description: "Second dimension of group."
           required:
             - key
             - values
           properties:
             key:
               type: string
-              description: 'Name of the event property used to group values.'
-              example: 'region'
+              description: "Name of the event property used to group values."
+              example: "region"
             values:
               type: array
-              description: 'Array of strings representing all possible values.'
-              example: ['us-east-1', 'us-east-2', 'eu-west-1']
+              description: "Array of strings representing all possible values."
+              example: ["us-east-1", "us-east-2", "eu-west-1"]
               items:
                 type: string

--- a/src/schemas/BillableMetricObject.yaml
+++ b/src/schemas/BillableMetricObject.yaml
@@ -12,21 +12,21 @@ required:
 properties:
   lago_id:
     type: string
-    format: 'uuid'
-    example: '1a901a90-1a90-1a90-1a90-1a901a901a90'
-    description: 'Unique identifier of the billable metric created by Lago.'
+    format: "uuid"
+    example: "1a901a90-1a90-1a90-1a90-1a901a901a90"
+    description: "Unique identifier of the billable metric created by Lago."
   name:
     type: string
-    example: 'Storage'
-    description: 'Name of the billable metric.'
+    example: "Storage"
+    description: "Name of the billable metric."
   code:
     type: string
-    example: 'storage'
-    description: 'Unique code used to identify the billable metric associated with the API request. This code associates each event with the correct metric.'
+    example: "storage"
+    description: "Unique code used to identify the billable metric associated with the API request. This code associates each event with the correct metric."
   description:
     type: string
-    example: 'GB of storage used in my application'
-    description: 'Internal description of the billable metric.'
+    example: "GB of storage used in my application"
+    description: "Internal description of the billable metric."
     nullable: true
   recurring:
     type: boolean
@@ -39,18 +39,18 @@ properties:
       - If not defined in the request, default value is `false`.
   created_at:
     type: string
-    format: 'date-time'
-    example: '2022-09-14T16:35:31Z'
-    description: 'Creation date of the billable metric.'
+    format: "date-time"
+    example: "2022-09-14T16:35:31Z"
+    description: "Creation date of the billable metric."
   field_name:
     type: string
-    example: 'gb'
-    description: 'Property of the billable metric used for aggregating usage data. This field is not required for `count_agg`.'
+    example: "gb"
+    description: "Property of the billable metric used for aggregating usage data. This field is not required for `count_agg`."
     nullable: true
   aggregation_type:
     type: string
-    description: 'Aggregation method used to compute usage for this billable metric.'
-    example: 'sum_agg'
+    description: "Aggregation method used to compute usage for this billable metric."
+    example: "sum_agg"
     enum:
       - count_agg
       - sum_agg
@@ -63,19 +63,23 @@ properties:
     enum:
       - seconds
     nullable: true
-    example: 'seconds'
-    description: 'Parameter exclusively utilized in conjunction with the `weighted_sum` aggregation type. It serves to adjust the aggregation result by assigning weights and proration to the result based on time intervals. When this field is not provided, the default time interval is assumed to be in `seconds`.'
+    example: "seconds"
+    description: "Parameter exclusively utilized in conjunction with the `weighted_sum` aggregation type. It serves to adjust the aggregation result by assigning weights and proration to the result based on time intervals. When this field is not provided, the default time interval is assumed to be in `seconds`."
   group:
-    $ref: './BillableMetricGroup.yaml'
+    $ref: "./BillableMetricGroup.yaml"
+  filters:
+    type: array
+    items:
+      $ref: "./BillableMetricFilterObject.yaml"
   active_subscriptions_count:
     type: integer
     example: 4
-    description: 'Number of active subscriptions using this billable metric.'
+    description: "Number of active subscriptions using this billable metric."
   draft_invoices_count:
     type: integer
     example: 10
-    description: 'Number of draft invoices for which this billable metric is listed as an invoice item.'
+    description: "Number of draft invoices for which this billable metric is listed as an invoice item."
   plans_count:
     type: integer
     example: 4
-    description: 'Number of plans using this billable metric.'
+    description: "Number of plans using this billable metric."

--- a/src/schemas/ChargeFilterInput.yaml
+++ b/src/schemas/ChargeFilterInput.yaml
@@ -14,6 +14,8 @@ properties:
     type: object
     description: "List of possible filter values. The key and values must match one of the billable metric filters."
     additionalProperties:
-      type: string
+      type: array
+      items:
+        type: string
     example:
-      region: us-east-1
+      region: [us-east-1]

--- a/src/schemas/ChargeFilterInput.yaml
+++ b/src/schemas/ChargeFilterInput.yaml
@@ -1,0 +1,19 @@
+type: object
+description: "Values used to apply differentiated pricing based on additional event properties."
+properties:
+  invoice_display_name:
+    type: string
+    description: "Specifies the name that will be displayed on an invoice. If no value is set for this field, the values of the filter will be used as the default display name."
+    example: AWS
+    nullable: true
+  properties:
+    allOf:
+      - $ref: "./ChargeProperties.yaml"
+      - description: List of all thresholds utilized for calculating the charge.
+  values:
+    type: object
+    description: "List of possible filter values. The key and values must match one of the billable metric filters."
+    additionalProperties:
+      type: string
+    example:
+      region: us-east-1

--- a/src/schemas/ChargeFilterObject.yaml
+++ b/src/schemas/ChargeFilterObject.yaml
@@ -1,16 +1,10 @@
 type: object
 description: "Values used to apply differentiated pricing based on additional event properties."
 required:
-  - lago_id
   - invoice_display_name
   - properties
   - values
 properties:
-  lago_id:
-    type: string
-    format: "uuid"
-    example: "1a901a90-1a90-1a90-1a90-1a901a901a90"
-    description: "Unique identifier of the charge filter created by Lago."
   invoice_display_name:
     type: string
     description: "Specifies the name that will be displayed on an invoice. If no value is set for this field, the values of the filter will be used as the default display name."

--- a/src/schemas/ChargeFilterObject.yaml
+++ b/src/schemas/ChargeFilterObject.yaml
@@ -1,0 +1,29 @@
+type: object
+description: "Values used to apply differentiated pricing based on additional event properties."
+required:
+  - lago_id
+  - invoice_display_name
+  - properties
+  - values
+properties:
+  lago_id:
+    type: string
+    format: "uuid"
+    example: "1a901a90-1a90-1a90-1a90-1a901a901a90"
+    description: "Unique identifier of the charge filter created by Lago."
+  invoice_display_name:
+    type: string
+    description: "Specifies the name that will be displayed on an invoice. If no value is set for this field, the values of the filter will be used as the default display name."
+    example: AWS
+    nullable: true
+  properties:
+    allOf:
+      - $ref: "./ChargeProperties.yaml"
+      - description: List of all thresholds utilized for calculating the charge.
+  values:
+    type: object
+    description: "List of possible filter values. The key and values must match one of the billable metric filters."
+    additionalProperties:
+      type: string
+    example:
+      region: us-east-1

--- a/src/schemas/ChargeFilterObject.yaml
+++ b/src/schemas/ChargeFilterObject.yaml
@@ -18,6 +18,8 @@ properties:
     type: object
     description: "List of possible filter values. The key and values must match one of the billable metric filters."
     additionalProperties:
-      type: string
+      type: array
+      items:
+        type: string
     example:
-      region: us-east-1
+      region: [us-east-1]

--- a/src/schemas/ChargeObject.yaml
+++ b/src/schemas/ChargeObject.yaml
@@ -72,6 +72,7 @@ properties:
   group_properties:
     type: array
     description: All charge information, sorted by groups.
+    deprecated: true
     items:
       $ref: "./GroupPropertiesObject.yaml"
   taxes:

--- a/src/schemas/ChargeObject.yaml
+++ b/src/schemas/ChargeObject.yaml
@@ -8,27 +8,27 @@ required:
 properties:
   lago_id:
     type: string
-    format: 'uuid'
+    format: "uuid"
     description: Unique identifier of charge, created by Lago.
-    example: '1a901a90-1a90-1a90-1a90-1a901a901a90'
+    example: "1a901a90-1a90-1a90-1a90-1a901a901a90"
   lago_billable_metric_id:
     type: string
-    format: 'uuid'
+    format: "uuid"
     description: Unique identifier of the billable metric created by Lago.
-    example: '1a901a90-1a90-1a90-1a90-1a901a901a90'
+    example: "1a901a90-1a90-1a90-1a90-1a901a901a90"
   billable_metric_code:
     type: string
     description: Unique code identifying a billable metric.
-    example: 'requests'
+    example: "requests"
   invoice_display_name:
     type: string
     description: Specifies the name that will be displayed on an invoice. If no value is set for this field, the name of the actual charge will be used as the default display name.
-    example: 'Setup'
+    example: "Setup"
   created_at:
     type: string
-    format: 'date-time'
+    format: "date-time"
     description: The date and time when the charge was created. It is expressed in UTC format according to the ISO 8601 datetime standard.
-    example: '2022-09-14T16:35:31Z'
+    example: "2022-09-14T16:35:31Z"
   charge_model:
     type: string
     description: Specifies the pricing model used for the calculation of the final fee. It can be `standard`, `graduated`, `graduated_percentage`, `package`, `percentage` or `volume`.
@@ -62,15 +62,20 @@ properties:
     example: 1200
   properties:
     allOf:
-      - $ref: './ChargeProperties.yaml'
+      - $ref: "./ChargeProperties.yaml"
       - description: List of all thresholds utilized for calculating the charge.
+  filters:
+    type: array
+    description: List of filters used to apply differentiated pricing based on additional event properties.
+    items:
+      $ref: "./ChargeFilterObject.yaml"
   group_properties:
     type: array
     description: All charge information, sorted by groups.
     items:
-      $ref: './GroupPropertiesObject.yaml'
+      $ref: "./GroupPropertiesObject.yaml"
   taxes:
     type: array
     description: All taxes applied to the charge.
     items:
-      $ref: './TaxObject.yaml'
+      $ref: "./TaxObject.yaml"

--- a/src/schemas/CustomerChargeFiltersUsageObject.yaml
+++ b/src/schemas/CustomerChargeFiltersUsageObject.yaml
@@ -1,0 +1,40 @@
+type: array
+description: Array of filter object, representing multiple dimensions for a charge item.
+required:
+  - lago_id
+  - values
+  - units
+  - events_count
+  - amount_cents
+items:
+  type: object
+  properties:
+    lago_id:
+      type: string
+      format: "uuid"
+      example: "1a901a90-1a90-1a90-1a90-1a901a901a90"
+      description: Unique identifier assigned to the charge filter within the Lago application. This ID is exclusively created by Lago and serves as a unique identifier for the charge filter record within the Lago system.
+    units:
+      type: string
+      pattern: "^[0-9]+.?[0-9]*$"
+      example: "0.9"
+      description: The number of units consumed for a specific charge filter related to a charge item.
+    amount_cents:
+      type: integer
+      example: 1000
+      description: The amount in cents, tax excluded, consumed for a specific charge filter related to a charge item.
+    events_count:
+      type: integer
+      example: 10
+      description: The quantity of usage events that have been recorded for a particular charge filter during the specified time period. These events may also be referred to as the number of transactions in some contexts.
+    invoice_display_name:
+      type: string
+      description: Specifies the name that will be displayed on an invoice.
+      example: "AWS eu-east-1"
+    values:
+      type: object
+      description: "List of filter values applied to the usage."
+      additionalProperties:
+        type: string
+      example:
+        region: us-east-1

--- a/src/schemas/CustomerChargeFiltersUsageObject.yaml
+++ b/src/schemas/CustomerChargeFiltersUsageObject.yaml
@@ -1,7 +1,6 @@
 type: array
 description: Array of filter object, representing multiple dimensions for a charge item.
 required:
-  - lago_id
   - values
   - units
   - events_count
@@ -9,11 +8,6 @@ required:
 items:
   type: object
   properties:
-    lago_id:
-      type: string
-      format: "uuid"
-      example: "1a901a90-1a90-1a90-1a90-1a901a901a90"
-      description: Unique identifier assigned to the charge filter within the Lago application. This ID is exclusively created by Lago and serves as a unique identifier for the charge filter record within the Lago system.
     units:
       type: string
       pattern: "^[0-9]+.?[0-9]*$"

--- a/src/schemas/CustomerChargeGroupedUsageObject.yaml
+++ b/src/schemas/CustomerChargeGroupedUsageObject.yaml
@@ -27,5 +27,7 @@ items:
       description: Key value list of event properties aggregated by the charge model
       additionalProperties:
         type: string
+    filters:
+      $ref: "./CustomerChargeFiltersUsageObject.yaml"
     groups:
       $ref: "./CustomerChargeGroupsUsageObject.yaml"

--- a/src/schemas/CustomerChargeGroupsUsageObject.yaml
+++ b/src/schemas/CustomerChargeGroupsUsageObject.yaml
@@ -1,5 +1,6 @@
 type: array
 description: Array of group object, representing multiple dimensions for a charge item.
+deprecated: true
 required:
   - lago_id
   - value

--- a/src/schemas/CustomerChargeUsageObject.yaml
+++ b/src/schemas/CustomerChargeUsageObject.yaml
@@ -83,6 +83,8 @@ properties:
           - max_agg
           - unique_count_agg
         example: sum_agg
+  filters:
+    $ref: "./CustomerChargeFiltersUsageObject.yaml"
   groups:
     $ref: "./CustomerChargeGroupsUsageObject.yaml"
   grouped_usage:

--- a/src/schemas/FeeObject.yaml
+++ b/src/schemas/FeeObject.yaml
@@ -24,6 +24,7 @@ properties:
     format: "uuid"
     nullable: true
     description: Unique identifier assigned to the group that the fee belongs to
+    deprecated: true
     example: "1a901a90-1a90-1a90-1a90-1a901a901a90"
   lago_charge_filter_id:
     type: string
@@ -210,9 +211,17 @@ properties:
         type: string
         description: Specifies the name that will be displayed on an invoice. If no value is set for this field, the actual charge filter values will be used as the default display name.
         example: "AWS eu-east-1"
+      filters:
+        type: object
+        description: Key value list of event properties
+        additionalProperties:
+          type: array
+          items:
+            type: string
       group_invoice_display_name:
         type: string
         description: Specifies the name that will be displayed on an invoice. If no value is set for this field, the name of the actual charge will be used as the default display name.
+        deprecated: true
         example: "Transactions - ACH"
       lago_item_id:
         type: string

--- a/src/schemas/FeeObject.yaml
+++ b/src/schemas/FeeObject.yaml
@@ -25,6 +25,12 @@ properties:
     nullable: true
     description: Unique identifier assigned to the group that the fee belongs to
     example: "1a901a90-1a90-1a90-1a90-1a901a901a90"
+  lago_charge_filter_id:
+    type: string
+    format: "uuid"
+    nullable: true
+    description: Unique identifier assigned to the charge filter that the fee belongs to
+    example: "1a901a90-1a90-1a90-1a90-1a901a901a90"
   lago_invoice_id:
     type: string
     format: uuid
@@ -200,6 +206,10 @@ properties:
         type: string
         description: Specifies the name that will be displayed on an invoice. If no value is set for this field, the name of the actual charge will be used as the default display name.
         example: "Setup Fee (SF1)"
+      filter_invoice_display_name:
+        type: string
+        description: Specifies the name that will be displayed on an invoice. If no value is set for this field, the actual charge filter values will be used as the default display name.
+        example: "AWS eu-east-1"
       group_invoice_display_name:
         type: string
         description: Specifies the name that will be displayed on an invoice. If no value is set for this field, the name of the actual charge will be used as the default display name.

--- a/src/schemas/PlanCreateInput.yaml
+++ b/src/schemas/PlanCreateInput.yaml
@@ -7,19 +7,19 @@ properties:
     properties:
       name:
         type: string
-        example: 'Startup'
+        example: "Startup"
         description: The name of the plan.
       invoice_display_name:
         type: string
-        example: 'Startup plan'
+        example: "Startup plan"
         description: Specifies the name that will be displayed on an invoice. If no value is set for this field, the name of the plan will be used as the default display name.
       code:
         type: string
-        example: 'startup'
+        example: "startup"
         description: The code of the plan. It serves as a unique identifier associated with a particular plan. The code is typically used for internal or system-level identification purposes, like assigning a subscription, for instance.
       interval:
         type: string
-        description: 'The interval used for recurring billing. It represents the frequency at which subscription billing occurs. The interval can be one of the following values: `yearly`, `quarterly`, `monthly`, or `weekly`.'
+        description: "The interval used for recurring billing. It represents the frequency at which subscription billing occurs. The interval can be one of the following values: `yearly`, `quarterly`, `monthly`, or `weekly`."
         example: monthly
         enum:
           - weekly
@@ -29,16 +29,16 @@ properties:
       description:
         type: string
         description: The description on the plan.
-        example: 'Plan for early stage startups.'
+        example: "Plan for early stage startups."
       amount_cents:
         type: integer
         description: The base cost of the plan, excluding any applicable taxes, that is billed on a recurring basis. This value is defined at 0 if your plan is a pay-as-you-go plan.
         example: 10000
       amount_currency:
         allOf:
-          - $ref: './Currency.yaml'
+          - $ref: "./Currency.yaml"
           - description: The currency of the plan. It indicates the monetary unit in which the plan's cost, including taxes and usage-based charges, is expressed.
-            example: 'USD'
+            example: "USD"
       trial_period:
         type: number
         description: The duration in days during which the base cost of the plan is offered for free.
@@ -68,9 +68,9 @@ properties:
           properties:
             billable_metric_id:
               type: string
-              format: 'uuid'
+              format: "uuid"
               description: Unique identifier of the billable metric created by Lago.
-              example: '1a901a90-1a90-1a90-1a90-1a901a901a90'
+              example: "1a901a90-1a90-1a90-1a90-1a901a901a90"
             charge_model:
               type: string
               description: Specifies the pricing model used for the calculation of the final fee. It can be `standard`, `graduated`, `graduated_percentage` `package`, `percentage` or `volume`.
@@ -81,7 +81,7 @@ properties:
                 - package
                 - percentage
                 - volume
-              example: 'standard'
+              example: "standard"
             pay_in_advance:
               type: boolean
               example: false
@@ -93,7 +93,7 @@ properties:
             invoice_display_name:
               type: string
               description: Specifies the name that will be displayed on an invoice. If no value is set for this field, the name of the actual charge will be used as the default display name.
-              example: 'Setup'
+              example: "Setup"
             prorated:
               type: boolean
               example: false
@@ -109,7 +109,7 @@ properties:
               example: 0
             properties:
               allOf:
-                - $ref: './ChargeProperties.yaml'
+                - $ref: "./ChargeProperties.yaml"
                 - description: List of all thresholds utilized for calculating the charge.
             group_properties:
               type: array
@@ -123,11 +123,16 @@ properties:
                   group_id:
                     type: string
                     description: Unique identifier of a billable metric group, created by Lago.
-                    example: '1a901a90-1a90-1a90-1a90-1a901a901a90'
+                    example: "1a901a90-1a90-1a90-1a90-1a901a901a90"
                   values:
                     allOf:
-                      - $ref: './ChargeProperties.yaml'
+                      - $ref: "./ChargeProperties.yaml"
                       - description: List of all thresholds utilized for calculating a charge, scoped by groups used as dimensions for a single charge.
+            filters:
+              type: array
+              description: List of filters used to apply differentiated pricing based on additional event properties.
+              items:
+                $ref: "./ChargeFilterInput.yaml"
             tax_codes:
               type: array
               items:
@@ -135,23 +140,23 @@ properties:
               description: List of unique code used to identify the taxes.
               example: [french_standard_vat]
         example:
-          - billable_metric_id: '1a901a90-1a90-1a90-1a90-1a901a901a91'
-            charge_model: 'package'
+          - billable_metric_id: "1a901a90-1a90-1a90-1a90-1a901a901a91"
+            charge_model: "package"
             invoiceable: true
-            invoice_display_name: 'Setup'
+            invoice_display_name: "Setup"
             pay_in_advance: false
             prorated: false
             min_amount_cents: 3000
             properties:
-              amount: '30'
+              amount: "30"
               free_units: 100
               package_size: 1000
             group_properties: []
             tax_codes: [french_standard_vat]
-          - billable_metric_id: '1a901a90-1a90-1a90-1a90-1a901a901a92'
-            charge_model: 'graduated'
+          - billable_metric_id: "1a901a90-1a90-1a90-1a90-1a901a901a92"
+            charge_model: "graduated"
             invoiceable: true
-            invoice_display_name: 'Setup'
+            invoice_display_name: "Setup"
             pay_in_advance: false
             prorated: false
             min_amount_cents: 0
@@ -159,38 +164,38 @@ properties:
               graduated_ranges:
                 - to_value: 10
                   from_value: 0
-                  flat_amount: '10'
-                  per_unit_amount: '0.5'
+                  flat_amount: "10"
+                  per_unit_amount: "0.5"
                 - to_value: null
                   from_value: 11
-                  flat_amount: '0'
-                  per_unit_amount: '0.4'
+                  flat_amount: "0"
+                  per_unit_amount: "0.4"
             group_properties: []
-          - billable_metric_id: '1a901a90-1a90-1a90-1a90-1a901a901a93'
-            charge_model: 'standard'
+          - billable_metric_id: "1a901a90-1a90-1a90-1a90-1a901a901a93"
+            charge_model: "standard"
             invoiceable: true
-            invoice_display_name: 'Setup'
+            invoice_display_name: "Setup"
             pay_in_advance: true
             prorated: false
             min_amount_cents: 0
             properties: {}
             group_properties:
-              - group_id: '1a901a90-1a90-1a90-1a90-1a901a901a01'
-                invoice_display_name: 'Europe'
+              - group_id: "1a901a90-1a90-1a90-1a90-1a901a901a01"
+                invoice_display_name: "Europe"
                 values:
-                  amount: '10'
-              - group_id: '1a901a90-1a90-1a90-1a90-1a901a901a02'
-                invoice_display_name: 'USA'
+                  amount: "10"
+              - group_id: "1a901a90-1a90-1a90-1a90-1a901a901a02"
+                invoice_display_name: "USA"
                 values:
-                  amount: '5'
-              - group_id: '1a901a90-1a90-1a90-1a90-1a901a901a03'
-                invoice_display_name: 'Africa'
+                  amount: "5"
+              - group_id: "1a901a90-1a90-1a90-1a90-1a901a901a03"
+                invoice_display_name: "Africa"
                 values:
-                  amount: '8'
-          - billable_metric_id: '1a901a90-1a90-1a90-1a90-1a901a901a94'
-            charge_model: 'volume'
+                  amount: "8"
+          - billable_metric_id: "1a901a90-1a90-1a90-1a90-1a901a901a94"
+            charge_model: "volume"
             invoiceable: true
-            invoice_display_name: 'Setup'
+            invoice_display_name: "Setup"
             pay_in_advance: false
             prorated: false
             min_amount_cents: 0
@@ -198,23 +203,23 @@ properties:
               volume_ranges:
                 - from_value: 0
                   to_value: 100
-                  flat_amount: '0'
-                  per_unit_amount: '0'
+                  flat_amount: "0"
+                  per_unit_amount: "0"
                 - from_value: 101
                   to_value: null
-                  flat_amount: '0'
-                  per_unit_amount: '0.5'
+                  flat_amount: "0"
+                  per_unit_amount: "0.5"
             group_properties: []
-          - billable_metric_id: '1a901a90-1a90-1a90-1a90-1a901a901a95'
-            charge_model: 'percentage'
+          - billable_metric_id: "1a901a90-1a90-1a90-1a90-1a901a901a95"
+            charge_model: "percentage"
             invoiceable: false
-            invoice_display_name: 'Setup'
+            invoice_display_name: "Setup"
             pay_in_advance: true
             prorated: false
             min_amount_cents: 0
             properties:
-              rate: '1'
-              fixed_amount: '0.5'
+              rate: "1"
+              fixed_amount: "0.5"
               free_units_per_events: 5
-              free_units_per_total_aggregation: '500'
+              free_units_per_total_aggregation: "500"
             group_properties: []

--- a/src/schemas/PlanCreateInput.yaml
+++ b/src/schemas/PlanCreateInput.yaml
@@ -59,7 +59,7 @@ properties:
         description: List of unique code used to identify the taxes.
         example: [french_standard_vat]
       minimum_commitment:
-        $ref: './MinimumCommitmentInput.yaml'
+        $ref: "./MinimumCommitmentInput.yaml"
       charges:
         type: array
         description: Additional usage-based charges for this plan.
@@ -114,6 +114,7 @@ properties:
             group_properties:
               type: array
               description: All charge information, sorted by groups.
+              deprecated: true
               items:
                 type: object
                 required:

--- a/src/schemas/PlanObject.yaml
+++ b/src/schemas/PlanObject.yaml
@@ -12,29 +12,29 @@ required:
 properties:
   lago_id:
     type: string
-    format: 'uuid'
+    format: "uuid"
     description: Unique identifier of the plan created by Lago.
-    example: '1a901a90-1a90-1a90-1a90-1a901a901a90'
+    example: "1a901a90-1a90-1a90-1a90-1a901a901a90"
   name:
     type: string
     description: The name of the plan.
-    example: 'Startup'
+    example: "Startup"
   invoice_display_name:
     type: string
     description: Specifies the name that will be displayed on an invoice. If no value is set for this field, the name of the plan will be used as the default display name.
-    example: 'Startup plan'
+    example: "Startup plan"
   created_at:
     type: string
-    format: 'date-time'
+    format: "date-time"
     description: The date and time when the plan was created. It is expressed in UTC format according to the ISO 8601 datetime standard. This field provides the timestamp for the exact moment when the plan was initially created.
-    example: '2023-06-27T19:43:42Z'
+    example: "2023-06-27T19:43:42Z"
   code:
     type: string
     description: The code of the plan. It serves as a unique identifier associated with a particular plan. The code is typically used for internal or system-level identification purposes, like assigning a subscription, for instance.
-    example: 'startup'
+    example: "startup"
   interval:
     type: string
-    description: 'The interval used for recurring billing. It represents the frequency at which subscription billing occurs. The interval can be one of the following values: `yearly`, `quarterly`, `monthly` or `weekly`.'
+    description: "The interval used for recurring billing. It represents the frequency at which subscription billing occurs. The interval can be one of the following values: `yearly`, `quarterly`, `monthly` or `weekly`."
     enum:
       - weekly
       - monthly
@@ -44,16 +44,16 @@ properties:
   description:
     type: string
     description: The description on the plan.
-    example: ''
+    example: ""
   amount_cents:
     type: integer
     description: The base cost of the plan, excluding any applicable taxes, that is billed on a recurring basis. This value is defined at 0 if your plan is a pay-as-you-go plan.
     example: 10000
   amount_currency:
     allOf:
-      - $ref: './Currency.yaml'
+      - $ref: "./Currency.yaml"
       - description: The currency of the plan. It indicates the monetary unit in which the plan's cost, including taxes and usage-based charges, is expressed.
-        example: 'USD'
+        example: "USD"
   trial_period:
     type: number
     description: The duration in days during which the base cost of the plan is offered for free.
@@ -76,35 +76,35 @@ properties:
     description: The number of draft invoices that include a subscription attached to the plan. This field provides valuable information about the impact of deleting the plan. By checking the value of this field, you can determine the number of draft invoices that will be affected if the plan is deleted.
     example: 0
   minimum_commitment:
-    $ref: './MinimumCommitmentObject.yaml'
+    $ref: "./MinimumCommitmentObject.yaml"
   charges:
     type: array
     items:
-      $ref: './ChargeObject.yaml'
+      $ref: "./ChargeObject.yaml"
     description: Additional usage-based charges for this plan.
     example:
-      - lago_id: '1a901a90-1a90-1a90-1a90-1a901a901a91'
-        lago_billable_metric_id: '1a901a90-1a90-1a90-1a90-1a901a901a91'
-        billable_metric_code: 'requests'
-        created_at: '2023-06-27T19:43:42Z'
-        charge_model: 'package'
+      - lago_id: "1a901a90-1a90-1a90-1a90-1a901a901a91"
+        lago_billable_metric_id: "1a901a90-1a90-1a90-1a90-1a901a901a91"
+        billable_metric_code: "requests"
+        created_at: "2023-06-27T19:43:42Z"
+        charge_model: "package"
         invoiceable: true
-        invoice_display_name: 'Setup'
+        invoice_display_name: "Setup"
         pay_in_advance: false
         prorated: false
         min_amount_cents: 3000
         properties:
-          amount: '30'
+          amount: "30"
           free_units: 100
           package_size: 1000
-        group_properties: []
-      - lago_id: '1a901a90-1a90-1a90-1a90-1a901a901a92'
-        lago_billable_metric_id: '1a901a90-1a90-1a90-1a90-1a901a901a92'
-        billable_metric_code: 'cpu'
-        created_at: '2023-06-27T19:43:42Z'
-        charge_model: 'graduated'
+        filters: []
+      - lago_id: "1a901a90-1a90-1a90-1a90-1a901a901a92"
+        lago_billable_metric_id: "1a901a90-1a90-1a90-1a90-1a901a901a92"
+        billable_metric_code: "cpu"
+        created_at: "2023-06-27T19:43:42Z"
+        charge_model: "graduated"
         invoiceable: true
-        invoice_display_name: 'Setup'
+        invoice_display_name: "Setup"
         pay_in_advance: false
         prorated: false
         min_amount_cents: 0
@@ -112,44 +112,47 @@ properties:
           graduated_ranges:
             - from_value: 0
               to_value: 10
-              flat_amount: '10'
-              per_unit_amount: '0.5'
+              flat_amount: "10"
+              per_unit_amount: "0.5"
             - from_value: 11
               to_value: null
-              flat_amount: '0'
-              per_unit_amount: '0.4'
-        group_properties: []
-      - lago_id: '1a901a90-1a90-1a90-1a90-1a901a901a93'
-        lago_billable_metric_id: '1a901a90-1a90-1a90-1a90-1a901a901a93'
-        billable_metric_code: 'seats'
-        created_at: '2023-06-27T19:43:42Z'
-        charge_model: 'standard'
+              flat_amount: "0"
+              per_unit_amount: "0.4"
+        filters: []
+      - lago_id: "1a901a90-1a90-1a90-1a90-1a901a901a93"
+        lago_billable_metric_id: "1a901a90-1a90-1a90-1a90-1a901a901a93"
+        billable_metric_code: "seats"
+        created_at: "2023-06-27T19:43:42Z"
+        charge_model: "standard"
         invoiceable: true
-        invoice_display_name: 'Setup'
+        invoice_display_name: "Setup"
         pay_in_advance: true
         prorated: false
         min_amount_cents: 0
         properties: {}
-        group_properties:
-          - group_id: '1a901a90-1a90-1a90-1a90-1a901a901a01'
-            invoice_display_name: 'Europe'
+        filters:
+          - invoice_display_name: "Europe"
+            properties:
+              amount: "10"
             values:
-              amount: '10'
-          - group_id: '1a901a90-1a90-1a90-1a90-1a901a901a02'
-            invoice_display_name: 'USA'
+              region: ["Europe"]
+          - invoice_display_name: "USA"
+            properties:
+              amount: "5"
             values:
-              amount: '5'
-          - group_id: '1a901a90-1a90-1a90-1a90-1a901a901a03'
-            invoice_display_name: 'Africa'
+              region: ["USA"]
+          - invoice_display_name: "Africa"
+            properties:
+              amount: "8"
             values:
-              amount: '8'
-      - lago_id: '1a901a90-1a90-1a90-1a90-1a901a901a94'
-        lago_billable_metric_id: '1a901a90-1a90-1a90-1a90-1a901a901a94'
-        billable_metric_code: 'storage'
-        created_at: '2023-06-27T19:43:42Z'
-        charge_model: 'volume'
+              region: ["Africa"]
+      - lago_id: "1a901a90-1a90-1a90-1a90-1a901a901a94"
+        lago_billable_metric_id: "1a901a90-1a90-1a90-1a90-1a901a901a94"
+        billable_metric_code: "storage"
+        created_at: "2023-06-27T19:43:42Z"
+        charge_model: "volume"
         invoiceable: true
-        invoice_display_name: 'Setup'
+        invoice_display_name: "Setup"
         pay_in_advance: false
         prorated: false
         min_amount_cents: 0
@@ -157,31 +160,31 @@ properties:
           volume_ranges:
             - from_value: 0
               to_value: 100
-              flat_amount: '0'
-              per_unit_amount: '0'
+              flat_amount: "0"
+              per_unit_amount: "0"
             - from_value: 101
               to_value: null
-              flat_amount: '0'
-              per_unit_amount: '0.5'
-        group_properties: []
-      - lago_id: '1a901a90-1a90-1a90-1a90-1a901a901a95'
-        lago_billable_metric_id: '1a901a90-1a90-1a90-1a90-1a901a901a95'
-        billable_metric_code: 'payments'
-        created_at: '2023-06-27T19:43:42Z'
-        charge_model: 'percentage'
+              flat_amount: "0"
+              per_unit_amount: "0.5"
+        filters: []
+      - lago_id: "1a901a90-1a90-1a90-1a90-1a901a901a95"
+        lago_billable_metric_id: "1a901a90-1a90-1a90-1a90-1a901a901a95"
+        billable_metric_code: "payments"
+        created_at: "2023-06-27T19:43:42Z"
+        charge_model: "percentage"
         invoiceable: false
-        invoice_display_name: 'Setup'
+        invoice_display_name: "Setup"
         pay_in_advance: true
         prorated: false
         min_amount_cents: 0
         properties:
-          rate: '1'
-          fixed_amount: '0.5'
+          rate: "1"
+          fixed_amount: "0.5"
           free_units_per_events: 5
-          free_units_per_total_aggregation: '500'
-        group_properties: []
+          free_units_per_total_aggregation: "500"
+        filters: []
   taxes:
     type: array
     description: All taxes applied to the plan.
     items:
-      $ref: './TaxObject.yaml'
+      $ref: "./TaxObject.yaml"

--- a/src/schemas/PlanOverridesObject.yaml
+++ b/src/schemas/PlanOverridesObject.yaml
@@ -7,20 +7,20 @@ properties:
     example: 10000
   amount_currency:
     allOf:
-      - $ref: './Currency.yaml'
+      - $ref: "./Currency.yaml"
       - description: The currency of the plan. It indicates the monetary unit in which the plan's cost, including taxes and usage-based charges, is expressed.
-        example: 'USD'
+        example: "USD"
   description:
     type: string
     description: The description on the plan.
-    example: 'Plan for early stage startups.'
+    example: "Plan for early stage startups."
   invoice_display_name:
     type: string
-    example: 'Startup plan'
+    example: "Startup plan"
     description: Specifies the name that will be displayed on an invoice. If no value is set for this field, the name of the plan will be used as the default display name.
   name:
     type: string
-    example: 'Startup'
+    example: "Startup"
     description: The name of the plan.
   tax_codes:
     type: array
@@ -42,25 +42,25 @@ properties:
       properties:
         id:
           type: string
-          format: 'uuid'
+          format: "uuid"
           description: Unique identifier of the charge created by Lago.
-          example: '1a901a90-1a90-1a90-1a90-1a901a901a90'
+          example: "1a901a90-1a90-1a90-1a90-1a901a901a90"
         billable_metric_id:
           type: string
-          format: 'uuid'
+          format: "uuid"
           description: Unique identifier of the billable metric created by Lago.
-          example: '1a901a90-1a90-1a90-1a90-1a901a901a90'
+          example: "1a901a90-1a90-1a90-1a90-1a901a901a90"
         invoice_display_name:
           type: string
           description: Specifies the name that will be displayed on an invoice. If no value is set for this field, the name of the actual charge will be used as the default display name.
-          example: 'Setup'
+          example: "Setup"
         min_amount_cents:
           type: integer
           description: The minimum spending amount required for the charge, measured in cents and excluding any applicable taxes. It indicates the minimum amount that needs to be charged for each billing period.
           example: 0
         properties:
           allOf:
-            - $ref: './ChargeProperties.yaml'
+            - $ref: "./ChargeProperties.yaml"
             - description: List of all thresholds utilized for calculating the charge.
         group_properties:
           type: array
@@ -74,11 +74,16 @@ properties:
               group_id:
                 type: string
                 description: Unique identifier of a billable metric group, created by Lago.
-                example: '1a901a90-1a90-1a90-1a90-1a901a901a90'
+                example: "1a901a90-1a90-1a90-1a90-1a901a901a90"
               values:
                 allOf:
-                  - $ref: './ChargeProperties.yaml'
+                  - $ref: "./ChargeProperties.yaml"
                   - description: List of all thresholds utilized for calculating a charge, scoped by groups used as dimensions for a single charge.
+        filters:
+          type: array
+          description: List of filters used to apply differentiated pricing based on additional event properties.
+          items:
+            $ref: "./ChargeFilterInput.yaml"
         tax_codes:
           type: array
           items:

--- a/src/schemas/PlanOverridesObject.yaml
+++ b/src/schemas/PlanOverridesObject.yaml
@@ -33,7 +33,7 @@ properties:
     description: The duration in days during which the base cost of the plan is offered for free.
     example: 5
   minimum_commitment:
-    $ref: './MinimumCommitmentObject.yaml'
+    $ref: "./MinimumCommitmentObject.yaml"
   charges:
     type: array
     description: Additional usage-based charges for this plan.
@@ -65,6 +65,7 @@ properties:
         group_properties:
           type: array
           description: All charge information, sorted by groups.
+          deprecated: true
           items:
             type: object
             required:

--- a/src/schemas/PlanUpdateInput.yaml
+++ b/src/schemas/PlanUpdateInput.yaml
@@ -7,19 +7,19 @@ properties:
     properties:
       name:
         type: string
-        example: 'Startup'
+        example: "Startup"
         description: The name of the plan.
       invoice_display_name:
         type: string
-        example: 'Startup plan'
+        example: "Startup plan"
         description: Specifies the name that will be displayed on an invoice. If no value is set for this field, the name of the plan will be used as the default display name.
       code:
         type: string
-        example: 'startup'
+        example: "startup"
         description: The code of the plan. It serves as a unique identifier associated with a particular plan. The code is typically used for internal or system-level identification purposes, like assigning a subscription, for instance.
       interval:
         type: string
-        description: 'The interval used for recurring billing. It represents the frequency at which subscription billing occurs. The interval can be one of the following values: `yearly`, `quarterly`, `monthly`, or `weekly`.'
+        description: "The interval used for recurring billing. It represents the frequency at which subscription billing occurs. The interval can be one of the following values: `yearly`, `quarterly`, `monthly`, or `weekly`."
         example: monthly
         enum:
           - weekly
@@ -29,16 +29,16 @@ properties:
       description:
         type: string
         description: The description on the plan.
-        example: 'Plan for early stage startups.'
+        example: "Plan for early stage startups."
       amount_cents:
         type: integer
         description: The base cost of the plan, excluding any applicable taxes, that is billed on a recurring basis. This value is defined at 0 if your plan is a pay-as-you-go plan.
         example: 10000
       amount_currency:
         allOf:
-          - $ref: './Currency.yaml'
+          - $ref: "./Currency.yaml"
           - description: The currency of the plan. It indicates the monetary unit in which the plan's cost, including taxes and usage-based charges, is expressed.
-            example: 'USD'
+            example: "USD"
       trial_period:
         type: number
         description: The duration in days during which the base cost of the plan is offered for free.
@@ -68,14 +68,14 @@ properties:
           properties:
             id:
               type: string
-              format: 'uuid'
+              format: "uuid"
               description: Unique identifier of the charge created by Lago.
-              example: '1a901a90-1a90-1a90-1a90-1a901a901a90'
+              example: "1a901a90-1a90-1a90-1a90-1a901a901a90"
             billable_metric_id:
               type: string
-              format: 'uuid'
+              format: "uuid"
               description: Unique identifier of the billable metric created by Lago.
-              example: '1a901a90-1a90-1a90-1a90-1a901a901a90'
+              example: "1a901a90-1a90-1a90-1a90-1a901a901a90"
             charge_model:
               type: string
               description: Specifies the pricing model used for the calculation of the final fee. It can be `standard`, `graduated`, `graduated_percentage`, `package`, `percentage` or `volume`.
@@ -86,7 +86,7 @@ properties:
                 - package
                 - percentage
                 - volume
-              example: 'standard'
+              example: "standard"
             pay_in_advance:
               type: boolean
               example: false
@@ -98,7 +98,7 @@ properties:
             invoice_display_name:
               type: string
               description: Specifies the name that will be displayed on an invoice. If no value is set for this field, the name of the actual charge will be used as the default display name.
-              example: 'Setup'
+              example: "Setup"
             prorated:
               type: boolean
               example: false
@@ -114,7 +114,7 @@ properties:
               example: 0
             properties:
               allOf:
-                - $ref: './ChargeProperties.yaml'
+                - $ref: "./ChargeProperties.yaml"
                 - description: List of all thresholds utilized for calculating the charge.
             group_properties:
               type: array
@@ -128,11 +128,16 @@ properties:
                   group_id:
                     type: string
                     description: Unique identifier of a billable metric group, created by Lago.
-                    example: '1a901a90-1a90-1a90-1a90-1a901a901a90'
+                    example: "1a901a90-1a90-1a90-1a90-1a901a901a90"
                   values:
                     allOf:
-                      - $ref: './ChargeProperties.yaml'
+                      - $ref: "./ChargeProperties.yaml"
                       - description: List of all thresholds utilized for calculating a charge, scoped by groups used as dimensions for a single charge.
+            filters:
+              type: array
+              description: List of filters used to apply differentiated pricing based on additional event properties.
+              items:
+                $ref: "./ChargeFilterInput.yaml"
             tax_codes:
               type: array
               items:
@@ -140,23 +145,23 @@ properties:
               description: List of unique code used to identify the taxes.
               example: [french_standard_vat]
         example:
-          - billable_metric_id: '1a901a90-1a90-1a90-1a90-1a901a901a91'
-            charge_model: 'package'
+          - billable_metric_id: "1a901a90-1a90-1a90-1a90-1a901a901a91"
+            charge_model: "package"
             invoiceable: true
-            invoice_display_name: 'Setup'
+            invoice_display_name: "Setup"
             pay_in_advance: false
             prorated: false
             min_amount_cents: 3000
             properties:
-              amount: '30'
+              amount: "30"
               free_units: 100
               package_size: 1000
             group_properties: []
             tax_codes: [french_standard_vat]
-          - billable_metric_id: '1a901a90-1a90-1a90-1a90-1a901a901a92'
-            charge_model: 'graduated'
+          - billable_metric_id: "1a901a90-1a90-1a90-1a90-1a901a901a92"
+            charge_model: "graduated"
             invoiceable: true
-            invoice_display_name: 'Setup'
+            invoice_display_name: "Setup"
             pay_in_advance: false
             prorated: false
             min_amount_cents: 0
@@ -164,38 +169,38 @@ properties:
               graduated_ranges:
                 - to_value: 10
                   from_value: 0
-                  flat_amount: '10'
-                  per_unit_amount: '0.5'
+                  flat_amount: "10"
+                  per_unit_amount: "0.5"
                 - to_value: null
                   from_value: 11
-                  flat_amount: '0'
-                  per_unit_amount: '0.4'
+                  flat_amount: "0"
+                  per_unit_amount: "0.4"
             group_properties: []
-          - billable_metric_id: '1a901a90-1a90-1a90-1a90-1a901a901a93'
-            charge_model: 'standard'
+          - billable_metric_id: "1a901a90-1a90-1a90-1a90-1a901a901a93"
+            charge_model: "standard"
             invoiceable: true
-            invoice_display_name: 'Setup'
+            invoice_display_name: "Setup"
             pay_in_advance: true
             prorated: false
             min_amount_cents: 0
             properties: {}
             group_properties:
-              - group_id: '1a901a90-1a90-1a90-1a90-1a901a901a01'
-                invoice_display_name: 'Europe'
+              - group_id: "1a901a90-1a90-1a90-1a90-1a901a901a01"
+                invoice_display_name: "Europe"
                 values:
-                  amount: '10'
-              - group_id: '1a901a90-1a90-1a90-1a90-1a901a901a02'
-                invoice_display_name: 'USA'
+                  amount: "10"
+              - group_id: "1a901a90-1a90-1a90-1a90-1a901a901a02"
+                invoice_display_name: "USA"
                 values:
-                  amount: '5'
-              - group_id: '1a901a90-1a90-1a90-1a90-1a901a901a03'
-                invoice_display_name: 'Africa'
+                  amount: "5"
+              - group_id: "1a901a90-1a90-1a90-1a90-1a901a901a03"
+                invoice_display_name: "Africa"
                 values:
-                  amount: '8'
-          - billable_metric_id: '1a901a90-1a90-1a90-1a90-1a901a901a94'
-            charge_model: 'volume'
+                  amount: "8"
+          - billable_metric_id: "1a901a90-1a90-1a90-1a90-1a901a901a94"
+            charge_model: "volume"
             invoiceable: true
-            invoice_display_name: 'Setup'
+            invoice_display_name: "Setup"
             pay_in_advance: false
             prorated: false
             min_amount_cents: 0
@@ -203,23 +208,23 @@ properties:
               volume_ranges:
                 - from_value: 0
                   to_value: 100
-                  flat_amount: '0'
-                  per_unit_amount: '0'
+                  flat_amount: "0"
+                  per_unit_amount: "0"
                 - from_value: 101
                   to_value: null
-                  flat_amount: '0'
-                  per_unit_amount: '0.5'
+                  flat_amount: "0"
+                  per_unit_amount: "0.5"
             group_properties: []
-          - billable_metric_id: '1a901a90-1a90-1a90-1a90-1a901a901a95'
-            charge_model: 'percentage'
+          - billable_metric_id: "1a901a90-1a90-1a90-1a90-1a901a901a95"
+            charge_model: "percentage"
             invoiceable: false
-            invoice_display_name: 'Setup'
+            invoice_display_name: "Setup"
             pay_in_advance: true
             prorated: false
             min_amount_cents: 0
             properties:
-              rate: '1'
-              fixed_amount: '0.5'
+              rate: "1"
+              fixed_amount: "0.5"
               free_units_per_events: 5
-              free_units_per_total_aggregation: '500'
+              free_units_per_total_aggregation: "500"
             group_properties: []

--- a/src/schemas/PlanUpdateInput.yaml
+++ b/src/schemas/PlanUpdateInput.yaml
@@ -59,7 +59,7 @@ properties:
         description: List of unique code used to identify the taxes.
         example: [french_standard_vat]
       minimum_commitment:
-        $ref: './MinimumCommitmentInput.yaml'
+        $ref: "./MinimumCommitmentInput.yaml"
       charges:
         type: array
         description: Additional usage-based charges for this plan.
@@ -119,6 +119,7 @@ properties:
             group_properties:
               type: array
               description: All charge information, sorted by groups.
+              deprecated: true
               items:
                 type: object
                 required:

--- a/src/schemas/_index.yaml
+++ b/src/schemas/_index.yaml
@@ -52,6 +52,10 @@ BillableMetricGroup:
   $ref: "./BillableMetricGroup.yaml"
 BillableMetricsPaginated:
   $ref: "./BillableMetricsPaginated.yaml"
+ChargeFilterInput:
+  $ref: "./ChargeFilterInput.yaml"
+ChargeFilterObject:
+  $ref: "./ChargeFilterObject.yaml"
 ChargeObject:
   $ref: "./ChargeObject.yaml"
 ChargeProperties:

--- a/src/schemas/_index.yaml
+++ b/src/schemas/_index.yaml
@@ -100,6 +100,8 @@ Customer:
   $ref: "./Customer.yaml"
 CustomerBillingConfiguration:
   $ref: "./CustomerBillingConfiguration.yaml"
+CustomerChargeFiltersUsageObject:
+  $ref: "./CustomerChargeFiltersUsageObject.yaml"
 CustomerChargeGroupedUsageObject:
   $ref: "./CustomerChargeGroupedUsageObject.yaml"
 CustomerChargeGroupsUsageObject:

--- a/src/schemas/_index.yaml
+++ b/src/schemas/_index.yaml
@@ -42,6 +42,10 @@ BillableMetricBaseInput:
   $ref: "./BillableMetricBaseInput.yaml"
 BillableMetricCreateInput:
   $ref: "./BillableMetricCreateInput.yaml"
+BillableMetricFilterInput:
+  $ref: "./BillableMetricFilterInput.yaml"
+BillableMetricFilterObject:
+  $ref: "./BillableMetricFilterObject.yaml"
 BillableMetricUpdateInput:
   $ref: "./BillableMetricUpdateInput.yaml"
 BillableMetricGroup:


### PR DESCRIPTION
## Context

Lago is not currently supporting more than 2 levels of event grouping (parent → children)

The goal of this feature is to allow more flexibility of event grouping by allowing an unlimited level of grouping and making it easier to define default charge properties for events based on their properties.

## Description

This PR add the documentation for the new filter in both input and output objects