### PR TITLE
feat(minimum-commitment): Add minimum commitment

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -5992,6 +5992,55 @@ components:
             $ref: '#/components/schemas/GroupObject'
         meta:
           $ref: '#/components/schemas/PaginationMeta'
+    MinimumCommitmentObject:
+      type: object
+      nullable: true
+      required:
+        - lago_id
+        - amount_cents
+        - created_at
+      properties:
+        lago_id:
+          type: string
+          format: uuid
+          description: 'Unique identifier of the minimum commitment, created by Lago.'
+          example: 1a901a90-1a90-1a90-1a90-1a901a901a90
+        plan_code:
+          type: string
+          example: premium
+          description: The unique code representing the plan to be attached to the customer.
+        amount_cents:
+          type: integer
+          description: The amount of the minimum commitment in cents.
+          example: 100000
+        invoice_display_name:
+          type: string
+          description: 'Specifies the name that will be displayed on an invoice. If no value is set for this field, the default name will be used as the display name.'
+          example: Minimum Commitment (C1)
+        interval:
+          type: string
+          description: 'The interval used for recurring billing. It represents the frequency at which subscription billing occurs. The interval can be one of the following values: `yearly`, `quarterly`, `monthly` or `weekly`.'
+          enum:
+            - weekly
+            - monthly
+            - quarterly
+            - yearly
+          example: monthly
+        created_at:
+          type: string
+          format: date-time
+          description: The date and time when the minimum commitment was created. It is expressed in UTC format according to the ISO 8601 datetime standard. This field provides the timestamp for the exact moment when the minimum commitment was initially created.
+          example: '2022-04-29T08:59:51Z'
+        updated_at:
+          type: string
+          format: date-time
+          description: The date and time when the minimum commitment was updated. It is expressed in UTC format according to the ISO 8601 datetime standard. This field provides the timestamp for the exact moment when the minimum commitment was initially created.
+          example: '2022-04-29T08:59:51Z'
+        taxes:
+          type: array
+          description: All taxes applied to the minimum commitment.
+          items:
+            $ref: '#/components/schemas/TaxObject'
     MrrObject:
       type: object
       required:
@@ -6765,6 +6814,8 @@ components:
               description: List of unique code used to identify the taxes.
               example:
                 - french_standard_vat
+            minimum_commitment:
+              $ref: '#/components/schemas/PlanOverridesObject/properties/minimum_commitment'
             charges:
               type: array
               description: Additional usage-based charges for this plan.
@@ -6961,6 +7012,28 @@ components:
           type: number
           description: The duration in days during which the base cost of the plan is offered for free.
           example: 5
+        minimum_commitment:
+          type: object
+          description: Minimum commitment for this plan.
+          nullable: true
+          required:
+            - amount_cents
+          properties:
+            amount_cents:
+              type: integer
+              description: The amount of the minimum commitment in cents.
+              example: 100000
+            invoice_display_name:
+              type: string
+              description: 'Specifies the name that will be displayed on an invoice. If no value is set for this field, the default name will be used as the display name.'
+              example: Minimum Commitment (C1)
+            tax_codes:
+              type: array
+              items:
+                type: string
+              description: List of unique code used to identify the taxes.
+              example:
+                - french_standard_vat
         charges:
           type: array
           description: Additional usage-based charges for this plan.
@@ -7075,6 +7148,8 @@ components:
               description: List of unique code used to identify the taxes.
               example:
                 - french_standard_vat
+            minimum_commitment:
+              $ref: '#/components/schemas/PlanOverridesObject/properties/minimum_commitment'
             charges:
               type: array
               description: Additional usage-based charges for this plan.
@@ -7318,6 +7393,8 @@ components:
           type: integer
           description: 'The number of draft invoices that include a subscription attached to the plan. This field provides valuable information about the impact of deleting the plan. By checking the value of this field, you can determine the number of draft invoices that will be affected if the plan is deleted.'
           example: 0
+        minimum_commitment:
+          $ref: '#/components/schemas/MinimumCommitmentObject'
         charges:
           type: array
           items:

--- a/src/schemas/MinimumCommitmentInput.yaml
+++ b/src/schemas/MinimumCommitmentInput.yaml
@@ -1,0 +1,22 @@
+type: object
+description: Minimum commitment for this plan.
+nullable: true
+required:
+  - amount_cents
+properties:
+  amount_cents:
+    type: integer
+    description: The amount of the minimum commitment in cents.
+    example: 100000
+  invoice_display_name:
+    type: string
+    description: Specifies the name that will be displayed on an invoice. If no value is set for this field, the default name will be used as the display name.
+    example: "Minimum Commitment (C1)"
+  tax_codes:
+    type: array
+    items:
+      type: string
+    description: List of unique code used to identify the taxes.
+    example: [french_standard_vat]
+
+

--- a/src/schemas/MinimumCommitmentObject.yaml
+++ b/src/schemas/MinimumCommitmentObject.yaml
@@ -1,0 +1,48 @@
+type: object
+nullable: true
+required:
+  - lago_id
+  - amount_cents
+  - created_at
+properties:
+  lago_id:
+    type: string
+    format: 'uuid'
+    description: Unique identifier of the minimum commitment, created by Lago.
+    example: '1a901a90-1a90-1a90-1a90-1a901a901a90'
+  plan_code:
+    type: string
+    example: 'premium'
+    description: The unique code representing the plan to be attached to the customer.
+  amount_cents:
+    type: integer
+    description: The amount of the minimum commitment in cents.
+    example: 100000
+  invoice_display_name:
+    type: string
+    description: Specifies the name that will be displayed on an invoice. If no value is set for this field, the default name will be used as the display name.
+    example: "Minimum Commitment (C1)"
+  interval:
+    type: string
+    description: 'The interval used for recurring billing. It represents the frequency at which subscription billing occurs. The interval can be one of the following values: `yearly`, `quarterly`, `monthly` or `weekly`.'
+    enum:
+      - weekly
+      - monthly
+      - quarterly
+      - yearly
+    example: monthly
+  created_at:
+    type: string
+    format: 'date-time'
+    description: The date and time when the minimum commitment was created. It is expressed in UTC format according to the ISO 8601 datetime standard. This field provides the timestamp for the exact moment when the minimum commitment was initially created.
+    example: '2022-04-29T08:59:51Z'
+  updated_at:
+    type: string
+    format: 'date-time'
+    description: The date and time when the minimum commitment was updated. It is expressed in UTC format according to the ISO 8601 datetime standard. This field provides the timestamp for the exact moment when the minimum commitment was initially created.
+    example: '2022-04-29T08:59:51Z'
+  taxes:
+    type: array
+    description: All taxes applied to the minimum commitment.
+    items:
+      $ref: './TaxObject.yaml'

--- a/src/schemas/PlanCreateInput.yaml
+++ b/src/schemas/PlanCreateInput.yaml
@@ -58,6 +58,8 @@ properties:
           type: string
         description: List of unique code used to identify the taxes.
         example: [french_standard_vat]
+      minimum_commitment:
+        $ref: './MinimumCommitmentInput.yaml'
       charges:
         type: array
         description: Additional usage-based charges for this plan.

--- a/src/schemas/PlanObject.yaml
+++ b/src/schemas/PlanObject.yaml
@@ -75,6 +75,8 @@ properties:
     type: integer
     description: The number of draft invoices that include a subscription attached to the plan. This field provides valuable information about the impact of deleting the plan. By checking the value of this field, you can determine the number of draft invoices that will be affected if the plan is deleted.
     example: 0
+  minimum_commitment:
+    $ref: './MinimumCommitmentObject.yaml'
   charges:
     type: array
     items:

--- a/src/schemas/PlanOverridesObject.yaml
+++ b/src/schemas/PlanOverridesObject.yaml
@@ -32,6 +32,8 @@ properties:
     type: number
     description: The duration in days during which the base cost of the plan is offered for free.
     example: 5
+  minimum_commitment:
+    $ref: './MinimumCommitmentInput.yaml'
   charges:
     type: array
     description: Additional usage-based charges for this plan.

--- a/src/schemas/PlanUpdateInput.yaml
+++ b/src/schemas/PlanUpdateInput.yaml
@@ -58,6 +58,8 @@ properties:
           type: string
         description: List of unique code used to identify the taxes.
         example: [french_standard_vat]
+      minimum_commitment:
+        $ref: './MinimumCommitmentInput.yaml'
       charges:
         type: array
         description: Additional usage-based charges for this plan.

--- a/src/schemas/_index.yaml
+++ b/src/schemas/_index.yaml
@@ -146,6 +146,8 @@ GroupPropertiesObject:
   $ref: "./GroupPropertiesObject.yaml"
 GroupsPaginated:
   $ref: "./GroupsPaginated.yaml"
+MinimumCommitmentObject:
+  $ref: "./MinimumCommitmentObject.yaml"
 MrrObject:
   $ref: "./MrrObject.yaml"
 Mrrs:


### PR DESCRIPTION
## Roadmap Task

👉  https://getlago.canny.io/feature-requests/p/set-minimum-spend-for-subscriptions

## Context

As a user, I want to define the minimum spend that applies to the customer's plan. Consider the following monthly plan:

- Subscription fee = $50 per month (in arrears);
- Usage-based charge = $10 per unit per month (in arrears); and
- Monthly minimum spend = $100.

If at the end of the month, the customer has consumed 3 units, their total invoice will be: $50 + 3 * $10 = $80 + $20 (true-up fee) = $100.

## Description

This PR adds minimum commitment to plan and plan overrides.