### PR TITLE
fix(openapi-schema): fix MinimumCommitmentObject ref

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -5992,6 +5992,28 @@ components:
             $ref: '#/components/schemas/GroupObject'
         meta:
           $ref: '#/components/schemas/PaginationMeta'
+    MinimumCommitmentInput:
+      type: object
+      description: Minimum commitment for this plan.
+      nullable: true
+      required:
+        - amount_cents
+      properties:
+        amount_cents:
+          type: integer
+          description: The amount of the minimum commitment in cents.
+          example: 100000
+        invoice_display_name:
+          type: string
+          description: 'Specifies the name that will be displayed on an invoice. If no value is set for this field, the default name will be used as the display name.'
+          example: Minimum Commitment (C1)
+        tax_codes:
+          type: array
+          items:
+            type: string
+          description: List of unique code used to identify the taxes.
+          example:
+            - french_standard_vat
     MinimumCommitmentObject:
       type: object
       nullable: true
@@ -6815,7 +6837,7 @@ components:
               example:
                 - french_standard_vat
             minimum_commitment:
-              $ref: '#/components/schemas/PlanOverridesObject/properties/minimum_commitment'
+              $ref: '#/components/schemas/MinimumCommitmentInput'
             charges:
               type: array
               description: Additional usage-based charges for this plan.
@@ -7013,27 +7035,7 @@ components:
           description: The duration in days during which the base cost of the plan is offered for free.
           example: 5
         minimum_commitment:
-          type: object
-          description: Minimum commitment for this plan.
-          nullable: true
-          required:
-            - amount_cents
-          properties:
-            amount_cents:
-              type: integer
-              description: The amount of the minimum commitment in cents.
-              example: 100000
-            invoice_display_name:
-              type: string
-              description: 'Specifies the name that will be displayed on an invoice. If no value is set for this field, the default name will be used as the display name.'
-              example: Minimum Commitment (C1)
-            tax_codes:
-              type: array
-              items:
-                type: string
-              description: List of unique code used to identify the taxes.
-              example:
-                - french_standard_vat
+          $ref: '#/components/schemas/MinimumCommitmentObject'
         charges:
           type: array
           description: Additional usage-based charges for this plan.
@@ -7149,7 +7151,7 @@ components:
               example:
                 - french_standard_vat
             minimum_commitment:
-              $ref: '#/components/schemas/PlanOverridesObject/properties/minimum_commitment'
+              $ref: '#/components/schemas/MinimumCommitmentInput'
             charges:
               type: array
               description: Additional usage-based charges for this plan.

--- a/src/schemas/PlanOverridesObject.yaml
+++ b/src/schemas/PlanOverridesObject.yaml
@@ -33,7 +33,7 @@ properties:
     description: The duration in days during which the base cost of the plan is offered for free.
     example: 5
   minimum_commitment:
-    $ref: './MinimumCommitmentInput.yaml'
+    $ref: './MinimumCommitmentObject.yaml'
   charges:
     type: array
     description: Additional usage-based charges for this plan.

--- a/src/schemas/_index.yaml
+++ b/src/schemas/_index.yaml
@@ -146,6 +146,8 @@ GroupPropertiesObject:
   $ref: "./GroupPropertiesObject.yaml"
 GroupsPaginated:
   $ref: "./GroupsPaginated.yaml"
+MinimumCommitmentInput:
+  $ref: "./MinimumCommitmentInput.yaml"
 MinimumCommitmentObject:
   $ref: "./MinimumCommitmentObject.yaml"
 MrrObject:


### PR DESCRIPTION
Adds missing schemas to `src/schemas/_index.yaml`.
Fixes inverted ref : `MinimumCommitmentInput` instead of `MinimumCommitmentObject`

Using the current `openapi.yaml` file we were unable to generate a properly typed openapi SDK (using openapi-typescript-codegen).

![Screenshot 2024-03-19 at 10 25 34](https://github.com/getlago/lago-openapi/assets/12938816/a1bbadcb-148f-4c49-95dc-cf975b9204a6)

Here is our openapi codegen config (from package.json): 
```
"lago-sdk": "openapi --input ./openapi.yaml --output src/providers/lago/lago.sdk --name LagoClient --client axios --useOptions --useUnionTypes",
```
Then running `tsc --noEmit` makes it easy to identify errors in the schema, maybe this could be a step in your CI upon schema change? 

