### PR TITLE
feat(trial_period): Add trial_ended_at to Subscription

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -7716,6 +7716,12 @@ components:
           example: '2022-04-30'
           description: 'The date when the plan will be downgraded, represented in ISO 8601 date format.'
           nullable: true
+        trial_ended_at:
+          type: string
+          format: date-time
+          example: '2022-08-08T00:00:00Z'
+          description: 'The date when the free trial is ended, represented in ISO 8601 date format.'
+          nullable: true
     SubscriptionObjectExtended:
       allOf:
         - $ref: '#/components/schemas/SubscriptionObject'

--- a/src/schemas/SubscriptionObject.yaml
+++ b/src/schemas/SubscriptionObject.yaml
@@ -107,3 +107,9 @@ properties:
     example: '2022-04-30'
     description: The date when the plan will be downgraded, represented in ISO 8601 date format.
     nullable: true
+  trial_ended_at:
+    type: string
+    format: 'date-time'
+    example: '2022-08-08T00:00:00Z'
+    description: The date when the free trial is ended, represented in ISO 8601 date format.
+    nullable: true


### PR DESCRIPTION
We're adding a new attribute in the Subscription response: `trial_ended_at`.

The goal of this PR is to reference it on the Open API doc.