### PR TITLE
fix: mark sequential_id as optional

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -6210,7 +6210,6 @@ components:
       type: object
       required:
         - lago_id
-        - sequential_id
         - number
         - issuing_date
         - invoice_type

--- a/src/schemas/InvoiceObject.yaml
+++ b/src/schemas/InvoiceObject.yaml
@@ -1,7 +1,6 @@
 type: object
 required:
   - lago_id
-  - sequential_id
   - number
   - issuing_date
   - invoice_type


### PR DESCRIPTION
Currently, we generate `sequential_id` upon invoice finalization. When the invoice is draft `sequential_id` could be nil.

We have to make this field optional in api response.