### PR TITLE
feat(wallet): Add transaction_status to wallet object

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2392,6 +2392,14 @@ paths:
           schema:
             type: string
             example: pending
+        - name: transaction_status
+          in: query
+          description: 'The transaction status of the wallet transaction. Possible values are `paid` (with pending or settled status), `offered` (settled status but null invoice_id) or `voided` (with outbound transaction type).'
+          required: false
+          explode: true
+          schema:
+            type: string
+            example: paid
         - name: transaction_type
           in: query
           description: The transaction type of the wallet transaction. Possible values are `inbound` (increasing the wallet balance) or `outbound` (decreasing the wallet balance).
@@ -8322,6 +8330,7 @@ components:
         - lago_id
         - lago_wallet_id
         - status
+        - transaction_status
         - transaction_type
         - credit_amount
         - amount
@@ -8344,6 +8353,14 @@ components:
             - settled
           description: The status of the wallet transaction. Possible values are `pending` or `settled`.
           example: settled
+        transaction_status:
+          type: string
+          enum:
+            - paid
+            - offered
+            - voided
+          description: 'The transaction status of the wallet transaction. Possible values are `paid` (with pending or settled status), `offered` (settled status but null invoice_id) or `voided` (with outbound transaction type).'
+          example: paid
         transaction_type:
           type: string
           enum:

--- a/src/resources/wallet_transactions.yaml
+++ b/src/resources/wallet_transactions.yaml
@@ -23,6 +23,14 @@ get:
       schema:
         type: string
         example: 'pending'
+    - name: transaction_status
+      in: query
+      description: The transaction status of the wallet transaction. Possible values are `paid` (with pending or settled status), `offered` (settled status but null invoice_id) or `voided` (with outbound transaction type).
+      required: false
+      explode: true
+      schema:
+        type: string
+        example: 'paid'
     - name: transaction_type
       in: query
       description: The transaction type of the wallet transaction. Possible values are `inbound` (increasing the wallet balance) or `outbound` (decreasing the wallet balance).

--- a/src/schemas/WalletTransactionObject.yaml
+++ b/src/schemas/WalletTransactionObject.yaml
@@ -3,6 +3,7 @@ required:
   - lago_id
   - lago_wallet_id
   - status
+  - transaction_status
   - transaction_type
   - credit_amount
   - amount
@@ -25,6 +26,14 @@ properties:
       - settled
     description: The status of the wallet transaction. Possible values are `pending` or `settled`.
     example: settled
+  transaction_status:
+    type: string
+    enum:
+      - paid
+      - offered
+      - voided
+    description: The transaction status of the wallet transaction. Possible values are `paid` (with pending or settled status), `offered` (settled status but null invoice_id) or `voided` (with outbound transaction type).
+    example: paid
   transaction_type:
     type: string
     enum:


### PR DESCRIPTION
## Context

We want to differentiate a free wallet transaction vs. a paid wallet transaction.
And be able to void some wallet transactions.

## Description

This PR aims to add the `transaction_status` field for Wallet.