### PR TITLE
feat(wallet): Add voided_credits to WalletTransaction

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -8500,13 +8500,18 @@ components:
             paid_credits:
               type: string
               pattern: '^[0-9]+.?[0-9]*$'
-              description: The number of paid credits. Required only if there is no granted credits.
+              description: The number of paid credits.
               example: '20.0'
             granted_credits:
               type: string
               pattern: '^[0-9]+.?[0-9]*$'
-              description: The number of free granted credits. Required only if there is no paid credits.
+              description: The number of free granted credits.
               example: '10.0'
+            voided_credits:
+              type: string
+              pattern: '^[0-9]+.?[0-9]*$'
+              description: The number of voided credits.
+              example: '5.0'
     WalletTransactionObject:
       type: object
       required:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2395,7 +2395,7 @@ paths:
             example: pending
         - name: transaction_status
           in: query
-          description: 'The transaction status of the wallet transaction. Possible values are `purchased` (with pending or settled status), `granted` (without invoice_id) or `voided` (with outbound transaction type).'
+          description: 'The transaction status of the wallet transaction. Possible values are `purchased` (with pending or settled status), `granted` (without invoice_id), `voided` or `invoiced`.'
           required: false
           explode: true
           schema:
@@ -8547,7 +8547,8 @@ components:
             - purchased
             - granted
             - voided
-          description: 'The transaction status of the wallet transaction. Possible values are `purchased` (with pending or settled status), `granted` (without invoice_id) or `voided` (with outbound transaction type).'
+            - invoiced
+          description: 'The transaction status of the wallet transaction. Possible values are `purchased` (with pending or settled status), `granted` (without invoice_id), `voided` or `invoiced`.'
           example: purchased
         transaction_type:
           type: string

--- a/src/resources/wallet_transactions.yaml
+++ b/src/resources/wallet_transactions.yaml
@@ -25,7 +25,7 @@ get:
         example: 'pending'
     - name: transaction_status
       in: query
-      description: The transaction status of the wallet transaction. Possible values are `purchased` (with pending or settled status), `granted` (without invoice_id) or `voided` (with outbound transaction type).
+      description: The transaction status of the wallet transaction. Possible values are `purchased` (with pending or settled status), `granted` (without invoice_id), `voided` or `invoiced`.
       required: false
       explode: true
       schema:

--- a/src/schemas/WalletTransactionCreateInput.yaml
+++ b/src/schemas/WalletTransactionCreateInput.yaml
@@ -15,10 +15,15 @@ properties:
       paid_credits:
         type: string
         pattern: '^[0-9]+.?[0-9]*$'
-        description: The number of paid credits. Required only if there is no granted credits.
+        description: The number of paid credits.
         example: '20.0'
       granted_credits:
         type: string
         pattern: '^[0-9]+.?[0-9]*$'
-        description: The number of free granted credits. Required only if there is no paid credits.
+        description: The number of free granted credits.
         example: '10.0'
+      voided_credits:
+        type: string
+        pattern: '^[0-9]+.?[0-9]*$'
+        description: The number of voided credits.
+        example: '5.0'

--- a/src/schemas/WalletTransactionObject.yaml
+++ b/src/schemas/WalletTransactionObject.yaml
@@ -32,7 +32,8 @@ properties:
       - purchased
       - granted
       - voided
-    description: The transaction status of the wallet transaction. Possible values are `purchased` (with pending or settled status), `granted` (without invoice_id) or `voided` (with outbound transaction type).
+      - invoiced
+    description: The transaction status of the wallet transaction. Possible values are `purchased` (with pending or settled status), `granted` (without invoice_id), `voided` or `invoiced`.
     example: purchased
   transaction_type:
     type: string


### PR DESCRIPTION
## Context

We want to differentiate a free wallet transaction vs. a paid wallet transaction.
And be able to void some wallet transactions.

## Description

This PR aims to create a voided wallet transaction.