### PR TITLE
feat(wallet): Rename wallet rule_type into trigger

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -8280,14 +8280,14 @@ components:
                 type: object
                 description: Object that represents rule for wallet recurring transactions.
                 required:
-                  - rule_type
+                  - trigger
                 properties:
-                  rule_type:
+                  trigger:
                     type: string
                     enum:
                       - interval
                       - threshold
-                    description: The rule type. Possible values are `interval` or `threshold`.
+                    description: The trigger. Possible values are `interval` or `threshold`.
                     example: interval
                   interval:
                     type: string
@@ -8296,12 +8296,12 @@ components:
                       - monthly
                       - quarterly
                       - yearly
-                    description: 'The interval used for recurring top-up. It represents the frequency at which automatic top-up occurs. The interval can be one of the following values: `weekly`, `monthly`, `quarterly` or `yearly`. Required only when rule type is `interval`.'
+                    description: 'The interval used for recurring top-up. It represents the frequency at which automatic top-up occurs. The interval can be one of the following values: `weekly`, `monthly`, `quarterly` or `yearly`. Required only when trigger is `interval`.'
                     example: monthly
                   threshold_credits:
                     type: string
                     pattern: '^[0-9]+.?[0-9]*$'
-                    description: 'The threshold for recurring top-ups is the value at which an automatic top-up is triggered. For example, if this threshold is set at 10 credits, an automatic top-up will occur whenever the wallet balance falls to or below 10 credits. Required only when rule type is set to `threshold`.'
+                    description: 'The threshold for recurring top-ups is the value at which an automatic top-up is triggered. For example, if this threshold is set at 10 credits, an automatic top-up will occur whenever the wallet balance falls to or below 10 credits. Required only when trigger is set to `threshold`.'
                     example: '20.0'
     WalletObject:
       type: object
@@ -8408,7 +8408,7 @@ components:
             description: Object that represents rule for wallet recurring transactions.
             required:
               - lago_id
-              - rule_type
+              - trigger
               - paid_credits
               - granted_credits
               - created_at
@@ -8418,12 +8418,12 @@ components:
                 format: uuid
                 example: 1a901a90-1a90-1a90-1a90-1a901a901a90
                 description: A unique identifier for the recurring transaction rule in the Lago application. Can be used to update a recurring transaction rule.
-              rule_type:
+              trigger:
                 type: string
                 enum:
                   - interval
                   - threshold
-                description: The rule type. Possible values are `interval` or `threshold`.
+                description: The trigger. Possible values are `interval` or `threshold`.
                 example: interval
               interval:
                 type: string
@@ -8432,12 +8432,12 @@ components:
                   - monthly
                   - quarterly
                   - yearly
-                description: 'The interval used for recurring top-up. It represents the frequency at which automatic top-up occurs. The interval can be one of the following values: `weekly`, `monthly`, `quarterly` or `yearly`. Required only if rule type is set to `interval`.'
+                description: 'The interval used for recurring top-up. It represents the frequency at which automatic top-up occurs. The interval can be one of the following values: `weekly`, `monthly`, `quarterly` or `yearly`. Required only if trigger is set to `interval`.'
                 example: monthly
               threshold_credits:
                 type: string
                 pattern: '^[0-9]+.?[0-9]*$'
-                description: 'The threshold for recurring top-ups is the value at which an automatic top-up is triggered. For example, if this threshold is set at 10 credits, an automatic top-up will occur whenever the wallet balance falls to or below 10 credits. Required only when rule type is set to `threshold`.'
+                description: 'The threshold for recurring top-ups is the value at which an automatic top-up is triggered. For example, if this threshold is set at 10 credits, an automatic top-up will occur whenever the wallet balance falls to or below 10 credits. Required only when trigger is set to `threshold`.'
                 example: '20.0'
               paid_credits:
                 type: string
@@ -8620,7 +8620,7 @@ components:
               type: array
               description: 'List of recurring transaction rules. Currently, we only allow one recurring rule per wallet.'
               required:
-                - rule_type
+                - trigger
                 - paid_credits
                 - granted_credits
               items:
@@ -8632,12 +8632,12 @@ components:
                     format: uuid
                     example: 1a901a90-1a90-1a90-1a90-1a901a901a90
                     description: A unique identifier for the recurring transaction rule in the Lago application. Can be used to update a recurring transaction rule.
-                  rule_type:
+                  trigger:
                     type: string
                     enum:
                       - interval
                       - threshold
-                    description: The rule type. Possible values are `interval` or `threshold`.
+                    description: The trigger. Possible values are `interval` or `threshold`.
                     example: interval
                   interval:
                     type: string
@@ -8646,12 +8646,12 @@ components:
                       - monthly
                       - quarterly
                       - yearly
-                    description: 'The interval used for recurring top-up. It represents the frequency at which automatic top-up occurs. The interval can be one of the following values: `weekly`, `monthly`, `quarterly` or `yearly`. Required only when rule type is set to `interval`.'
+                    description: 'The interval used for recurring top-up. It represents the frequency at which automatic top-up occurs. The interval can be one of the following values: `weekly`, `monthly`, `quarterly` or `yearly`. Required only when trigger is set to `interval`.'
                     example: monthly
                   threshold_credits:
                     type: string
                     pattern: '^[0-9]+.?[0-9]*$'
-                    description: 'The threshold for recurring top-ups is the value at which an automatic top-up is triggered. For example, if this threshold is set at 10 credits, an automatic top-up will occur whenever the wallet balance falls to or below 10 credits. Required only when rule type is set to `threshold`.'
+                    description: 'The threshold for recurring top-ups is the value at which an automatic top-up is triggered. For example, if this threshold is set at 10 credits, an automatic top-up will occur whenever the wallet balance falls to or below 10 credits. Required only when trigger is set to `threshold`.'
                     example: '20.0'
                   paid_credits:
                     type: string

--- a/src/schemas/WalletCreateInput.yaml
+++ b/src/schemas/WalletCreateInput.yaml
@@ -50,14 +50,14 @@ properties:
           type: object
           description: Object that represents rule for wallet recurring transactions.
           required:
-            - rule_type
+            - trigger
           properties:
-            rule_type:
+            trigger:
               type: string
               enum:
                 - interval
                 - threshold
-              description: The rule type. Possible values are `interval` or `threshold`.
+              description: The trigger. Possible values are `interval` or `threshold`.
               example: 'interval'
             interval:
               type: string
@@ -66,10 +66,10 @@ properties:
                 - monthly
                 - quarterly
                 - yearly
-              description: "The interval used for recurring top-up. It represents the frequency at which automatic top-up occurs. The interval can be one of the following values: `weekly`, `monthly`, `quarterly` or `yearly`. Required only when rule type is `interval`."
+              description: "The interval used for recurring top-up. It represents the frequency at which automatic top-up occurs. The interval can be one of the following values: `weekly`, `monthly`, `quarterly` or `yearly`. Required only when trigger is `interval`."
               example: 'monthly'
             threshold_credits:
               type: string
               pattern: '^[0-9]+.?[0-9]*$'
-              description: The threshold for recurring top-ups is the value at which an automatic top-up is triggered. For example, if this threshold is set at 10 credits, an automatic top-up will occur whenever the wallet balance falls to or below 10 credits. Required only when rule type is set to `threshold`.
+              description: The threshold for recurring top-ups is the value at which an automatic top-up is triggered. For example, if this threshold is set at 10 credits, an automatic top-up will occur whenever the wallet balance falls to or below 10 credits. Required only when trigger is set to `threshold`.
               example: '20.0'

--- a/src/schemas/WalletRecurringTransactionRule.yaml
+++ b/src/schemas/WalletRecurringTransactionRule.yaml
@@ -2,7 +2,7 @@ type: object
 description: Object that represents rule for wallet recurring transactions.
 required:
   - lago_id
-  - rule_type
+  - trigger
   - paid_credits
   - granted_credits
   - created_at
@@ -12,12 +12,12 @@ properties:
     format: 'uuid'
     example: '1a901a90-1a90-1a90-1a90-1a901a901a90'
     description: 'A unique identifier for the recurring transaction rule in the Lago application. Can be used to update a recurring transaction rule.'
-  rule_type:
+  trigger:
     type: string
     enum:
       - interval
       - threshold
-    description: The rule type. Possible values are `interval` or `threshold`.
+    description: The trigger. Possible values are `interval` or `threshold`.
     example: 'interval'
   interval:
     type: string
@@ -26,12 +26,12 @@ properties:
       - monthly
       - quarterly
       - yearly
-    description: "The interval used for recurring top-up. It represents the frequency at which automatic top-up occurs. The interval can be one of the following values: `weekly`, `monthly`, `quarterly` or `yearly`. Required only if rule type is set to `interval`."
+    description: "The interval used for recurring top-up. It represents the frequency at which automatic top-up occurs. The interval can be one of the following values: `weekly`, `monthly`, `quarterly` or `yearly`. Required only if trigger is set to `interval`."
     example: 'monthly'
   threshold_credits:
     type: string
     pattern: '^[0-9]+.?[0-9]*$'
-    description: The threshold for recurring top-ups is the value at which an automatic top-up is triggered. For example, if this threshold is set at 10 credits, an automatic top-up will occur whenever the wallet balance falls to or below 10 credits. Required only when rule type is set to `threshold`.
+    description: The threshold for recurring top-ups is the value at which an automatic top-up is triggered. For example, if this threshold is set at 10 credits, an automatic top-up will occur whenever the wallet balance falls to or below 10 credits. Required only when trigger is set to `threshold`.
     example: '20.0'
   paid_credits:
     type: string

--- a/src/schemas/WalletUpdateInput.yaml
+++ b/src/schemas/WalletUpdateInput.yaml
@@ -20,7 +20,7 @@ properties:
         type: array
         description: List of recurring transaction rules. Currently, we only allow one recurring rule per wallet.
         required:
-          - rule_type
+          - trigger
           - paid_credits
           - granted_credits
         items:
@@ -32,12 +32,12 @@ properties:
               format: 'uuid'
               example: '1a901a90-1a90-1a90-1a90-1a901a901a90'
               description: 'A unique identifier for the recurring transaction rule in the Lago application. Can be used to update a recurring transaction rule.'
-            rule_type:
+            trigger:
               type: string
               enum:
                 - interval
                 - threshold
-              description: The rule type. Possible values are `interval` or `threshold`.
+              description: The trigger. Possible values are `interval` or `threshold`.
               example: 'interval'
             interval:
               type: string
@@ -46,12 +46,12 @@ properties:
                 - monthly
                 - quarterly
                 - yearly
-              description: "The interval used for recurring top-up. It represents the frequency at which automatic top-up occurs. The interval can be one of the following values: `weekly`, `monthly`, `quarterly` or `yearly`. Required only when rule type is set to `interval`."
+              description: "The interval used for recurring top-up. It represents the frequency at which automatic top-up occurs. The interval can be one of the following values: `weekly`, `monthly`, `quarterly` or `yearly`. Required only when trigger is set to `interval`."
               example: 'monthly'
             threshold_credits:
               type: string
               pattern: '^[0-9]+.?[0-9]*$'
-              description: The threshold for recurring top-ups is the value at which an automatic top-up is triggered. For example, if this threshold is set at 10 credits, an automatic top-up will occur whenever the wallet balance falls to or below 10 credits. Required only when rule type is set to `threshold`.
+              description: The threshold for recurring top-ups is the value at which an automatic top-up is triggered. For example, if this threshold is set at 10 credits, an automatic top-up will occur whenever the wallet balance falls to or below 10 credits. Required only when trigger is set to `threshold`.
               example: '20.0'
             paid_credits:
               type: string


### PR DESCRIPTION
## Context

After the release of real-time wallet version 1, some customers have expressed concerns about odd or missing behaviors.

## Description

The goal of this PR is to rename `Wallet#rule_type` into `Wallet#trigger`.