### PR TITLE
feat(wallet): Add fields to recurring_transaction_rule

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -8317,6 +8317,11 @@ components:
                       - yearly
                     description: 'The interval used for recurring top-up. It represents the frequency at which automatic top-up occurs. The interval can be one of the following values: `weekly`, `monthly`, `quarterly` or `yearly`. Required only when trigger is `interval`.'
                     example: monthly
+                  started_at:
+                    type: string
+                    format: date-time
+                    example: '2022-08-08T00:00:00Z'
+                    description: The effective start date for recurring top-ups. This date should be provided in ISO 8601 datetime format and expressed in Coordinated Universal Time (UTC).
                   threshold_credits:
                     type: string
                     pattern: '^[0-9]+.?[0-9]*$'
@@ -8484,6 +8489,11 @@ components:
                 pattern: '^[0-9]+.?[0-9]*$'
                 description: The number of free granted credits. Required only if there is no paid credits.
                 example: '10.0'
+              started_at:
+                type: string
+                format: date-time
+                example: '2022-08-08T00:00:00Z'
+                description: The effective start date for recurring top-ups. This date should be provided in ISO 8601 datetime format and expressed in Coordinated Universal Time (UTC).
               target_ongoing_balance:
                 type: string
                 pattern: '^[0-9]+.?[0-9]*$'
@@ -8710,6 +8720,11 @@ components:
                     pattern: '^[0-9]+.?[0-9]*$'
                     description: The number of free granted credits. Required only if there is no paid credits.
                     example: '10.0'
+                  started_at:
+                    type: string
+                    format: date-time
+                    example: '2022-08-08T00:00:00Z'
+                    description: The effective start date for recurring top-ups. This date should be provided in ISO 8601 datetime format and expressed in Coordinated Universal Time (UTC).
                   target_ongoing_balance:
                     type: string
                     pattern: '^[0-9]+.?[0-9]*$'

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -8322,6 +8322,11 @@ components:
                     pattern: '^[0-9]+.?[0-9]*$'
                     description: 'The threshold for recurring top-ups is the value at which an automatic top-up is triggered. For example, if this threshold is set at 10 credits, an automatic top-up will occur whenever the wallet balance falls to or below 10 credits. Required only when trigger is set to `threshold`.'
                     example: '20.0'
+                  target_ongoing_balance:
+                    type: string
+                    pattern: '^[0-9]+.?[0-9]*$'
+                    description: The target ongoing balance is the value set for the ongoing balance to be reached by the automatic top-up. Required only when trigger is set to `target`.
+                    example: '200.0'
     WalletObject:
       type: object
       required:
@@ -8427,10 +8432,13 @@ components:
             description: Object that represents rule for wallet recurring transactions.
             required:
               - lago_id
+              - interval
               - trigger
               - method
               - paid_credits
               - granted_credits
+              - threshold_credits
+              - target_ongoing_balance
               - created_at
             properties:
               lago_id:
@@ -8476,6 +8484,11 @@ components:
                 pattern: '^[0-9]+.?[0-9]*$'
                 description: The number of free granted credits. Required only if there is no paid credits.
                 example: '10.0'
+              target_ongoing_balance:
+                type: string
+                pattern: '^[0-9]+.?[0-9]*$'
+                description: The target ongoing balance is the value set for the ongoing balance to be reached by the automatic top-up. Required only when trigger is set to `target`.
+                example: '200.0'
               created_at:
                 type: string
                 format: date-time
@@ -8697,6 +8710,11 @@ components:
                     pattern: '^[0-9]+.?[0-9]*$'
                     description: The number of free granted credits. Required only if there is no paid credits.
                     example: '10.0'
+                  target_ongoing_balance:
+                    type: string
+                    pattern: '^[0-9]+.?[0-9]*$'
+                    description: The target ongoing balance is the value set for the ongoing balance to be reached by the automatic top-up. Required only when trigger is set to `target`.
+                    example: '200.0'
     WebhookEndpoint:
       type: object
       required:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -8282,6 +8282,18 @@ components:
                 required:
                   - trigger
                 properties:
+                  paid_credits:
+                    type: string
+                    pattern: '^[0-9]+.?[0-9]*$'
+                    nullable: true
+                    description: The number of paid credits used for recurring top-up.
+                    example: '20.0'
+                  granted_credits:
+                    type: string
+                    pattern: '^[0-9]+.?[0-9]*$'
+                    nullable: true
+                    description: The number of free granted credits used for recurring top-up.
+                    example: '10.0'
                   trigger:
                     type: string
                     enum:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -8294,6 +8294,13 @@ components:
                     nullable: true
                     description: The number of free granted credits used for recurring top-up.
                     example: '10.0'
+                  method:
+                    type: string
+                    enum:
+                      - fixed
+                      - target
+                    description: The method used for recurring top-up. Possible values are `fixed` or `target`.
+                    example: target
                   trigger:
                     type: string
                     enum:
@@ -8421,6 +8428,7 @@ components:
             required:
               - lago_id
               - trigger
+              - method
               - paid_credits
               - granted_credits
               - created_at
@@ -8437,6 +8445,13 @@ components:
                   - threshold
                 description: The trigger. Possible values are `interval` or `threshold`.
                 example: interval
+              method:
+                type: string
+                enum:
+                  - fixed
+                  - target
+                description: The method used for recurring top-up. Possible values are `fixed` or `target`.
+                example: target
               interval:
                 type: string
                 enum:
@@ -8651,6 +8666,13 @@ components:
                       - threshold
                     description: The trigger. Possible values are `interval` or `threshold`.
                     example: interval
+                  method:
+                    type: string
+                    enum:
+                      - fixed
+                      - target
+                    description: The method used for recurring top-up. Possible values are `fixed` or `target`.
+                    example: target
                   interval:
                     type: string
                     enum:

--- a/src/schemas/WalletCreateInput.yaml
+++ b/src/schemas/WalletCreateInput.yaml
@@ -92,3 +92,8 @@ properties:
               pattern: '^[0-9]+.?[0-9]*$'
               description: The threshold for recurring top-ups is the value at which an automatic top-up is triggered. For example, if this threshold is set at 10 credits, an automatic top-up will occur whenever the wallet balance falls to or below 10 credits. Required only when trigger is set to `threshold`.
               example: '20.0'
+            target_ongoing_balance:
+              type: string
+              pattern: '^[0-9]+.?[0-9]*$'
+              description: The target ongoing balance is the value set for the ongoing balance to be reached by the automatic top-up. Required only when trigger is set to `target`.
+              example: '200.0'

--- a/src/schemas/WalletCreateInput.yaml
+++ b/src/schemas/WalletCreateInput.yaml
@@ -64,6 +64,13 @@ properties:
               nullable: true
               description: The number of free granted credits used for recurring top-up.
               example: '10.0'
+            method:
+              type: string
+              enum:
+                - fixed
+                - target
+              description: The method used for recurring top-up. Possible values are `fixed` or `target`.
+              example: 'target'
             trigger:
               type: string
               enum:

--- a/src/schemas/WalletCreateInput.yaml
+++ b/src/schemas/WalletCreateInput.yaml
@@ -87,6 +87,11 @@ properties:
                 - yearly
               description: "The interval used for recurring top-up. It represents the frequency at which automatic top-up occurs. The interval can be one of the following values: `weekly`, `monthly`, `quarterly` or `yearly`. Required only when trigger is `interval`."
               example: 'monthly'
+            started_at:
+              type: string
+              format: date-time
+              example: "2022-08-08T00:00:00Z"
+              description: The effective start date for recurring top-ups. This date should be provided in ISO 8601 datetime format and expressed in Coordinated Universal Time (UTC).
             threshold_credits:
               type: string
               pattern: '^[0-9]+.?[0-9]*$'

--- a/src/schemas/WalletCreateInput.yaml
+++ b/src/schemas/WalletCreateInput.yaml
@@ -52,6 +52,18 @@ properties:
           required:
             - trigger
           properties:
+            paid_credits:
+              type: string
+              pattern: '^[0-9]+.?[0-9]*$'
+              nullable: true
+              description: The number of paid credits used for recurring top-up.
+              example: '20.0'
+            granted_credits:
+              type: string
+              pattern: '^[0-9]+.?[0-9]*$'
+              nullable: true
+              description: The number of free granted credits used for recurring top-up.
+              example: '10.0'
             trigger:
               type: string
               enum:

--- a/src/schemas/WalletRecurringTransactionRule.yaml
+++ b/src/schemas/WalletRecurringTransactionRule.yaml
@@ -54,6 +54,11 @@ properties:
     pattern: '^[0-9]+.?[0-9]*$'
     description: The number of free granted credits. Required only if there is no paid credits.
     example: '10.0'
+  started_at:
+    type: string
+    format: date-time
+    example: "2022-08-08T00:00:00Z"
+    description: The effective start date for recurring top-ups. This date should be provided in ISO 8601 datetime format and expressed in Coordinated Universal Time (UTC).
   target_ongoing_balance:
     type: string
     pattern: '^[0-9]+.?[0-9]*$'

--- a/src/schemas/WalletRecurringTransactionRule.yaml
+++ b/src/schemas/WalletRecurringTransactionRule.yaml
@@ -2,10 +2,13 @@ type: object
 description: Object that represents rule for wallet recurring transactions.
 required:
   - lago_id
+  - interval
   - trigger
   - method
   - paid_credits
   - granted_credits
+  - threshold_credits
+  - target_ongoing_balance
   - created_at
 properties:
   lago_id:
@@ -51,6 +54,11 @@ properties:
     pattern: '^[0-9]+.?[0-9]*$'
     description: The number of free granted credits. Required only if there is no paid credits.
     example: '10.0'
+  target_ongoing_balance:
+    type: string
+    pattern: '^[0-9]+.?[0-9]*$'
+    description: The target ongoing balance is the value set for the ongoing balance to be reached by the automatic top-up. Required only when trigger is set to `target`.
+    example: '200.0'
   created_at:
     type: string
     format: 'date-time'

--- a/src/schemas/WalletRecurringTransactionRule.yaml
+++ b/src/schemas/WalletRecurringTransactionRule.yaml
@@ -3,6 +3,7 @@ description: Object that represents rule for wallet recurring transactions.
 required:
   - lago_id
   - trigger
+  - method
   - paid_credits
   - granted_credits
   - created_at
@@ -19,6 +20,13 @@ properties:
       - threshold
     description: The trigger. Possible values are `interval` or `threshold`.
     example: 'interval'
+  method:
+    type: string
+    enum:
+      - fixed
+      - target
+    description: The method used for recurring top-up. Possible values are `fixed` or `target`.
+    example: 'target'
   interval:
     type: string
     enum:

--- a/src/schemas/WalletUpdateInput.yaml
+++ b/src/schemas/WalletUpdateInput.yaml
@@ -70,6 +70,11 @@ properties:
               pattern: '^[0-9]+.?[0-9]*$'
               description: The number of free granted credits. Required only if there is no paid credits.
               example: '10.0'
+            started_at:
+              type: string
+              format: date-time
+              example: "2022-08-08T00:00:00Z"
+              description: The effective start date for recurring top-ups. This date should be provided in ISO 8601 datetime format and expressed in Coordinated Universal Time (UTC).
             target_ongoing_balance:
               type: string
               pattern: '^[0-9]+.?[0-9]*$'

--- a/src/schemas/WalletUpdateInput.yaml
+++ b/src/schemas/WalletUpdateInput.yaml
@@ -39,6 +39,13 @@ properties:
                 - threshold
               description: The trigger. Possible values are `interval` or `threshold`.
               example: 'interval'
+            method:
+              type: string
+              enum:
+                - fixed
+                - target
+              description: The method used for recurring top-up. Possible values are `fixed` or `target`.
+              example: 'target'
             interval:
               type: string
               enum:

--- a/src/schemas/WalletUpdateInput.yaml
+++ b/src/schemas/WalletUpdateInput.yaml
@@ -70,3 +70,8 @@ properties:
               pattern: '^[0-9]+.?[0-9]*$'
               description: The number of free granted credits. Required only if there is no paid credits.
               example: '10.0'
+            target_ongoing_balance:
+              type: string
+              pattern: '^[0-9]+.?[0-9]*$'
+              description: The target ongoing balance is the value set for the ongoing balance to be reached by the automatic top-up. Required only when trigger is set to `target`.
+              example: '200.0'


### PR DESCRIPTION
## Roadmap Task

👉 https://getlago.canny.io/feature-requests/p/define-a-target-balance-to-reach-for-recurring-top-up

## Context

We want to allow users to top-up their wallets to reach a specific target balance.

We can currently define a fixed top-up but we want to add the ability to specify a dynamic top-up (target balance to reach).

## Description

The goal of this PR is to add:

- `granted_credits`
- `paid_credits` 
- `method`
- `target_ongoing_balance`
- `started_at`

to `recurring_transaction_rule`