### PR TITLE
fix(invoice-params): use right quotation

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2572,7 +2572,7 @@ components:
     lago_invoice_id:
       name: lago_id
       in: path
-      description: Unique identifier assigned to the invoice within the Lago application. This ID is exclusively created by Lago and serves as a unique identifier for the invoice’s record within the Lago system.
+      description: Unique identifier assigned to the invoice within the Lago application. This ID is exclusively created by Lago and serves as a unique identifier for the invoice's record within the Lago system.
       required: true
       schema:
         type: string

--- a/src/parameters/lago_invoice_id.yaml
+++ b/src/parameters/lago_invoice_id.yaml
@@ -1,6 +1,6 @@
 name: lago_id
 in: path
-description: Unique identifier assigned to the invoice within the Lago application. This ID is exclusively created by Lago and serves as a unique identifier for the invoice’s record within the Lago system.
+description: Unique identifier assigned to the invoice within the Lago application. This ID is exclusively created by Lago and serves as a unique identifier for the invoice's record within the Lago system.
 required: true
 schema:
   type: string


### PR DESCRIPTION
# Description

Use right quotation in params section. Invalid quotation can lead to encoding issues in the browser