### PR TITLE
feat(dunning): Add payment_overdue to invoice

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -6487,6 +6487,10 @@ components:
           format: date
           description: 'The payment due date for the invoice, specified in the ISO 8601 date format.'
           example: '2022-04-30'
+        payment_overdue:
+          type: boolean
+          description: Specifies if the payment is considered as overdue.
+          example: true
         net_payment_term:
           type: integer
           example: 30

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1533,6 +1533,14 @@ paths:
               - pending
               - failed
               - succeeded
+        - name: payment_overdue
+          in: query
+          description: Filter invoices by payment_overdue. Possible values are `true` or `false`.
+          required: false
+          explode: true
+          schema:
+            type: boolean
+            example: true
       responses:
         '200':
           description: Invoices

--- a/src/resources/invoices.yaml
+++ b/src/resources/invoices.yaml
@@ -73,6 +73,14 @@ get:
           - pending
           - failed
           - succeeded
+    - name: payment_overdue
+      in: query
+      description: Filter invoices by payment_overdue. Possible values are `true` or `false`.
+      required: false
+      explode: true
+      schema:
+        type: boolean
+        example: true
   responses:
     '200':
       description: Invoices

--- a/src/schemas/InvoiceObject.yaml
+++ b/src/schemas/InvoiceObject.yaml
@@ -45,6 +45,10 @@ properties:
     format: 'date'
     description: The payment due date for the invoice, specified in the ISO 8601 date format.
     example: '2022-04-30'
+  payment_overdue:
+    type: boolean
+    description: Specifies if the payment is considered as overdue.
+    example: true
   net_payment_term:
     type: integer
     example: 30


### PR DESCRIPTION
## Roadmap Task

👉 https://getlago.canny.io/feature-requests/p/regroup-invoices-to-generate-one-payment-intent

## Context

We want to be able to group invoices to generate one payment.
Today we don't track payment terms and do not mention whether a payment or an invoice is overdue.

## Description

The goal of this PR is to add:

- `payment_overdue`

to `invoice`