### PR TITLE
fix: Improve event#properties definition

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -5581,7 +5581,10 @@ components:
               type: object
               description: 'This field represents additional properties associated with the event, which are utilized in the calculation of the final fee. This object becomes mandatory when the targeted billable metric employs a `sum_agg`, `max_agg`, or `unique_count_agg` aggregation method. However, when using a simple `count_agg`, this object is not required.'
               additionalProperties:
-                type: string
+                oneOf:
+                  - type: string
+                  - type: integer
+                  - type: number
               example:
                 gb: 10
     EventObject:
@@ -5640,7 +5643,10 @@ components:
                 - add
                 - remove
           additionalProperties:
-            type: string
+            oneOf:
+              - type: string
+              - type: integer
+              - type: number
           example:
             gb: 10
         lago_subscription_id:

--- a/src/schemas/EventInput.yaml
+++ b/src/schemas/EventInput.yaml
@@ -10,28 +10,28 @@ properties:
     properties:
       transaction_id:
         type: string
-        example: 'transaction_1234567890'
+        example: "transaction_1234567890"
         description: This field represents a unique identifier for the event. It is crucial for ensuring idempotency, meaning that each event can be uniquely identified and processed without causing any unintended side effects.
       external_customer_id:
         type: string
-        example: '5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba'
+        example: "5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba"
         description: |
           The customer external unique identifier (provided by your own application). This field is optional if you send the `external_subscription_id`, targeting a specific subscription.
           This field is deprecated and is no longer supported or maintained. Please use the `external_subscription_id` instead.
         deprecated: true
       external_subscription_id:
         type: string
-        example: 'sub_1234567890'
+        example: "sub_1234567890"
         description: The unique identifier of the subscription within your application. It is a mandatory field when the customer possesses multiple subscriptions or when the `external_customer_id` is not provided.
       code:
         type: string
-        example: 'storage'
+        example: "storage"
         description: The code that identifies a targeted billable metric. It is essential that this code matches the `code` property of one of your active billable metrics. If the provided code does not correspond to any active billable metric, it will be ignored during the process.
       timestamp:
         anyOf:
           - type: integer
           - type: string
-        example: '1651240791.123'
+        example: "1651240791.123"
         description: |
           This field captures the Unix timestamp in seconds indicating the occurrence of the event in Coordinated Universal Time (UTC).
           If this timestamp is not provided, the API will automatically set it to the time of event reception.
@@ -40,6 +40,9 @@ properties:
         type: object
         description: This field represents additional properties associated with the event, which are utilized in the calculation of the final fee. This object becomes mandatory when the targeted billable metric employs a `sum_agg`, `max_agg`, or `unique_count_agg` aggregation method. However, when using a simple `count_agg`, this object is not required.
         additionalProperties:
-          type: string
+          oneOf:
+            - type: string
+            - type: integer
+            - type: number
         example:
           gb: 10

--- a/src/schemas/EventObject.yaml
+++ b/src/schemas/EventObject.yaml
@@ -12,35 +12,35 @@ required:
 properties:
   lago_id:
     type: string
-    format: 'uuid'
-    example: '1a901a90-1a90-1a90-1a90-1a901a901a90'
+    format: "uuid"
+    example: "1a901a90-1a90-1a90-1a90-1a901a901a90"
     description: Unique identifier assigned to the event within the Lago application. This ID is exclusively created by Lago and serves as a unique identifier for the event's record within the Lago system
   transaction_id:
     type: string
-    example: 'transaction_1234567890'
+    example: "transaction_1234567890"
     description: This field represents a unique identifier for the event. It is crucial for ensuring idempotency, meaning that each event can be uniquely identified and processed without causing any unintended side effects.
   lago_customer_id:
     type: string
-    format: 'uuid'
+    format: "uuid"
     nullable: true
-    example: '1a901a90-1a90-1a90-1a90-1a901a901a90'
+    example: "1a901a90-1a90-1a90-1a90-1a901a901a90"
     description: Unique identifier assigned to the customer within the Lago application. This ID is exclusively created by Lago and serves as a unique identifier for the customer's record within the Lago system
   external_customer_id:
     type: string
     nullable: true
-    example: '5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba'
+    example: "5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba"
     description: |
       The customer external unique identifier (provided by your own application). This field is optional if you send the `external_subscription_id`, targeting a specific subscription.
       This field is deprecated and is no longer supported or maintained. Please use the `external_subscription_id` instead.
     deprecated: true
   code:
     type: string
-    example: 'storage'
+    example: "storage"
     description: The code that identifies a targeted billable metric. It is essential that this code matches the `code` property of one of your active billable metrics. If the provided code does not correspond to any active billable metric, it will be ignored during the process.
   timestamp:
     type: string
-    format: 'date-time'
-    example: '2022-04-29T08:59:51.123Z'
+    format: "date-time"
+    example: "2022-04-29T08:59:51.123Z"
     description: This field captures the Unix timestamp in seconds indicating the occurrence of the event in Coordinated Universal Time (UTC). If this timestamp is not provided, the API will automatically set it to the time of event reception.
   properties:
     type: object
@@ -53,22 +53,25 @@ properties:
           - add
           - remove
     additionalProperties:
-      type: string
+      oneOf:
+        - type: string
+        - type: integer
+        - type: number
     example:
       gb: 10
   lago_subscription_id:
     type: string
-    format: 'uuid'
+    format: "uuid"
     nullable: true
-    example: '1a901a90-1a90-1a90-1a90-1a901a901a90'
+    example: "1a901a90-1a90-1a90-1a90-1a901a901a90"
     description: Unique identifier assigned to the subscription within the Lago application. This ID is exclusively created by Lago and serves as a unique identifier for the subscription's record within the Lago system
   external_subscription_id:
     type: string
     nullable: true
-    example: 'sub_1234567890'
+    example: "sub_1234567890"
     description: The unique identifier of the subscription within your application. It is a mandatory field when the customer possesses multiple subscriptions or when the `external_customer_id` is not provided.
   created_at:
     type: string
-    format: 'date-time'
-    example: '2022-04-29T08:59:51Z'
+    format: "date-time"
+    example: "2022-04-29T08:59:51Z"
     description: The creation date of the event's record in the Lago application, presented in the ISO 8601 datetime format, specifically in Coordinated Universal Time (UTC). It provides the precise timestamp of when the event's record was created within the Lago application


### PR DESCRIPTION
fixes https://github.com/getlago/lago-javascript-client/issues/43

This PR improves the definition of `events#properties` payload for input and output to make clear that value types could be `string`, `integer` or `number`