### PR TITLE
Add missing value for aggregation_type in CustomerChargeUsageObject

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -5080,6 +5080,8 @@ components:
                 - sum_agg
                 - max_agg
                 - unique_count_agg
+                - weighted_sum_agg
+                - latest_agg
               example: sum_agg
         filters:
           $ref: '#/components/schemas/CustomerChargeFiltersUsageObject'

--- a/src/schemas/CustomerChargeUsageObject.yaml
+++ b/src/schemas/CustomerChargeUsageObject.yaml
@@ -82,6 +82,8 @@ properties:
           - sum_agg
           - max_agg
           - unique_count_agg
+          - weighted_sum_agg
+          - latest_agg
         example: sum_agg
   filters:
     $ref: "./CustomerChargeFiltersUsageObject.yaml"


### PR DESCRIPTION
The `weighted_sum_agg` and `latest_agg` were missing into the `CustomerChargeUsageObject`.

These missing values cause errors during the deserialization process.
