### PR TITLE
misc: Add EU cluster server in definition

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -11,7 +11,13 @@ externalDocs:
   description: Lago Github
   url: 'https://github.com/getlago'
 servers:
-  - url: 'https://api.getlago.com/api/v1'
+  - url: 'https://{region}.getlago.com/api/v1'
+    variables:
+      region:
+        default: api
+        enum:
+          - api
+          - api.eu
 security:
   - bearerAuth: []
 tags:

--- a/src/openapi.yaml
+++ b/src/openapi.yaml
@@ -12,7 +12,13 @@ externalDocs:
   description: Lago Github
   url: https://github.com/getlago
 servers:
-  - url: https://api.getlago.com/api/v1
+  - url: https://{region}.getlago.com/api/v1
+    variables:
+      region:
+        default: api
+        enum:
+          - api
+          - api.eu
 security:
   - bearerAuth: []
 tags:


### PR DESCRIPTION
This PR adds the `api.eu` subdoamin in the list of API server