### PR TITLE
feat(analytics): Add overdue balance endpoint

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -6298,6 +6298,9 @@ components:
       type: object
       required:
         - month
+        - amount_cents
+        - currency
+        - invoices_count
       properties:
         month:
           type: string
@@ -6500,7 +6503,6 @@ components:
       required:
         - month
         - invoices_count
-        - amount_cents
       properties:
         month:
           type: string

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -6312,6 +6312,10 @@ components:
             - $ref: '#/components/schemas/Currency'
             - description: The currency of revenue analytics. Format must be ISO 4217.
               example: USD
+        invoices_count:
+          type: integer
+          description: Contains invoices count.
+          example: 10
     GrossRevenues:
       type: object
       required:
@@ -7126,6 +7130,44 @@ components:
                   - credit_note.created
             billing_configuration:
               $ref: '#/components/schemas/OrganizationBillingConfiguration'
+    OverdueBalanceObject:
+      type: object
+      required:
+        - month
+        - amount_cents
+        - currency
+        - lago_invoice_ids
+      properties:
+        month:
+          type: string
+          description: Identifies the month to analyze revenue.
+          example: '2023-11-01T00:00:00.000Z'
+        amount_cents:
+          type: integer
+          description: 'The total amount of revenue for a period, expressed in cents.'
+          example: 50000
+        currency:
+          allOf:
+            - $ref: '#/components/schemas/Currency'
+            - description: The currency of revenue analytics. Format must be ISO 4217.
+              example: USD
+        lago_invoice_ids:
+          type: array
+          items:
+            type: string
+            format: uuid
+          description: The Lago invoice IDs associated with the revenue.
+          example:
+            - 5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba
+    OverdueBalances:
+      type: object
+      required:
+        - overdue_balances
+      properties:
+        overdue_balances:
+          type: array
+          items:
+            $ref: '#/components/schemas/OverdueBalanceObject'
     PaginationMeta:
       type: object
       required:

--- a/src/resources/overdue_balances.yaml
+++ b/src/resources/overdue_balances.yaml
@@ -1,0 +1,34 @@
+get:
+  tags:
+    - analytics
+  summary: List overdue balance
+  description: Overdue balance is the total amount associated with overdue invoices (invoices with pending or failed payments which are past their due dates).
+  operationId: findAllOverdueBalances
+  parameters:
+    - name: currency
+      in: query
+      description: Currency of revenue analytics. Format must be ISO 4217.
+      required: false
+      explode: true
+      schema:
+        allOf:
+          - $ref: '../schemas/Currency.yaml'
+          - example: 'USD'
+    - name: external_customer_id
+      in: query
+      description: The customer external unique identifier (provided by your own application). Use it to filter revenue analytics at the customer level.
+      required: false
+      explode: true
+      schema:
+        type: string
+        example: '5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba'
+    - $ref: '../parameters/months.yaml'
+  responses:
+    '200':
+      description: Overdue balance
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/OverdueBalances.yaml'
+    '401':
+      $ref: '../responses/Unauthorized.yaml'

--- a/src/schemas/GrossRevenueObject.yaml
+++ b/src/schemas/GrossRevenueObject.yaml
@@ -1,6 +1,9 @@
 type: object
 required:
   - month
+  - amount_cents
+  - currency
+  - invoices_count
 properties:
   month:
     type: string

--- a/src/schemas/InvoiceCollectionObject.yaml
+++ b/src/schemas/InvoiceCollectionObject.yaml
@@ -2,7 +2,6 @@ type: object
 required:
   - month
   - invoices_count
-  - amount_cents
 properties:
   month:
     type: string

--- a/src/schemas/OverdueBalanceObject.yaml
+++ b/src/schemas/OverdueBalanceObject.yaml
@@ -1,6 +1,9 @@
 type: object
 required:
   - month
+  - amount_cents
+  - currency
+  - lago_invoice_ids
 properties:
   month:
     type: string
@@ -15,7 +18,10 @@ properties:
       - $ref: './Currency.yaml'
       - description: The currency of revenue analytics. Format must be ISO 4217.
         example: 'USD'
-  invoices_count:
-    type: integer
-    description: Contains invoices count.
-    example: 10
+  lago_invoice_ids:
+    type: array
+    items:
+      type: string
+      format: uuid
+    description: The Lago invoice IDs associated with the revenue.
+    example: ['5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba']

--- a/src/schemas/OverdueBalances.yaml
+++ b/src/schemas/OverdueBalances.yaml
@@ -1,0 +1,8 @@
+type: object
+required:
+  - overdue_balances
+properties:
+  overdue_balances:
+    type: array
+    items:
+      $ref: './OverdueBalanceObject.yaml'

--- a/src/schemas/_index.yaml
+++ b/src/schemas/_index.yaml
@@ -200,6 +200,10 @@ OrganizationObject:
   $ref: "./OrganizationObject.yaml"
 OrganizationUpdateInput:
   $ref: "./OrganizationUpdateInput.yaml"
+OverdueBalanceObject:
+  $ref: "./OverdueBalanceObject.yaml"
+OverdueBalances:
+  $ref: "./OverdueBalances.yaml"
 PaginationMeta:
   $ref: "./PaginationMeta.yaml"
 Plan:


### PR DESCRIPTION
## Roadmap Task

👉 https://getlago.canny.io/feature-requests/p/regroup-invoices-to-generate-one-payment-intent

## Context

We want to be able to group invoices to generate one payment.
Today we don't track payment terms and do not mention whether a payment or an invoice is overdue.

## Description

The goal of this PR is to add an analytics endpoint for fetching overdue balances per month and per currency at the customer or organization level.
