### PR TITLE
Remove `allOf` to reference EventInput in /event endpoint

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -5570,42 +5570,7 @@ components:
         events:
           type: array
           items:
-            type: object
-            required:
-              - transaction_id
-              - code
-            properties:
-              transaction_id:
-                type: string
-                example: transaction_1234567890
-                description: 'This field represents a unique identifier for the event. It is crucial for ensuring idempotency, meaning that each event can be uniquely identified and processed without causing any unintended side effects.'
-              external_subscription_id:
-                type: string
-                example: sub_1234567890
-                description: The unique identifier of the subscription within your application. It is a mandatory field when the customer possesses multiple subscriptions or when the `external_customer_id` is not provided.
-              code:
-                type: string
-                example: storage
-                description: 'The code that identifies a targeted billable metric. It is essential that this code matches the `code` property of one of your active billable metrics. If the provided code does not correspond to any active billable metric, it will be ignored during the process.'
-              timestamp:
-                anyOf:
-                  - type: integer
-                  - type: string
-                example: '1651240791.123'
-                description: |
-                  This field captures the Unix timestamp in seconds indicating the occurrence of the event in Coordinated Universal Time (UTC).
-                  If this timestamp is not provided, the API will automatically set it to the time of event reception.
-                  You can also provide miliseconds precision by appending decimals to the timestamp.
-              properties:
-                type: object
-                description: 'This field represents additional properties associated with the event, which are utilized in the calculation of the final fee. This object becomes mandatory when the targeted billable metric employs a `sum_agg`, `max_agg`, or `unique_count_agg` aggregation method. However, when using a simple `count_agg`, this object is not required.'
-                additionalProperties:
-                  oneOf:
-                    - type: string
-                    - type: integer
-                    - type: number
-                example:
-                  gb: 10
+            $ref: '#/components/schemas/EventInput/properties/event'
     EventEstimateFeesInput:
       type: object
       required:
@@ -5634,8 +5599,42 @@ components:
         - event
       properties:
         event:
-          allOf:
-            - $ref: '#/components/schemas/EventBatchInput/properties/events/items'
+          type: object
+          required:
+            - transaction_id
+            - code
+          properties:
+            transaction_id:
+              type: string
+              example: transaction_1234567890
+              description: 'This field represents a unique identifier for the event. It is crucial for ensuring idempotency, meaning that each event can be uniquely identified and processed without causing any unintended side effects.'
+            external_subscription_id:
+              type: string
+              example: sub_1234567890
+              description: The unique identifier of the subscription within your application. It is a mandatory field when the customer possesses multiple subscriptions or when the `external_customer_id` is not provided.
+            code:
+              type: string
+              example: storage
+              description: 'The code that identifies a targeted billable metric. It is essential that this code matches the `code` property of one of your active billable metrics. If the provided code does not correspond to any active billable metric, it will be ignored during the process.'
+            timestamp:
+              anyOf:
+                - type: integer
+                - type: string
+              example: '1651240791.123'
+              description: |
+                This field captures the Unix timestamp in seconds indicating the occurrence of the event in Coordinated Universal Time (UTC).
+                If this timestamp is not provided, the API will automatically set it to the time of event reception.
+                You can also provide miliseconds precision by appending decimals to the timestamp.
+            properties:
+              type: object
+              description: 'This field represents additional properties associated with the event, which are utilized in the calculation of the final fee. This object becomes mandatory when the targeted billable metric employs a `sum_agg`, `max_agg`, or `unique_count_agg` aggregation method. However, when using a simple `count_agg`, this object is not required.'
+              additionalProperties:
+                oneOf:
+                  - type: string
+                  - type: integer
+                  - type: number
+              example:
+                gb: 10
     EventObject:
       type: object
       required:

--- a/src/schemas/EventInput.yaml
+++ b/src/schemas/EventInput.yaml
@@ -3,5 +3,4 @@ required:
   - event
 properties:
   event:
-    allOf:
-    - $ref: './EventInputObject.yaml'
+    $ref: './EventInputObject.yaml'


### PR DESCRIPTION
Following https://github.com/getlago/lago-openapi/pull/249 I'm removing the `allOf` to refer to the EventInputObject schema in EventInput.

Today, the batch `EventBatchInput` has the complete definition of an event, while the `EventInput` references `#/components/schemas/EventBatchInput/properties/events/items`.

This PR changes so `EventInput` has the definition of an event and `EventBatchInput` references it.

_"What's the difference"_ you're asking. I dunno but I'm hoping it's going to make a difference for [openapi-generator](https://github.com/OpenAPITools/openapi-generator) when generating client. Also, it feels a little better.

Note: make sure you expend the diff of `openapi.yaml`