### PR TITLE
Add precise amounts to fee object

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -5838,6 +5838,14 @@ components:
           type: integer
           description: 'The cost of this specific fee, excluding any applicable taxes.'
           example: 100
+        precise_amount:
+          type: string
+          description: 'The cost of this specific fee, excluding any applicable taxes, with precision.'
+          example: '1.0001'
+        precise_total_amount:
+          type: string
+          description: 'The cost of this specific fee, including any applicable taxes, with precision.'
+          example: '1.0212'
         amount_currency:
           allOf:
             - $ref: '#/components/schemas/Currency'
@@ -5847,6 +5855,10 @@ components:
           type: integer
           description: The cost of the tax associated with this specific fee.
           example: 20
+        taxes_precise_amount:
+          type: string
+          description: 'The cost of the tax associated with this specific fee, with precision.'
+          example: '0.20123'
         taxes_rate:
           type: number
           description: The tax rate associated with this specific fee.

--- a/src/schemas/FeeObject.yaml
+++ b/src/schemas/FeeObject.yaml
@@ -73,6 +73,14 @@ properties:
     type: integer
     description: The cost of this specific fee, excluding any applicable taxes.
     example: 100
+  precise_amount:
+    type: string
+    description: The cost of this specific fee, excluding any applicable taxes, with precision.
+    example: "1.0001"
+  precise_total_amount:
+    type: string
+    description: The cost of this specific fee, including any applicable taxes, with precision.
+    example: "1.0212"
   amount_currency:
     allOf:
       - $ref: "./Currency.yaml"
@@ -82,6 +90,10 @@ properties:
     type: integer
     description: The cost of the tax associated with this specific fee.
     example: 20
+  taxes_precise_amount:
+    type: string
+    description: The cost of the tax associated with this specific fee, with precision.
+    example: "0.20123"
   taxes_rate:
     type: number
     description: The tax rate associated with this specific fee.


### PR DESCRIPTION
## Context

For some customers some amounts are not enough precise as Lago convert fees to `amount_cent`.

## Description

Add precise amounts to fee object.