### PR TITLE
feat(customer-type): Add customer type, firstname and lastname to customer

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -5361,6 +5361,26 @@ components:
               example: Gavin Belson
               description: The full name of the customer
               nullable: true
+            firstname:
+              type: string
+              example: Gavin
+              description: First name of the customer
+              nullable: true
+            lastname:
+              type: string
+              example: Belson
+              description: Last name of the customer
+              nullable: true
+            customer_type:
+              type: string
+              enum:
+                - company
+                - individual
+              nullable: true
+              description: |-
+                The type of the customer. It can have one of the following values:
+                - `company`: the customer is a company.
+                - `individual`: the customer is an individual.
             phone:
               type: string
               example: 1-171-883-3711 x245
@@ -5599,6 +5619,26 @@ components:
               example: Gavin Belson
               description: The full name of the customer
               nullable: true
+            firstname:
+              type: string
+              example: Gavin
+              description: First name of the customer
+              nullable: true
+            lastname:
+              type: string
+              example: Belson
+              description: Last name of the customer
+              nullable: true
+            customer_type:
+              type: string
+              enum:
+                - company
+                - individual
+              nullable: true
+              description: |-
+                The type of the customer. It can have one of the following values:
+                - `company`: the customer is a company.
+                - `individual`: the customer is an individual.
             phone:
               type: string
               example: 1-171-883-3711 x245

--- a/src/schemas/CustomerBaseObject.yaml
+++ b/src/schemas/CustomerBaseObject.yaml
@@ -81,6 +81,26 @@ properties:
     example: 'Gavin Belson'
     description: 'The full name of the customer'
     nullable: true
+  firstname:
+    type: string
+    example: 'Gavin'
+    description: 'First name of the customer'
+    nullable: true
+  lastname:
+    type: string
+    example: 'Belson'
+    description: 'Last name of the customer'
+    nullable: true
+  customer_type:
+    type: string
+    enum:
+      - company
+      - individual
+    nullable: true
+    description: |-
+      The type of the customer. It can have one of the following values:
+      - `company`: the customer is a company.
+      - `individual`: the customer is an individual.
   phone:
     type: string
     example: '1-171-883-3711 x245'

--- a/src/schemas/CustomerCreateInput.yaml
+++ b/src/schemas/CustomerCreateInput.yaml
@@ -63,6 +63,26 @@ properties:
         example: 'Gavin Belson'
         description: 'The full name of the customer'
         nullable: true
+      firstname:
+        type: string
+        example: 'Gavin'
+        description: 'First name of the customer'
+        nullable: true
+      lastname:
+        type: string
+        example: 'Belson'
+        description: 'Last name of the customer'
+        nullable: true
+      customer_type:
+        type: string
+        enum:
+          - company
+          - individual
+        nullable: true
+        description: |-
+          The type of the customer. It can have one of the following values:
+          - `company`: the customer is a company.
+          - `individual`: the customer is an individual.
       phone:
         type: string
         example: '1-171-883-3711 x245'


### PR DESCRIPTION
## Context
We currently only create Lago customers as **companies**, but there is a need to support both **companies** and **individuals**. This change is motivated by scenarios where customers may be a mix of B2B and B2C, and where external integrations require handling both **Contacts** and **Companies**.

To address this, we are introducing a new field, `customer_type`, to distinguish whether a customer is a **company** or an **individual**. Existing customers will remain unaffected with `customer_type` set to the default `nil`. 

## Description
This PR adds `firstname`, `lastname` and `customer_type` to the customer object and create input.