### PR TITLE
feat(customer-portal): Remove premium restriction

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1021,8 +1021,6 @@ paths:
                         description: An embeddable link for displaying a customer portal
         '401':
           $ref: '#/components/responses/Unauthorized'
-        '403':
-          $ref: '#/components/responses/Forbidden'
         '404':
           $ref: '#/components/responses/NotFound'
   '/customers/{external_customer_id}/current_usage':

--- a/src/resources/customer_portal_url.yaml
+++ b/src/resources/customer_portal_url.yaml
@@ -13,10 +13,10 @@ get:
       required: true
       schema:
         type: string
-        example: '5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba'
+        example: "5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba"
   operationId: getCustomerPortalUrl
   responses:
-    '200':
+    "200":
       description: Portal URL
       content:
         application/json:
@@ -32,11 +32,9 @@ get:
                 properties:
                   portal_url:
                     type: string
-                    example: 'https://app.lago.com/customer-portal/1234567890'
+                    example: "https://app.lago.com/customer-portal/1234567890"
                     description: An embeddable link for displaying a customer portal
-    '401':
-      $ref: '../responses/Unauthorized.yaml'
-    '403':
-      $ref: '../responses/Forbidden.yaml'
-    '404':
-      $ref: '../responses/NotFound.yaml'
+    "401":
+      $ref: "../responses/Unauthorized.yaml"
+    "404":
+      $ref: "../responses/NotFound.yaml"


### PR DESCRIPTION
## Roadmap Task

👉  [https://getlago.canny.io/feature-requests/p/{{FEATURE_SLUG}}](https://getlago.canny.io/feature-requests/p/add-features-to-the-customer-portal)

## Context

We got feedback that this portal is too limited in terms of features and information. Why?

**1st reason:** the number of information displayed is limited

**2nd reason:** the end user cannot take actions out of it (change info, add payment method)

**3rd reason:** the UI and display is not customizable

## Description

The goal of this PR is to make accessible to all our users (free and premium) the customer portal URL.
