### PR TITLE
Fix: Specify expiration on coupon as required at coupon create input schema

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -4191,6 +4191,7 @@ components:
                 - code
                 - coupon_type
                 - frequency
+                - expiration
     CouponObject:
       type: object
       required:

--- a/src/schemas/CouponCreateInput.yaml
+++ b/src/schemas/CouponCreateInput.yaml
@@ -10,3 +10,4 @@ properties:
       - code
       - coupon_type
       - frequency
+      - expiration


### PR DESCRIPTION
Expiration field on coupon has not_null constraint in the DB, with no default value, so this field should be required in the request