### PR TITLE
feat(DynamicPricing): Document Event#precise_total_amount_cents

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -5869,6 +5869,11 @@ components:
                 This field captures the Unix timestamp in seconds indicating the occurrence of the event in Coordinated Universal Time (UTC).
                 If this timestamp is not provided, the API will automatically set it to the time of event reception.
                 You can also provide miliseconds precision by appending decimals to the timestamp.
+            precise_total_amount_cents:
+              type: string
+              nullable: true
+              example: '1234.56'
+              description: The precise total amount in cents with precision used by the `dynamic` pricing model to compute the usage amount.
             properties:
               type: object
               description: 'This field represents additional properties associated with the event, which are utilized in the calculation of the final fee. This object becomes mandatory when the targeted billable metric employs a `sum_agg`, `max_agg`, or `unique_count_agg` aggregation method. However, when using a simple `count_agg`, this object is not required.'
@@ -5915,6 +5920,11 @@ components:
           format: date-time
           example: '2022-04-29T08:59:51.123Z'
           description: 'This field captures the Unix timestamp in seconds indicating the occurrence of the event in Coordinated Universal Time (UTC). If this timestamp is not provided, the API will automatically set it to the time of event reception.'
+        precise_total_amount_cents:
+          type: string
+          nullable: true
+          example: '1234.56'
+          description: The precise total amount that was sent in the event payload. This filed is used by the `dynamic` pricing model.
         properties:
           type: object
           description: 'This field represents additional properties associated with the event, which are utilized in the calculation of the final fee. This object becomes mandatory when the targeted billable metric employs a `sum_agg`, `max_agg`, or `unique_count_agg` aggregation method. However, when using a simple `count_agg`, this object is not required.'

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3593,7 +3593,7 @@ components:
           example: '2022-09-14T16:35:31Z'
         charge_model:
           type: string
-          description: 'Specifies the pricing model used for the calculation of the final fee. It can be `standard`, `graduated`, `graduated_percentage`, `package`, `percentage` or `volume`.'
+          description: 'Specifies the pricing model used for the calculation of the final fee. It can be `standard`, `graduated`, `graduated_percentage`, `package`, `percentage`, `volume` or `dynamic`.'
           enum:
             - standard
             - graduated
@@ -3601,6 +3601,7 @@ components:
             - package
             - percentage
             - volume
+            - dynamic
         pay_in_advance:
           type: boolean
           description: 'This field determines the billing timing for this specific usage-based charge. When set to `true`, the charge is due and invoiced immediately. Conversely, when set to `false`, the charge is due and invoiced at the end of each billing period.'
@@ -7583,7 +7584,7 @@ components:
                     example: 1a901a90-1a90-1a90-1a90-1a901a901a90
                   charge_model:
                     type: string
-                    description: 'Specifies the pricing model used for the calculation of the final fee. It can be `standard`, `graduated`, `graduated_percentage` `package`, `percentage` or `volume`.'
+                    description: 'Specifies the pricing model used for the calculation of the final fee. It can be `standard`, `graduated`, `graduated_percentage` `package`, `percentage`, `volume` or `dynamic`.'
                     enum:
                       - standard
                       - graduated
@@ -7591,6 +7592,7 @@ components:
                       - package
                       - percentage
                       - volume
+                      - dynamic
                     example: standard
                   pay_in_advance:
                     type: boolean
@@ -7886,7 +7888,7 @@ components:
                     example: 1a901a90-1a90-1a90-1a90-1a901a901a90
                   charge_model:
                     type: string
-                    description: 'Specifies the pricing model used for the calculation of the final fee. It can be `standard`, `graduated`, `graduated_percentage`, `package`, `percentage` or `volume`.'
+                    description: 'Specifies the pricing model used for the calculation of the final fee. It can be `standard`, `graduated`, `graduated_percentage`, `package`, `percentage`, `volume` or `dynamic`.'
                     enum:
                       - standard
                       - graduated
@@ -7894,6 +7896,7 @@ components:
                       - package
                       - percentage
                       - volume
+                      - dynamic
                     example: standard
                   pay_in_advance:
                     type: boolean

--- a/src/schemas/ChargeObject.yaml
+++ b/src/schemas/ChargeObject.yaml
@@ -31,7 +31,7 @@ properties:
     example: "2022-09-14T16:35:31Z"
   charge_model:
     type: string
-    description: Specifies the pricing model used for the calculation of the final fee. It can be `standard`, `graduated`, `graduated_percentage`, `package`, `percentage` or `volume`.
+    description: Specifies the pricing model used for the calculation of the final fee. It can be `standard`, `graduated`, `graduated_percentage`, `package`, `percentage`, `volume` or `dynamic`.
     enum:
       - standard
       - graduated
@@ -39,6 +39,7 @@ properties:
       - package
       - percentage
       - volume
+      - dynamic
   pay_in_advance:
     type: boolean
     description: This field determines the billing timing for this specific usage-based charge. When set to `true`, the charge is due and invoiced immediately. Conversely, when set to `false`, the charge is due and invoiced at the end of each billing period.

--- a/src/schemas/EventInputObject.yaml
+++ b/src/schemas/EventInputObject.yaml
@@ -24,6 +24,11 @@ properties:
       This field captures the Unix timestamp in seconds indicating the occurrence of the event in Coordinated Universal Time (UTC).
       If this timestamp is not provided, the API will automatically set it to the time of event reception.
       You can also provide miliseconds precision by appending decimals to the timestamp.
+  precise_total_amount_cents:
+    type: string
+    nullable: true
+    example: "1234.56"
+    description: The precise total amount in cents with precision used by the `dynamic` pricing model to compute the usage amount.
   properties:
     type: object
     description: This field represents additional properties associated with the event, which are utilized in the calculation of the final fee. This object becomes mandatory when the targeted billable metric employs a `sum_agg`, `max_agg`, or `unique_count_agg` aggregation method. However, when using a simple `count_agg`, this object is not required.

--- a/src/schemas/EventObject.yaml
+++ b/src/schemas/EventObject.yaml
@@ -33,6 +33,11 @@ properties:
     format: "date-time"
     example: "2022-04-29T08:59:51.123Z"
     description: This field captures the Unix timestamp in seconds indicating the occurrence of the event in Coordinated Universal Time (UTC). If this timestamp is not provided, the API will automatically set it to the time of event reception.
+  precise_total_amount_cents:
+    type: string
+    nullable: true
+    example: "1234.56"
+    description: The precise total amount that was sent in the event payload. This filed is used by the `dynamic` pricing model.
   properties:
     type: object
     description: This field represents additional properties associated with the event, which are utilized in the calculation of the final fee. This object becomes mandatory when the targeted billable metric employs a `sum_agg`, `max_agg`, or `unique_count_agg` aggregation method. However, when using a simple `count_agg`, this object is not required.

--- a/src/schemas/PlanCreateInput.yaml
+++ b/src/schemas/PlanCreateInput.yaml
@@ -73,7 +73,7 @@ properties:
               example: "1a901a90-1a90-1a90-1a90-1a901a901a90"
             charge_model:
               type: string
-              description: Specifies the pricing model used for the calculation of the final fee. It can be `standard`, `graduated`, `graduated_percentage` `package`, `percentage` or `volume`.
+              description: Specifies the pricing model used for the calculation of the final fee. It can be `standard`, `graduated`, `graduated_percentage` `package`, `percentage`, `volume` or `dynamic`.
               enum:
                 - standard
                 - graduated
@@ -81,6 +81,7 @@ properties:
                 - package
                 - percentage
                 - volume
+                - dynamic
               example: "standard"
             pay_in_advance:
               type: boolean

--- a/src/schemas/PlanUpdateInput.yaml
+++ b/src/schemas/PlanUpdateInput.yaml
@@ -78,7 +78,7 @@ properties:
               example: "1a901a90-1a90-1a90-1a90-1a901a901a90"
             charge_model:
               type: string
-              description: Specifies the pricing model used for the calculation of the final fee. It can be `standard`, `graduated`, `graduated_percentage`, `package`, `percentage` or `volume`.
+              description: Specifies the pricing model used for the calculation of the final fee. It can be `standard`, `graduated`, `graduated_percentage`, `package`, `percentage`, `volume` or `dynamic`.
               enum:
                 - standard
                 - graduated
@@ -86,6 +86,7 @@ properties:
                 - package
                 - percentage
                 - volume
+                - dynamic
               example: "standard"
             pay_in_advance:
               type: boolean


### PR DESCRIPTION
## Context

AI, CPaaS and Fintech customers can apply a price to a unit that fluctuates over time. Currently Lago does not support this usecase.

## Description

This PR is related to https://github.com/getlago/lago-api/pull/2610.
It documents the new `precise_total_amount_cents` in input and result payloads on `POST /api/v1/events` and `POST /api/v1/batch_events`