### PR TITLE
misc(region): Change the region part in the url

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -12,13 +12,13 @@ externalDocs:
   description: Lago Github
   url: 'https://github.com/getlago'
 servers:
-  - url: 'https://{region}.getlago.com/api/v1'
+  - url: 'https://api.{region}getlago.com/api/v1'
     variables:
       region:
-        default: api
+        default: ''
         enum:
-          - api
-          - api.eu
+          - ''
+          - eu.
 security:
   - bearerAuth: []
 tags:

--- a/src/openapi.yaml
+++ b/src/openapi.yaml
@@ -13,13 +13,13 @@ externalDocs:
   description: Lago Github
   url: https://github.com/getlago
 servers:
-  - url: https://{region}.getlago.com/api/v1
+  - url: https://api.{region}getlago.com/api/v1
     variables:
       region:
-        default: api
+        default: ''
         enum:
-          - api
-          - api.eu
+          - ''
+          - eu.
 security:
   - bearerAuth: []
 tags:


### PR DESCRIPTION
Change the region part in the url so instead of this format:

`{{region}}.getlago.com`

we'll have: `api.{{region}}getlago.com`