### PR TITLE
fix: Fix issue with incorrect base URL generation due to empty string in region variable

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -12,13 +12,13 @@ externalDocs:
   description: Lago Github
   url: 'https://github.com/getlago'
 servers:
-  - url: 'https://api.{region}getlago.com/api/v1'
+  - url: 'https://api{region}getlago.com/api/v1'
     variables:
       region:
-        default: ''
+        default: .
         enum:
-          - ''
-          - eu.
+          - .
+          - .eu.
 security:
   - bearerAuth: []
 tags:

--- a/src/openapi.yaml
+++ b/src/openapi.yaml
@@ -13,13 +13,13 @@ externalDocs:
   description: Lago Github
   url: https://github.com/getlago
 servers:
-  - url: https://api.{region}getlago.com/api/v1
+  - url: https://api{region}getlago.com/api/v1
     variables:
       region:
-        default: ''
+        default: .
         enum:
-          - ''
-          - eu.
+          - .
+          - .eu.
 security:
   - bearerAuth: []
 tags:


### PR DESCRIPTION
This PR addresses an issue where an empty string in the region variable resulted in an incorrect base URL being generated, specifically https://api. {region}getlago.com/api/v1 instead of https://api.getlago.com/api/v1.

The previous configuration for the region variable used an empty string as the default, which caused the incorrect URL structure. The fix involves adjusting the default value of the region variable and ensuring that the resulting URL is properly constructed as https://api.getlago.com/api/v1 when no region is specified.

<img width="587" alt="Screenshot 2024-10-24 at 12 33 05 PM" src="https://github.com/user-attachments/assets/ffaaba54-703b-4003-a364-618e2ac4fb48">
<img width="587" alt="Screenshot 2024-10-24 at 12 33 00 PM" src="https://github.com/user-attachments/assets/43bb9a6f-001b-4a08-97c2-b7de51504ee7">
