### PR TITLE
feat(felixible aggregation): Expose expression in API

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3405,6 +3405,10 @@ components:
           format: date-time
           example: '2022-09-14T16:35:31Z'
           description: Creation date of the billable metric.
+        expression:
+          type: string
+          example: round((ended_at - started_at) * units)
+          description: Expression used to calculate the event units. The expression is evalutated for each event and the result is then used to calculate the total aggregated units.
         field_name:
           type: string
           example: gb
@@ -3469,6 +3473,11 @@ components:
             - If set to `true`: the accumulated number of units calculated from the previous billing period is persisted to the next billing period.
             - If set to `false`: the accumulated number of units is reset to 0 at the end of the billing period.
             - If not defined in the request, default value is `false`.
+        expression:
+          type: string
+          example: round((ended_at - started_at) * units)
+          description: Expression used to calculate the event units. The expression is evalutated for each event and the result is then used to calculate the total aggregated units.
+          nullable: true
         field_name:
           type: string
           example: gb

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -486,6 +486,33 @@ paths:
                 $ref: '#/components/schemas/BillableMetricsPaginated'
         '401':
           $ref: '#/components/responses/Unauthorized'
+  /billable_metrics/evaluate_expression:
+    post:
+      tags:
+        - billable_metrics
+      summary: Evaluate an expression for a billable metric
+      description: Evaluate an expression for a billable metric creation by providing the expression and test data
+      operationId: evaluateBillableMetricExpression
+      requestBody:
+        description: Billable metric expression evaluation payload
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/BillableMetricEvaluateExpressionInput'
+        required: true
+      responses:
+        '200':
+          description: Billable metric expression evaluation result
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BillableMetricEvaluateExpressionResult'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '422':
+          $ref: '#/components/responses/UnprocessableEntity'
   '/billable_metrics/{code}':
     parameters:
       - name: code
@@ -1881,7 +1908,7 @@ paths:
       tags:
         - invoices
       summary: Void an invoice
-      description: "This endpoint is used for voiding an invoice. You can void an invoice only when it's in a `finalized` status, and the payment status is not `succeeded`."
+      description: 'This endpoint is used for voiding an invoice. You can void an invoice only when it''s in a `finalized` status, and the payment status is not `succeeded`.'
       parameters:
         - $ref: '#/components/parameters/lago_invoice_id'
       operationId: voidInvoice
@@ -3257,7 +3284,7 @@ components:
           type: string
           format: date-time
           nullable: true
-          description: "The date and time after which the coupon will stop applying to customer's invoices. Once the expiration date is reached, the coupon will no longer be applicable, and any further invoices generated for the customer will not include the coupon discount."
+          description: 'The date and time after which the coupon will stop applying to customer''s invoices. Once the expiration date is reached, the coupon will no longer be applicable, and any further invoices generated for the customer will not include the coupon discount.'
           example: '2022-04-29T08:59:51Z'
         created_at:
           type: string
@@ -3476,7 +3503,10 @@ components:
         expression:
           type: string
           example: round((ended_at - started_at) * units)
-          description: Expression used to calculate the event units. The expression is evalutated for each event and the result is then used to calculate the total aggregated units.
+          description: |
+            Expression used to calculate the event units. The expression is evalutated for each event and the result is then used to calculate the total aggregated units.
+            Accepted function are `ceil`, `concat` and `round` as well as `+`, `-`, `\` and `*` operations.
+            Round is accepting an optional second parameter to specify the number of decimal.
           nullable: true
         field_name:
           type: string
@@ -3517,6 +3547,63 @@ components:
                 - name
                 - code
                 - aggregation_type
+    BillableMetricEvaluateExpressionInput:
+      type: object
+      required:
+        - expression
+        - event
+      properties:
+        expression:
+          type: string
+          example: round((ended_at - started_at) * units)
+          description: |
+            Expression used to calculate the event units. The expression is evalutated for each event and the result is then used to calculate the total aggregated units.
+            Accepted function are `ceil`, `concat` and `round` as well as `+`, `-`, `\` and `*` operations.
+            Round is accepting an optional second parameter to specify the number of decimal.
+        event:
+          type: object
+          required:
+            - code
+            - properties
+          properties:
+            code:
+              type: string
+              example: storage
+              description: The code that identifies a targeted billable metric.
+            timestamp:
+              anyOf:
+                - type: integer
+                - type: string
+              example: '1651240791'
+              description: |
+                This field captures the Unix timestamp in seconds indicating the occurrence of the event in Coordinated Universal Time (UTC).
+                If this timestamp is not provided, the API will automatically set it to the time of event reception.
+            properties:
+              type: object
+              description: This field represents additional properties associated with the event. They can be used when evaluating the expression.
+              additionalProperties:
+                oneOf:
+                  - type: string
+                  - type: integer
+                  - type: number
+              example:
+                gb: 10
+    BillableMetricEvaluateExpressionResult:
+      type: object
+      required:
+        - expression_result
+      properties:
+        expression_result:
+          type: object
+          required:
+            - value
+          properties:
+            value:
+              anyOf:
+                - type: string
+                - type: number
+              example: 1
+              description: Result of evaluating the expression
     BillableMetricFilterInput:
       type: object
       description: Values used to apply differentiated pricing based on additional event properties.
@@ -4221,7 +4308,7 @@ components:
               nullable: true
               items:
                 type: string
-              description: "An array of plan codes to which the coupon is applicable. By specifying the plan codes in this field, you can restrict the coupon's usage to specific plans only."
+              description: 'An array of plan codes to which the coupon is applicable. By specifying the plan codes in this field, you can restrict the coupon''s usage to specific plans only.'
               example:
                 - startup_plan
             billable_metric_codes:
@@ -4229,7 +4316,7 @@ components:
               nullable: true
               items:
                 type: string
-              description: "An array of billable metric codes to which the coupon is applicable. By specifying the billable metric codes in this field, you can restrict the coupon's usage to specific metrics only."
+              description: 'An array of billable metric codes to which the coupon is applicable. By specifying the billable metric codes in this field, you can restrict the coupon''s usage to specific metrics only.'
               example: []
     CouponCreateInput:
       type: object
@@ -4309,7 +4396,7 @@ components:
           example: true
         plan_codes:
           type: array
-          description: "An array of plan codes to which the coupon is applicable. By specifying the plan codes in this field, you can restrict the coupon's usage to specific plans only."
+          description: 'An array of plan codes to which the coupon is applicable. By specifying the plan codes in this field, you can restrict the coupon''s usage to specific plans only.'
           items:
             type: string
           example:
@@ -4320,7 +4407,7 @@ components:
           example: false
         billable_metric_codes:
           type: array
-          description: "An array of billable metric codes to which the coupon is applicable. By specifying the billable metric codes in this field, you can restrict the coupon's usage to specific metrics only."
+          description: 'An array of billable metric codes to which the coupon is applicable. By specifying the billable metric codes in this field, you can restrict the coupon''s usage to specific metrics only.'
           items:
             type: string
           example: []
@@ -4373,7 +4460,7 @@ components:
         terminated_at:
           type: string
           format: date-time
-          description: "This field indicates if the coupon has been terminated and is no longer usable. If it's not null, it won't be removed for existing customers using it, but it prevents the coupon from being applied in the future."
+          description: 'This field indicates if the coupon has been terminated and is no longer usable. If it''s not null, it won''t be removed for existing customers using it, but it prevents the coupon from being applied in the future.'
           example: '2022-08-08T23:59:59Z'
     CouponsPaginated:
       type: object
@@ -4501,7 +4588,7 @@ components:
                 properties:
                   amount_cents:
                     type: integer
-                    description: "The credit note's item amount, expressed in cents."
+                    description: 'The credit note''s item amount, expressed in cents.'
                     example: 100
                   lago_fee_id:
                     type: string
@@ -4600,11 +4687,11 @@ components:
               example: coupon
             code:
               type: string
-              description: "The code of the credit applied. It can be the code of the coupon attached to the credit, the credit note's number or the `progressive_billing` invoice number."
+              description: 'The code of the credit applied. It can be the code of the coupon attached to the credit, the credit note''s number or the `progressive_billing` invoice number.'
               example: startup_deal
             name:
               type: string
-              description: "The name of the credit applied. It can be the name of the coupon attached to the credit, the initial invoice's number linked to the credit note or the `progressive_billing` invoice number."
+              description: 'The name of the credit applied. It can be the name of the coupon attached to the credit, the initial invoice''s number linked to the credit note or the `progressive_billing` invoice number.'
               example: Startup Deal
         invoice:
           type: object
@@ -4654,11 +4741,11 @@ components:
         lago_id:
           type: string
           format: uuid
-          description: "The credit note's item unique identifier, created by Lago."
+          description: 'The credit note''s item unique identifier, created by Lago.'
           example: 1a901a90-1a90-1a90-1a90-1a901a901a90
         amount_cents:
           type: integer
-          description: "The credit note's item amount, expressed in cents."
+          description: 'The credit note''s item amount, expressed in cents.'
           example: 100
         amount_currency:
           allOf:
@@ -5132,7 +5219,7 @@ components:
         provider_customer_id:
           type: string
           example: cus_12345
-          description: "The customer ID within the payment provider's system. If this field is not provided, Lago has the option to create a new customer record within the payment provider's system on behalf of the customer"
+          description: 'The customer ID within the payment provider''s system. If this field is not provided, Lago has the option to create a new customer record within the payment provider''s system on behalf of the customer'
         sync:
           type: boolean
           example: true
@@ -5140,7 +5227,7 @@ components:
         sync_with_provider:
           type: boolean
           example: true
-          description: "Set this field to `true` if you want to create a customer record in the payment provider's system. This option is applicable only when the `provider_customer_id` is null and the `sync_with_provider` field is set to `true`. By default, the value is set to `false`"
+          description: 'Set this field to `true` if you want to create a customer record in the payment provider''s system. This option is applicable only when the `provider_customer_id` is null and the `sync_with_provider` field is set to `true`. By default, the value is set to `false`'
         document_locale:
           type: string
           example: fr
@@ -5179,11 +5266,11 @@ components:
         external_customer_id:
           type: string
           example: cus_12345
-          description: "The customer ID within the integration's system. If this field is not provided, Lago has the option to create a new customer record within the integration's system on behalf of the customer."
+          description: 'The customer ID within the integration''s system. If this field is not provided, Lago has the option to create a new customer record within the integration''s system on behalf of the customer.'
         sync_with_provider:
           type: boolean
           example: true
-          description: "Set this field to `true` if you want to create a customer record in the integration's system. This option is applicable only when the `external_customer_id` is null and the `sync_with_provider` field is set to `true`. By default, the value is set to `false`"
+          description: 'Set this field to `true` if you want to create a customer record in the integration''s system. This option is applicable only when the `external_customer_id` is null and the `sync_with_provider` field is set to `true`. By default, the value is set to `false`'
         subsidiary_id:
           type: string
           example: '2'
@@ -5458,7 +5545,7 @@ components:
             timezone:
               allOf:
                 - $ref: '#/components/schemas/Timezone'
-                - description: "The customer's timezone, used for billing purposes in their local time. Overrides the organization's timezone"
+                - description: 'The customer''s timezone, used for billing purposes in their local time. Overrides the organization''s timezone'
                   nullable: true
             url:
               type: string
@@ -5518,11 +5605,11 @@ components:
                   external_customer_id:
                     type: string
                     example: cus_12345
-                    description: "The customer ID within the integration's system. If this field is not provided, Lago has the option to create a new customer record within the integration's system on behalf of the customer."
+                    description: 'The customer ID within the integration''s system. If this field is not provided, Lago has the option to create a new customer record within the integration''s system on behalf of the customer.'
                   sync_with_provider:
                     type: boolean
                     example: true
-                    description: "Set this field to `true` if you want to create a customer record in the integration's system. This option is applicable only when the `external_customer_id` is null and the `sync_with_provider` field is set to `true`. By default, the value is set to `false`"
+                    description: 'Set this field to `true` if you want to create a customer record in the integration''s system. This option is applicable only when the `external_customer_id` is null and the `sync_with_provider` field is set to `true`. By default, the value is set to `false`'
                   subsidiary_id:
                     type: string
                     example: '2'
@@ -5605,11 +5692,11 @@ components:
             sequential_id:
               type: integer
               example: 1
-              description: "The unique identifier assigned to the customer within the organization's scope. This identifier is used to track and reference the customer's order of creation within the organization's system. It ensures that each customer has a distinct `sequential_id`` associated with them, allowing for easy identification and sorting based on the order of creation"
+              description: 'The unique identifier assigned to the customer within the organization''s scope. This identifier is used to track and reference the customer''s order of creation within the organization''s system. It ensures that each customer has a distinct `sequential_id`` associated with them, allowing for easy identification and sorting based on the order of creation'
             slug:
               type: string
               example: LAG-1234-001
-              description: "A concise and unique identifier for the customer, formed by combining the Organization's `name`, `id`, and customer's `sequential_id`"
+              description: 'A concise and unique identifier for the customer, formed by combining the Organization''s `name`, `id`, and customer''s `sequential_id`'
             external_id:
               type: string
               example: 5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba
@@ -5627,7 +5714,7 @@ components:
             applicable_timezone:
               allOf:
                 - $ref: '#/components/schemas/Timezone'
-                - description: "The customer's applicable timezone, used for billing purposes in their local time."
+                - description: 'The customer''s applicable timezone, used for billing purposes in their local time.'
             city:
               type: string
               example: Woodland Hills
@@ -5709,7 +5796,7 @@ components:
             timezone:
               allOf:
                 - $ref: '#/components/schemas/Timezone'
-                - description: "The customer's timezone, used for billing purposes in their local time. Overrides the organization's timezone"
+                - description: 'The customer''s timezone, used for billing purposes in their local time. Overrides the organization''s timezone'
                   nullable: true
             url:
               type: string
@@ -6019,7 +6106,7 @@ components:
           type: string
           format: date-time
           example: '2022-04-29T08:59:51Z'
-          description: "The creation date of the event's record in the Lago application, presented in the ISO 8601 datetime format, specifically in Coordinated Universal Time (UTC). It provides the precise timestamp of when the event's record was created within the Lago application"
+          description: 'The creation date of the event''s record in the Lago application, presented in the ISO 8601 datetime format, specifically in Coordinated Universal Time (UTC). It provides the precise timestamp of when the event''s record was created within the Lago application'
     Fee:
       type: object
       required:
@@ -6875,7 +6962,7 @@ components:
               example: 1a901a90-1a90-1a90-1a90-1a901a901a90
             sequential_id:
               type: integer
-              description: "This ID helps in uniquely identifying and organizing the invoices associated with a specific customer. It provides a sequential numbering system specific to the customer, allowing for easy tracking and management of invoices within the customer's context."
+              description: 'This ID helps in uniquely identifying and organizing the invoices associated with a specific customer. It provides a sequential numbering system specific to the customer, allowing for easy tracking and management of invoices within the customer''s context.'
               example: 2
             number:
               type: string
@@ -7182,7 +7269,7 @@ components:
         invoice_grace_period:
           type: integer
           example: 3
-          description: "The grace period, expressed in days, for finalizing the invoice. This period refers to the additional time granted to your customers beyond the invoice due date to adjust usage and line items. Can be overwritten by the customer's grace period."
+          description: 'The grace period, expressed in days, for finalizing the invoice. This period refers to the additional time granted to your customers beyond the invoice due date to adjust usage and line items. Can be overwritten by the customer''s grace period.'
         document_locale:
           type: string
           example: en
@@ -7308,7 +7395,7 @@ components:
         timezone:
           allOf:
             - $ref: '#/components/schemas/Timezone'
-            - description: "Your organization's timezone, used for billing purposes in your own local time. Can be overwritten by the customer's timezone."
+            - description: 'Your organization''s timezone, used for billing purposes in your own local time. Can be overwritten by the customer''s timezone.'
               example: America/New_York
         billing_configuration:
           $ref: '#/components/schemas/OrganizationBillingConfiguration'
@@ -7415,7 +7502,7 @@ components:
             timezone:
               allOf:
                 - $ref: '#/components/schemas/Timezone'
-                - description: "Your organization's timezone, used for billing purposes in your own local time. Can be overwritten by the customer's timezone."
+                - description: 'Your organization''s timezone, used for billing purposes in your own local time. Can be overwritten by the customer''s timezone.'
                   example: America/New_York
             email_settings:
               type: array
@@ -7615,7 +7702,7 @@ components:
             amount_currency:
               allOf:
                 - $ref: '#/components/schemas/Currency'
-                - description: "The currency of the plan. It indicates the monetary unit in which the plan's cost, including taxes and usage-based charges, is expressed."
+                - description: 'The currency of the plan. It indicates the monetary unit in which the plan''s cost, including taxes and usage-based charges, is expressed.'
                   example: USD
             trial_period:
               type: number
@@ -7627,7 +7714,7 @@ components:
               example: true
             bill_charges_monthly:
               type: boolean
-              description: "This field, when set to `true`, enables to invoice usage-based charges on monthly basis, even if the cadence of the plan is yearly. This allows customers to pay charges overage on a monthly basis. This can be set to true only if the plan's interval is `yearly`."
+              description: 'This field, when set to `true`, enables to invoice usage-based charges on monthly basis, even if the cadence of the plan is yearly. This allows customers to pay charges overage on a monthly basis. This can be set to true only if the plan''s interval is `yearly`.'
               nullable: true
               example: null
             tax_codes:
@@ -7802,7 +7889,7 @@ components:
         amount_currency:
           allOf:
             - $ref: '#/components/schemas/Currency'
-            - description: "The currency of the plan. It indicates the monetary unit in which the plan's cost, including taxes and usage-based charges, is expressed."
+            - description: 'The currency of the plan. It indicates the monetary unit in which the plan''s cost, including taxes and usage-based charges, is expressed.'
               example: USD
         description:
           type: string
@@ -7914,7 +8001,7 @@ components:
             amount_currency:
               allOf:
                 - $ref: '#/components/schemas/Currency'
-                - description: "The currency of the plan. It indicates the monetary unit in which the plan's cost, including taxes and usage-based charges, is expressed."
+                - description: 'The currency of the plan. It indicates the monetary unit in which the plan''s cost, including taxes and usage-based charges, is expressed.'
                   example: USD
             trial_period:
               type: number
@@ -7926,7 +8013,7 @@ components:
               example: true
             bill_charges_monthly:
               type: boolean
-              description: "This field, when set to `true`, enables to invoice usage-based charges on monthly basis, even if the cadence of the plan is yearly. This allows customers to pay charges overage on a monthly basis. This can be set to true only if the plan's interval is `yearly`."
+              description: 'This field, when set to `true`, enables to invoice usage-based charges on monthly basis, even if the cadence of the plan is yearly. This allows customers to pay charges overage on a monthly basis. This can be set to true only if the plan''s interval is `yearly`.'
               nullable: true
               example: null
             tax_codes:
@@ -8154,7 +8241,7 @@ components:
         amount_currency:
           allOf:
             - $ref: '#/components/schemas/Currency'
-            - description: "The currency of the plan. It indicates the monetary unit in which the plan's cost, including taxes and usage-based charges, is expressed."
+            - description: 'The currency of the plan. It indicates the monetary unit in which the plan''s cost, including taxes and usage-based charges, is expressed.'
               example: USD
         trial_period:
           type: number
@@ -8167,7 +8254,7 @@ components:
         bill_charges_monthly:
           type: boolean
           nullable: true
-          description: "This field, when set to `true`, enables to invoice usage-based charges on monthly basis, even if the cadence of the plan is yearly. This allows customers to pay charges overage on a monthly basis. This can be set to true only if the plan's interval is `yearly`."
+          description: 'This field, when set to `true`, enables to invoice usage-based charges on monthly basis, even if the cadence of the plan is yearly. This allows customers to pay charges overage on a monthly basis. This can be set to true only if the plan''s interval is `yearly`.'
           example: null
         active_subscriptions_count:
           type: integer
@@ -8342,7 +8429,7 @@ components:
             name:
               type: string
               example: Repository A
-              description: "The display name of the subscription on an invoice. This field allows for customization of the subscription's name for billing purposes, especially useful when a single customer has multiple subscriptions using the same plan."
+              description: 'The display name of the subscription on an invoice. This field allows for customization of the subscription''s name for billing purposes, especially useful when a single customer has multiple subscriptions using the same plan.'
             external_id:
               type: string
               example: my_sub_1234567890
@@ -8387,7 +8474,7 @@ components:
               type: string
               example: Repository B
               nullable: true
-              description: "The display name of the subscription on an invoice. This field allows for customization of the subscription's name for billing purposes, especially useful when a single customer has multiple subscriptions using the same plan."
+              description: 'The display name of the subscription on an invoice. This field allows for customization of the subscription''s name for billing purposes, especially useful when a single customer has multiple subscriptions using the same plan.'
             ending_at:
               type: string
               format: date-time
@@ -8442,7 +8529,7 @@ components:
         name:
           type: string
           example: Repository A
-          description: "The display name of the subscription on an invoice. This field allows for customization of the subscription's name for billing purposes, especially useful when a single customer has multiple subscriptions using the same plan."
+          description: 'The display name of the subscription on an invoice. This field allows for customization of the subscription''s name for billing purposes, especially useful when a single customer has multiple subscriptions using the same plan.'
           nullable: true
         plan_code:
           type: string

--- a/src/openapi.yaml
+++ b/src/openapi.yaml
@@ -104,124 +104,126 @@ tags:
       url: https://doc.getlago.com/docs/api/payment_requests/payment_request-object
 paths:
   /add_ons:
-    $ref: './resources/add_ons.yaml'
+    $ref: "./resources/add_ons.yaml"
   /add_ons/{code}:
-    $ref: './resources/add_on.yaml'
+    $ref: "./resources/add_on.yaml"
   /analytics/gross_revenue:
-    $ref: './resources/gross_revenues.yaml'
+    $ref: "./resources/gross_revenues.yaml"
   /analytics/invoice_collection:
-    $ref: './resources/invoice_collections.yaml'
+    $ref: "./resources/invoice_collections.yaml"
   /analytics/invoiced_usage:
-    $ref: './resources/invoiced_usages.yaml'
+    $ref: "./resources/invoiced_usages.yaml"
   /analytics/mrr:
-    $ref: './resources/mrrs.yaml'
+    $ref: "./resources/mrrs.yaml"
   /analytics/overdue_balance:
-    $ref: './resources/overdue_balances.yaml'
+    $ref: "./resources/overdue_balances.yaml"
   /applied_coupons:
-    $ref: './resources/applied_coupons.yaml'
+    $ref: "./resources/applied_coupons.yaml"
   /billable_metrics:
-    $ref: './resources/billable_metrics.yaml'
+    $ref: "./resources/billable_metrics.yaml"
+  /billable_metrics/evaluate_expression:
+    $ref: "./resources/billable_metric_evaluate_expression.yaml"
   /billable_metrics/{code}:
-    $ref: './resources/billable_metric.yaml'
+    $ref: "./resources/billable_metric.yaml"
   /coupons:
-    $ref: './resources/coupons.yaml'
+    $ref: "./resources/coupons.yaml"
   /coupons/{code}:
-    $ref: './resources/coupon.yaml'
+    $ref: "./resources/coupon.yaml"
   /credit_notes:
-    $ref: './resources/credit_notes.yaml'
+    $ref: "./resources/credit_notes.yaml"
   /credit_notes/{lago_id}:
-    $ref: './resources/credit_note.yaml'
+    $ref: "./resources/credit_note.yaml"
   /credit_notes/{lago_id}/download:
-    $ref: './resources/credit_note_download.yaml'
+    $ref: "./resources/credit_note_download.yaml"
   /credit_notes/estimate:
-    $ref: './resources/credit_note_estimate.yaml'
+    $ref: "./resources/credit_note_estimate.yaml"
   /credit_notes/{lago_id}/void:
-    $ref: './resources/credit_note_void.yaml'
+    $ref: "./resources/credit_note_void.yaml"
   /customers:
-    $ref: './resources/customers.yaml'
+    $ref: "./resources/customers.yaml"
   /customers/{external_id}:
-    $ref: './resources/customer.yaml'
+    $ref: "./resources/customer.yaml"
   /customers/{external_customer_id}/applied_coupons/{applied_coupon_id}:
-    $ref: './resources/customer_applied_coupon.yaml'
+    $ref: "./resources/customer_applied_coupon.yaml"
   /customers/{external_customer_id}/portal_url:
-    $ref: './resources/customer_portal_url.yaml'
+    $ref: "./resources/customer_portal_url.yaml"
   /customers/{external_customer_id}/current_usage:
-    $ref: './resources/customer_current_usage.yaml'
+    $ref: "./resources/customer_current_usage.yaml"
   /customers/{external_customer_id}/past_usage:
-    $ref: './resources/customer_past_usage.yaml'
+    $ref: "./resources/customer_past_usage.yaml"
   /customers/{external_customer_id}/checkout_url:
-    $ref: './resources/customer_checkout_url.yaml'
+    $ref: "./resources/customer_checkout_url.yaml"
   /events:
-    $ref: './resources/events.yaml'
+    $ref: "./resources/events.yaml"
   /events/batch:
-    $ref: './resources/events_batch.yaml'
+    $ref: "./resources/events_batch.yaml"
   /events/estimate_fees:
-    $ref: './resources/event_estimate_fees.yaml'
+    $ref: "./resources/event_estimate_fees.yaml"
   /events/{transaction_id}:
-    $ref: './resources/event.yaml'
+    $ref: "./resources/event.yaml"
   /fees:
-    $ref: './resources/fees.yaml'
+    $ref: "./resources/fees.yaml"
   /fees/{lago_id}:
-    $ref: './resources/fee.yaml'
+    $ref: "./resources/fee.yaml"
   /invoices:
-    $ref: './resources/invoices.yaml'
+    $ref: "./resources/invoices.yaml"
   /invoices/{lago_id}:
-    $ref: './resources/invoice.yaml'
+    $ref: "./resources/invoice.yaml"
   /invoices/{lago_id}/download:
-    $ref: './resources/invoice_download.yaml'
+    $ref: "./resources/invoice_download.yaml"
   /invoices/{lago_id}/finalize:
-    $ref: './resources/invoice_finalize.yaml'
+    $ref: "./resources/invoice_finalize.yaml"
   /invoices/{lago_id}/lose_dispute:
-    $ref: './resources/invoice_lose_dispute.yaml'
+    $ref: "./resources/invoice_lose_dispute.yaml"
   /invoices/{lago_id}/refresh:
-    $ref: './resources/invoice_refresh.yaml'
+    $ref: "./resources/invoice_refresh.yaml"
   /invoices/{lago_id}/retry:
-    $ref: './resources/invoice_retry.yaml'
+    $ref: "./resources/invoice_retry.yaml"
   /invoices/{lago_id}/payment_url:
-    $ref: './resources/invoice_payment_url.yaml'
+    $ref: "./resources/invoice_payment_url.yaml"
   /invoices/{lago_id}/retry_payment:
-    $ref: './resources/invoice_retry_payment.yaml'
+    $ref: "./resources/invoice_retry_payment.yaml"
   /invoices/{lago_id}/void:
-    $ref: './resources/invoice_void.yaml'
+    $ref: "./resources/invoice_void.yaml"
   /organizations:
-    $ref: './resources/organizations.yaml'
+    $ref: "./resources/organizations.yaml"
   /payment_requests:
-    $ref: './resources/payment_requests.yaml'
+    $ref: "./resources/payment_requests.yaml"
   /plans:
-    $ref: './resources/plans.yaml'
+    $ref: "./resources/plans.yaml"
   /plans/{code}:
-    $ref: './resources/plan.yaml'
+    $ref: "./resources/plan.yaml"
   /subscriptions:
-    $ref: './resources/subscriptions.yaml'
+    $ref: "./resources/subscriptions.yaml"
   /subscriptions/{external_id}:
-    $ref: './resources/subscription.yaml'
+    $ref: "./resources/subscription.yaml"
   /subscriptions/{external_id}/lifetime_usage:
-    $ref: './resources/subscription_lifetime_usage.yaml'
+    $ref: "./resources/subscription_lifetime_usage.yaml"
   /taxes:
-    $ref: './resources/taxes.yaml'
+    $ref: "./resources/taxes.yaml"
   /taxes/{code}:
-    $ref: './resources/tax.yaml'
+    $ref: "./resources/tax.yaml"
   /wallets:
-    $ref: './resources/wallets.yaml'
+    $ref: "./resources/wallets.yaml"
   /wallets/{lago_id}:
-    $ref: './resources/wallet.yaml'
+    $ref: "./resources/wallet.yaml"
   /wallet_transactions:
-    $ref: './resources/wallet_top_up.yaml'
+    $ref: "./resources/wallet_top_up.yaml"
   /wallets/{lago_id}/wallet_transactions:
-    $ref: './resources/wallet_transactions.yaml'
+    $ref: "./resources/wallet_transactions.yaml"
   /webhooks/public_key:
-    $ref: './resources/webhook_public_key.yaml'
+    $ref: "./resources/webhook_public_key.yaml"
   /webhook_endpoints:
-    $ref: './resources/webhook_endpoints.yaml'
+    $ref: "./resources/webhook_endpoints.yaml"
   /webhook_endpoints/{lago_id}:
-    $ref: './resources/webhook_endpoint.yaml'
+    $ref: "./resources/webhook_endpoint.yaml"
 components:
   parameters:
-    $ref: './parameters/_index.yaml'
+    $ref: "./parameters/_index.yaml"
   schemas:
-    $ref: './schemas/_index.yaml'
+    $ref: "./schemas/_index.yaml"
   responses:
-    $ref: './responses/_index.yaml'
+    $ref: "./responses/_index.yaml"
   securitySchemes:
     bearerAuth:
       type: http

--- a/src/resources/billable_metric_evaluate_expression.yaml
+++ b/src/resources/billable_metric_evaluate_expression.yaml
@@ -1,0 +1,26 @@
+post:
+  tags:
+    - billable_metrics
+  summary: Evaluate an expression for a billable metric
+  description: Evaluate an expression for a billable metric creation by providing the expression and test data
+  operationId: evaluateBillableMetricExpression
+  requestBody:
+    description: Billable metric expression evaluation payload
+    content:
+      application/json:
+        schema:
+          $ref: "../schemas/BillableMetricEvaluateExpressionInput.yaml"
+    required: true
+  responses:
+    "200":
+      description: Billable metric expression evaluation result
+      content:
+        application/json:
+          schema:
+            $ref: "../schemas/BillableMetricEvaluateExpressionResult.yaml"
+    "400":
+      $ref: "../responses/BadRequest.yaml"
+    "401":
+      $ref: "../responses/Unauthorized.yaml"
+    "422":
+      $ref: "../responses/UnprocessableEntity.yaml"

--- a/src/schemas/BillableMetricBaseInput.yaml
+++ b/src/schemas/BillableMetricBaseInput.yaml
@@ -25,7 +25,10 @@ properties:
   expression:
     type: string
     example: "round((ended_at - started_at) * units)"
-    description: "Expression used to calculate the event units. The expression is evalutated for each event and the result is then used to calculate the total aggregated units."
+    description: |
+      Expression used to calculate the event units. The expression is evalutated for each event and the result is then used to calculate the total aggregated units.
+      Accepted function are `ceil`, `concat` and `round` as well as `+`, `-`, `\` and `*` operations.
+      Round is accepting an optional second parameter to specify the number of decimal.
     nullable: true
   field_name:
     type: string

--- a/src/schemas/BillableMetricBaseInput.yaml
+++ b/src/schemas/BillableMetricBaseInput.yaml
@@ -22,6 +22,11 @@ properties:
       - If set to `true`: the accumulated number of units calculated from the previous billing period is persisted to the next billing period.
       - If set to `false`: the accumulated number of units is reset to 0 at the end of the billing period.
       - If not defined in the request, default value is `false`.
+  expression:
+    type: string
+    example: "round((ended_at - started_at) * units)"
+    description: "Expression used to calculate the event units. The expression is evalutated for each event and the result is then used to calculate the total aggregated units."
+    nullable: true
   field_name:
     type: string
     example: "gb"

--- a/src/schemas/BillableMetricEvaluateExpressionInput.yaml
+++ b/src/schemas/BillableMetricEvaluateExpressionInput.yaml
@@ -1,0 +1,40 @@
+type: object
+required:
+  - expression
+  - event
+properties:
+  expression:
+    type: string
+    example: "round((ended_at - started_at) * units)"
+    description: |
+      Expression used to calculate the event units. The expression is evalutated for each event and the result is then used to calculate the total aggregated units.
+      Accepted function are `ceil`, `concat` and `round` as well as `+`, `-`, `\` and `*` operations.
+      Round is accepting an optional second parameter to specify the number of decimal.
+  event:
+    type: object
+    required:
+      - code
+      - properties
+    properties:
+      code:
+        type: string
+        example: "storage"
+        description: The code that identifies a targeted billable metric.
+      timestamp:
+        anyOf:
+          - type: integer
+          - type: string
+        example: "1651240791"
+        description: |
+          This field captures the Unix timestamp in seconds indicating the occurrence of the event in Coordinated Universal Time (UTC).
+          If this timestamp is not provided, the API will automatically set it to the time of event reception.
+      properties:
+        type: object
+        description: This field represents additional properties associated with the event. They can be used when evaluating the expression.
+        additionalProperties:
+          oneOf:
+            - type: string
+            - type: integer
+            - type: number
+        example:
+          gb: 10

--- a/src/schemas/BillableMetricEvaluateExpressionResult.yaml
+++ b/src/schemas/BillableMetricEvaluateExpressionResult.yaml
@@ -1,0 +1,15 @@
+type: object
+required:
+  - expression_result
+properties:
+  expression_result:
+    type: object
+    required:
+      - value
+    properties:
+      value:
+        anyOf:
+          - type: string
+          - type: number
+        example: 1.0
+        description: "Result of evaluating the expression"

--- a/src/schemas/BillableMetricObject.yaml
+++ b/src/schemas/BillableMetricObject.yaml
@@ -42,6 +42,10 @@ properties:
     format: "date-time"
     example: "2022-09-14T16:35:31Z"
     description: "Creation date of the billable metric."
+  expression:
+    type: string
+    example: "round((ended_at - started_at) * units)"
+    description: "Expression used to calculate the event units. The expression is evalutated for each event and the result is then used to calculate the total aggregated units."
   field_name:
     type: string
     example: "gb"

--- a/src/schemas/_index.yaml
+++ b/src/schemas/_index.yaml
@@ -44,6 +44,10 @@ BillableMetricBaseInput:
   $ref: "./BillableMetricBaseInput.yaml"
 BillableMetricCreateInput:
   $ref: "./BillableMetricCreateInput.yaml"
+BillableMetricEvaluateExpressionInput:
+  $ref: "./BillableMetricEvaluateExpressionInput.yaml"
+BillableMetricEvaluateExpressionResult:
+  $ref: "./BillableMetricEvaluateExpressionResult.yaml"
 BillableMetricFilterInput:
   $ref: "./BillableMetricFilterInput.yaml"
 BillableMetricFilterObject:


### PR DESCRIPTION
This PR is related to https://github.com/getlago/lago-api/pull/2704

It exposes:
- The new `expression` field on billable metric input and output payloads
- The new `POST /api/v1/billable_metrics/evaluate_expression` api end-point