### PR TITLE
Remove all unnecessary allOf

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 out/
 node_modules
+/.idea/

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1881,7 +1881,7 @@ paths:
       tags:
         - invoices
       summary: Void an invoice
-      description: "This endpoint is used for voiding an invoice. You can void an invoice only when it's in a `finalized` status, and the payment status is not `succeeded`."
+      description: 'This endpoint is used for voiding an invoice. You can void an invoice only when it''s in a `finalized` status, and the payment status is not `succeeded`.'
       parameters:
         - $ref: '#/components/parameters/lago_invoice_id'
       operationId: voidInvoice
@@ -2896,10 +2896,9 @@ components:
           description: 'The cost of the add-on in cents, excluding any applicable taxes, that is billed to a customer. By creating a one-off invoice, you will be able to override this value.'
           example: 50000
         amount_currency:
-          allOf:
-            - $ref: '#/components/schemas/Currency'
-            - description: The currency of the add-on.
-              example: USD
+          $ref: '#/components/schemas/Currency'
+          description: The currency of the add-on.
+          example: USD
         description:
           type: string
           nullable: true
@@ -2918,13 +2917,12 @@ components:
         - add_on
       properties:
         add_on:
-          allOf:
-            - $ref: '#/components/schemas/AddOnBaseInput'
-            - required:
-                - name
-                - code
-                - amount_cents
-                - amount_currency
+          $ref: '#/components/schemas/AddOnBaseInput'
+          required:
+            - name
+            - code
+            - amount_cents
+            - amount_currency
     AddOnObject:
       type: object
       required:
@@ -2957,10 +2955,9 @@ components:
           description: 'The cost of the add-on in cents, excluding any applicable taxes, that is billed to a customer. By creating a one-off invoice, you will be able to override this value.'
           example: 50000
         amount_currency:
-          allOf:
-            - $ref: '#/components/schemas/Currency'
-            - description: The currency of the add-on.
-              example: USD
+          $ref: '#/components/schemas/Currency'
+          description: The currency of the add-on.
+          example: USD
         description:
           type: string
           nullable: true
@@ -3150,11 +3147,10 @@ components:
               description: The amount of the coupon in cents. This field is required only for coupon with `fixed_amount` type.
               example: 2000
             amount_currency:
-              allOf:
-                - $ref: '#/components/schemas/Currency'
-                - nullable: true
-                  description: The currency of the coupon. This field is required only for coupon with `fixed_amount` type.
-                  example: EUR
+              $ref: '#/components/schemas/Currency'
+              nullable: true
+              description: The currency of the coupon. This field is required only for coupon with `fixed_amount` type.
+              example: EUR
             percentage_rate:
               type: string
               pattern: '^[0-9]+.?[0-9]*$'
@@ -3219,11 +3215,10 @@ components:
           description: The remaining amount in cents for a `fixed_amount` coupon with a frequency set to `once`. This field indicates the remaining balance or value that can still be utilized from the coupon.
           example: 50
         amount_currency:
-          allOf:
-            - $ref: '#/components/schemas/Currency'
-            - nullable: true
-              description: The currency of the coupon. This field is required only for coupon with `fixed_amount` type.
-              example: EUR
+          $ref: '#/components/schemas/Currency'
+          nullable: true
+          description: The currency of the coupon. This field is required only for coupon with `fixed_amount` type.
+          example: EUR
         percentage_rate:
           type: string
           pattern: '^[0-9]+.?[0-9]*$'
@@ -3257,7 +3252,7 @@ components:
           type: string
           format: date-time
           nullable: true
-          description: "The date and time after which the coupon will stop applying to customer's invoices. Once the expiration date is reached, the coupon will no longer be applicable, and any further invoices generated for the customer will not include the coupon discount."
+          description: 'The date and time after which the coupon will stop applying to customer''s invoices. Once the expiration date is reached, the coupon will no longer be applicable, and any further invoices generated for the customer will not include the coupon discount.'
           example: '2022-04-29T08:59:51Z'
         created_at:
           type: string
@@ -3344,10 +3339,9 @@ components:
           description: Amount of the tax
           example: 2000
         amount_currency:
-          allOf:
-            - $ref: '#/components/schemas/Currency'
-            - description: Currency of the tax
-              example: USD
+          $ref: '#/components/schemas/Currency'
+          description: Currency of the tax
+          example: USD
         created_at:
           type: string
           format: date-time
@@ -3502,12 +3496,11 @@ components:
         - billable_metric
       properties:
         billable_metric:
-          allOf:
-            - $ref: '#/components/schemas/BillableMetricBaseInput'
-            - required:
-                - name
-                - code
-                - aggregation_type
+          $ref: '#/components/schemas/BillableMetricBaseInput'
+          required:
+            - name
+            - code
+            - aggregation_type
     BillableMetricFilterInput:
       type: object
       description: Values used to apply differentiated pricing based on additional event properties.
@@ -3571,9 +3564,8 @@ components:
           example: AWS
           nullable: true
         properties:
-          allOf:
-            - $ref: '#/components/schemas/ChargeProperties'
-            - description: List of all thresholds utilized for calculating the charge.
+          $ref: '#/components/schemas/ChargeProperties'
+          description: List of all thresholds utilized for calculating the charge.
         values:
           type: object
           description: List of possible filter values. The key and values must match one of the billable metric filters.
@@ -3598,9 +3590,8 @@ components:
           example: AWS
           nullable: true
         properties:
-          allOf:
-            - $ref: '#/components/schemas/ChargeProperties'
-            - description: List of all thresholds utilized for calculating the charge.
+          $ref: '#/components/schemas/ChargeProperties'
+          description: List of all thresholds utilized for calculating the charge.
         values:
           type: object
           description: List of possible filter values. The key and values must match one of the billable metric filters.
@@ -3689,9 +3680,8 @@ components:
           description: 'The minimum spending amount required for the charge, measured in cents and excluding any applicable taxes. It indicates the minimum amount that needs to be charged for each billing period.'
           example: 1200
         properties:
-          allOf:
-            - $ref: '#/components/schemas/ChargeProperties'
-            - description: List of all thresholds utilized for calculating the charge.
+          $ref: '#/components/schemas/ChargeProperties'
+          description: List of all thresholds utilized for calculating the charge.
         filters:
           type: array
           description: List of filters used to apply differentiated pricing based on additional event properties.
@@ -4152,11 +4142,10 @@ components:
           description: The amount of the coupon in cents. This field is required only for coupon with `fixed_amount` type.
           example: 5000
         amount_currency:
-          allOf:
-            - $ref: '#/components/schemas/Currency'
-            - description: The currency of the coupon. This field is required only for coupon with `fixed_amount` type.
-              nullable: true
-              example: USD
+          $ref: '#/components/schemas/Currency'
+          description: The currency of the coupon. This field is required only for coupon with `fixed_amount` type.
+          nullable: true
+          example: USD
         reusable:
           type: boolean
           description: 'Indicates whether the coupon can be reused or not. If set to `true`, the coupon is reusable, meaning it can be applied multiple times to the same customer. If set to `false`, the coupon can only be used once and is not reusable. If not specified, this field is set to `true` by default.'
@@ -4212,7 +4201,7 @@ components:
               nullable: true
               items:
                 type: string
-              description: "An array of plan codes to which the coupon is applicable. By specifying the plan codes in this field, you can restrict the coupon's usage to specific plans only."
+              description: 'An array of plan codes to which the coupon is applicable. By specifying the plan codes in this field, you can restrict the coupon''s usage to specific plans only.'
               example:
                 - startup_plan
             billable_metric_codes:
@@ -4220,7 +4209,7 @@ components:
               nullable: true
               items:
                 type: string
-              description: "An array of billable metric codes to which the coupon is applicable. By specifying the billable metric codes in this field, you can restrict the coupon's usage to specific metrics only."
+              description: 'An array of billable metric codes to which the coupon is applicable. By specifying the billable metric codes in this field, you can restrict the coupon''s usage to specific metrics only.'
               example: []
     CouponCreateInput:
       type: object
@@ -4228,14 +4217,13 @@ components:
         - coupon
       properties:
         coupon:
-          allOf:
-            - $ref: '#/components/schemas/CouponBaseInput'
-            - required:
-                - name
-                - code
-                - coupon_type
-                - frequency
-                - expiration
+          $ref: '#/components/schemas/CouponBaseInput'
+          required:
+            - name
+            - code
+            - coupon_type
+            - frequency
+            - expiration
     CouponObject:
       type: object
       required:
@@ -4285,11 +4273,10 @@ components:
           description: The amount of the coupon in cents. This field is required only for coupon with `fixed_amount` type.
           example: 5000
         amount_currency:
-          allOf:
-            - $ref: '#/components/schemas/Currency'
-            - nullable: true
-              description: The currency of the coupon. This field is required only for coupon with `fixed_amount` type.
-              example: USD
+          $ref: '#/components/schemas/Currency'
+          nullable: true
+          description: The currency of the coupon. This field is required only for coupon with `fixed_amount` type.
+          example: USD
         reusable:
           type: boolean
           description: 'Indicates whether the coupon can be reused or not. If set to `true`, the coupon is reusable, meaning it can be applied multiple times to the same customer. If set to `false`, the coupon can only be used once and is not reusable. If not specified, this field is set to `true` by default.'
@@ -4300,7 +4287,7 @@ components:
           example: true
         plan_codes:
           type: array
-          description: "An array of plan codes to which the coupon is applicable. By specifying the plan codes in this field, you can restrict the coupon's usage to specific plans only."
+          description: 'An array of plan codes to which the coupon is applicable. By specifying the plan codes in this field, you can restrict the coupon''s usage to specific plans only.'
           items:
             type: string
           example:
@@ -4311,7 +4298,7 @@ components:
           example: false
         billable_metric_codes:
           type: array
-          description: "An array of billable metric codes to which the coupon is applicable. By specifying the billable metric codes in this field, you can restrict the coupon's usage to specific metrics only."
+          description: 'An array of billable metric codes to which the coupon is applicable. By specifying the billable metric codes in this field, you can restrict the coupon''s usage to specific metrics only.'
           items:
             type: string
           example: []
@@ -4364,7 +4351,7 @@ components:
         terminated_at:
           type: string
           format: date-time
-          description: "This field indicates if the coupon has been terminated and is no longer usable. If it's not null, it won't be removed for existing customers using it, but it prevents the coupon from being applied in the future."
+          description: 'This field indicates if the coupon has been terminated and is no longer usable. If it''s not null, it won''t be removed for existing customers using it, but it prevents the coupon from being applied in the future.'
           example: '2022-08-08T23:59:59Z'
     CouponsPaginated:
       type: object
@@ -4384,8 +4371,7 @@ components:
         - coupon
       properties:
         coupon:
-          allOf:
-            - $ref: '#/components/schemas/CouponBaseInput'
+          $ref: '#/components/schemas/CouponBaseInput'
     CreditNoteEstimateInput:
       type: object
       required:
@@ -4454,10 +4440,9 @@ components:
               description: 'The invoice unique number, related to the credit note.'
               example: LAG-1234
             currency:
-              allOf:
-                - $ref: '#/components/schemas/Currency'
-                - description: The currency of the credit note.
-                  example: EUR
+              $ref: '#/components/schemas/Currency'
+              description: The currency of the credit note.
+              example: EUR
             taxes_amount_cents:
               type: integer
               description: 'The tax amount of the credit note, expressed in cents.'
@@ -4492,7 +4477,7 @@ components:
                 properties:
                   amount_cents:
                     type: integer
-                    description: "The credit note's item amount, expressed in cents."
+                    description: 'The credit note''s item amount, expressed in cents.'
                     example: 100
                   lago_fee_id:
                     type: string
@@ -4535,10 +4520,9 @@ components:
                     description: Amount of the tax
                     example: 2000
                   amount_currency:
-                    allOf:
-                      - $ref: '#/components/schemas/Currency'
-                      - description: Currency of the tax
-                        example: USD
+                    $ref: '#/components/schemas/Currency'
+                    description: Currency of the tax
+                    example: USD
     CreditObject:
       type: object
       required:
@@ -4559,10 +4543,9 @@ components:
           description: 'The amount of credit associated with the invoice, expressed in cents.'
           example: 1200
         amount_currency:
-          allOf:
-            - $ref: '#/components/schemas/Currency'
-            - description: The currency of the credit.
-              example: EUR
+          $ref: '#/components/schemas/Currency'
+          description: The currency of the credit.
+          example: EUR
         before_taxes:
           type: boolean
           description: Indicates whether the credit is applied on the amount before taxes (coupons) or after taxes (credit notes). This flag helps determine the order in which credits are applied to the invoice calculation
@@ -4591,11 +4574,11 @@ components:
               example: coupon
             code:
               type: string
-              description: "The code of the credit applied. It can be the code of the coupon attached to the credit, the credit note's number or the `progressive_billing` invoice number."
+              description: 'The code of the credit applied. It can be the code of the coupon attached to the credit, the credit note''s number or the `progressive_billing` invoice number.'
               example: startup_deal
             name:
               type: string
-              description: "The name of the credit applied. It can be the name of the coupon attached to the credit, the initial invoice's number linked to the credit note or the `progressive_billing` invoice number."
+              description: 'The name of the credit applied. It can be the name of the coupon attached to the credit, the initial invoice''s number linked to the credit note or the `progressive_billing` invoice number.'
               example: Startup Deal
         invoice:
           type: object
@@ -4645,21 +4628,19 @@ components:
         lago_id:
           type: string
           format: uuid
-          description: "The credit note's item unique identifier, created by Lago."
+          description: 'The credit note''s item unique identifier, created by Lago.'
           example: 1a901a90-1a90-1a90-1a90-1a901a901a90
         amount_cents:
           type: integer
-          description: "The credit note's item amount, expressed in cents."
+          description: 'The credit note''s item amount, expressed in cents.'
           example: 100
         amount_currency:
-          allOf:
-            - $ref: '#/components/schemas/Currency'
-            - description: The credit note's item currency.
-              example: EUR
+          $ref: '#/components/schemas/Currency'
+          description: The credit note's item currency.
+          example: EUR
         fee:
-          allOf:
-            - $ref: '#/components/schemas/FeeObject'
-            - description: The fee object related to the credit note item.
+          $ref: '#/components/schemas/FeeObject'
+          description: The fee object related to the credit note item.
     CreditNoteObject:
       type: object
       required:
@@ -4756,10 +4737,9 @@ components:
           description: The description of the credit note.
           example: Free text
         currency:
-          allOf:
-            - $ref: '#/components/schemas/Currency'
-            - description: The currency of the credit note.
-              example: EUR
+          $ref: '#/components/schemas/Currency'
+          description: The currency of the credit note.
+          example: EUR
         total_amount_cents:
           type: integer
           description: 'The total amount of the credit note, expressed in cents.'
@@ -5083,11 +5063,10 @@ components:
           description: The city of the customer's billing address
           nullable: true
         country:
-          allOf:
-            - $ref: '#/components/schemas/Country'
-            - nullable: true
-              description: Country code of the customer's billing address. Format must be ISO 3166 (alpha-2)
-              example: US
+          $ref: '#/components/schemas/Country'
+          nullable: true
+          description: Country code of the customer's billing address. Format must be ISO 3166 (alpha-2)
+          example: US
         state:
           type: string
           example: CA
@@ -5123,7 +5102,7 @@ components:
         provider_customer_id:
           type: string
           example: cus_12345
-          description: "The customer ID within the payment provider's system. If this field is not provided, Lago has the option to create a new customer record within the payment provider's system on behalf of the customer"
+          description: 'The customer ID within the payment provider''s system. If this field is not provided, Lago has the option to create a new customer record within the payment provider''s system on behalf of the customer'
         sync:
           type: boolean
           example: true
@@ -5131,7 +5110,7 @@ components:
         sync_with_provider:
           type: boolean
           example: true
-          description: "Set this field to `true` if you want to create a customer record in the payment provider's system. This option is applicable only when the `provider_customer_id` is null and the `sync_with_provider` field is set to `true`. By default, the value is set to `false`"
+          description: 'Set this field to `true` if you want to create a customer record in the payment provider''s system. This option is applicable only when the `provider_customer_id` is null and the `sync_with_provider` field is set to `true`. By default, the value is set to `false`'
         document_locale:
           type: string
           example: fr
@@ -5170,11 +5149,11 @@ components:
         external_customer_id:
           type: string
           example: cus_12345
-          description: "The customer ID within the integration's system. If this field is not provided, Lago has the option to create a new customer record within the integration's system on behalf of the customer."
+          description: 'The customer ID within the integration''s system. If this field is not provided, Lago has the option to create a new customer record within the integration''s system on behalf of the customer.'
         sync_with_provider:
           type: boolean
           example: true
-          description: "Set this field to `true` if you want to create a customer record in the integration's system. This option is applicable only when the `external_customer_id` is null and the `sync_with_provider` field is set to `true`. By default, the value is set to `false`"
+          description: 'Set this field to `true` if you want to create a customer record in the integration''s system. This option is applicable only when the `external_customer_id` is null and the `sync_with_provider` field is set to `true`. By default, the value is set to `false`'
         subsidiary_id:
           type: string
           example: '2'
@@ -5271,10 +5250,9 @@ components:
           example: 123
           description: 'The amount in cents, tax excluded, consumed by the customer for a specific charge item.'
         amount_currency:
-          allOf:
-            - $ref: '#/components/schemas/Currency'
-            - description: The currency of a usage item consumed by the customer.
-              example: EUR
+          $ref: '#/components/schemas/Currency'
+          description: The currency of a usage item consumed by the customer.
+          example: EUR
         charge:
           type: object
           description: Object listing all the properties for a specific charge item.
@@ -5368,16 +5346,14 @@ components:
               description: The city of the customer's billing address
               nullable: true
             country:
-              allOf:
-                - $ref: '#/components/schemas/Country'
-                - nullable: true
-                  description: Country code of the customer's billing address. Format must be ISO 3166 (alpha-2)
-                  example: US
+              $ref: '#/components/schemas/Country'
+              nullable: true
+              description: Country code of the customer's billing address. Format must be ISO 3166 (alpha-2)
+              example: US
             currency:
-              allOf:
-                - $ref: '#/components/schemas/Currency'
-                - description: Currency of the customer. Format must be ISO 4217
-                  nullable: true
+              $ref: '#/components/schemas/Currency'
+              description: Currency of the customer. Format must be ISO 4217
+              nullable: true
             email:
               type: string
               format: email
@@ -5447,10 +5423,9 @@ components:
               description: The tax identification number of the customer
               nullable: true
             timezone:
-              allOf:
-                - $ref: '#/components/schemas/Timezone'
-                - description: "The customer's timezone, used for billing purposes in their local time. Overrides the organization's timezone"
-                  nullable: true
+              $ref: '#/components/schemas/Timezone'
+              description: 'The customer''s timezone, used for billing purposes in their local time. Overrides the organization''s timezone'
+              nullable: true
             url:
               type: string
               example: 'http://hooli.com'
@@ -5509,11 +5484,11 @@ components:
                   external_customer_id:
                     type: string
                     example: cus_12345
-                    description: "The customer ID within the integration's system. If this field is not provided, Lago has the option to create a new customer record within the integration's system on behalf of the customer."
+                    description: 'The customer ID within the integration''s system. If this field is not provided, Lago has the option to create a new customer record within the integration''s system on behalf of the customer.'
                   sync_with_provider:
                     type: boolean
                     example: true
-                    description: "Set this field to `true` if you want to create a customer record in the integration's system. This option is applicable only when the `external_customer_id` is null and the `sync_with_provider` field is set to `true`. By default, the value is set to `false`"
+                    description: 'Set this field to `true` if you want to create a customer record in the integration''s system. This option is applicable only when the `external_customer_id` is null and the `sync_with_provider` field is set to `true`. By default, the value is set to `false`'
                   subsidiary_id:
                     type: string
                     example: '2'
@@ -5596,11 +5571,11 @@ components:
             sequential_id:
               type: integer
               example: 1
-              description: "The unique identifier assigned to the customer within the organization's scope. This identifier is used to track and reference the customer's order of creation within the organization's system. It ensures that each customer has a distinct `sequential_id`` associated with them, allowing for easy identification and sorting based on the order of creation"
+              description: 'The unique identifier assigned to the customer within the organization''s scope. This identifier is used to track and reference the customer''s order of creation within the organization''s system. It ensures that each customer has a distinct `sequential_id`` associated with them, allowing for easy identification and sorting based on the order of creation'
             slug:
               type: string
               example: LAG-1234-001
-              description: "A concise and unique identifier for the customer, formed by combining the Organization's `name`, `id`, and customer's `sequential_id`"
+              description: 'A concise and unique identifier for the customer, formed by combining the Organization''s `name`, `id`, and customer''s `sequential_id`'
             external_id:
               type: string
               example: 5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba
@@ -5616,26 +5591,23 @@ components:
               description: The second line of the billing address
               nullable: true
             applicable_timezone:
-              allOf:
-                - $ref: '#/components/schemas/Timezone'
-                - description: "The customer's applicable timezone, used for billing purposes in their local time."
+              $ref: '#/components/schemas/Timezone'
+              description: 'The customer''s applicable timezone, used for billing purposes in their local time.'
             city:
               type: string
               example: Woodland Hills
               description: The city of the customer's billing address
               nullable: true
             country:
-              allOf:
-                - $ref: '#/components/schemas/Country'
-                - nullable: true
-                  description: Country code of the customer's billing address. Format must be ISO 3166 (alpha-2)
-                  example: US
+              $ref: '#/components/schemas/Country'
+              nullable: true
+              description: Country code of the customer's billing address. Format must be ISO 3166 (alpha-2)
+              example: US
             currency:
-              allOf:
-                - $ref: '#/components/schemas/Currency'
-                - example: USD
-                  description: Currency of the customer. Format must be ISO 4217
-                  nullable: true
+              $ref: '#/components/schemas/Currency'
+              example: USD
+              description: Currency of the customer. Format must be ISO 4217
+              nullable: true
             email:
               type: string
               format: email
@@ -5698,10 +5670,9 @@ components:
               description: The tax identification number of the customer
               nullable: true
             timezone:
-              allOf:
-                - $ref: '#/components/schemas/Timezone'
-                - description: "The customer's timezone, used for billing purposes in their local time. Overrides the organization's timezone"
-                  nullable: true
+              $ref: '#/components/schemas/Timezone'
+              description: 'The customer''s timezone, used for billing purposes in their local time. Overrides the organization''s timezone'
+              nullable: true
             url:
               type: string
               example: 'http://hooli.com'
@@ -5831,10 +5802,9 @@ components:
           example: 1a901a90-1a90-1a90-1a90-1a901a901a90
           description: A unique identifier associated with the invoice related to this particular usage record.
         currency:
-          allOf:
-            - $ref: '#/components/schemas/Currency'
-            - description: The currency of the customer's current usage.
-              example: EUR
+          $ref: '#/components/schemas/Currency'
+          description: The currency of the customer's current usage.
+          example: EUR
         amount_cents:
           type: integer
           description: 'The amount in cents, tax excluded.'
@@ -6010,7 +5980,7 @@ components:
           type: string
           format: date-time
           example: '2022-04-29T08:59:51Z'
-          description: "The creation date of the event's record in the Lago application, presented in the ISO 8601 datetime format, specifically in Coordinated Universal Time (UTC). It provides the precise timestamp of when the event's record was created within the Lago application"
+          description: 'The creation date of the event''s record in the Lago application, presented in the ISO 8601 datetime format, specifically in Coordinated Universal Time (UTC). It provides the precise timestamp of when the event''s record was created within the Lago application'
     Fee:
       type: object
       required:
@@ -6119,10 +6089,9 @@ components:
           description: 'The cost of this specific fee, including any applicable taxes, with precision.'
           example: '1.0212'
         amount_currency:
-          allOf:
-            - $ref: '#/components/schemas/Currency'
-            - description: The currency of this specific fee. It indicates the monetary unit in which the fee's cost is expressed.
-              example: EUR
+          $ref: '#/components/schemas/Currency'
+          description: The currency of this specific fee. It indicates the monetary unit in which the fee's cost is expressed.
+          example: EUR
         taxes_amount_cents:
           type: integer
           description: The cost of the tax associated with this specific fee.
@@ -6148,10 +6117,9 @@ components:
           description: 'The cost of this specific fee, including any applicable taxes.'
           example: 120
         total_amount_currency:
-          allOf:
-            - $ref: '#/components/schemas/Currency'
-            - description: 'The currency of this specific fee, including any applicable taxes.'
-              example: EUR
+          $ref: '#/components/schemas/Currency'
+          description: 'The currency of this specific fee, including any applicable taxes.'
+          example: EUR
         events_count:
           type: integer
           description: The number of events that have been sent and used to charge the customer. This field indicates the count or quantity of events that have been processed and considered in the charging process.
@@ -6215,183 +6183,182 @@ components:
           description: Unique identifier assigned to the transaction. This field is specifically displayed when the fee type is `charge` and the payment for the fee is made in advance (`pay_in_advance` is set to `true`).
           example: transaction_1234567890
         amount_details:
-          allOf:
-            - type: object
-              properties:
-                graduated_ranges:
-                  type: array
-                  description: 'Graduated ranges, used for a `graduated` charge model.'
-                  items:
-                    type: object
-                    required:
-                      - units
-                      - from_value
-                      - to_value
-                      - flat_unit_amount
-                      - per_unit_amount
-                      - per_unit_total_amount
-                      - total_with_flat_amount
-                    properties:
-                      units:
-                        type: string
-                        pattern: '^[0-9]+.?[0-9]*$'
-                        example: '10.0'
-                        description: Total units received in Lago.
-                      from_value:
-                        type: integer
-                        description: Lower value of a tier. It is either 0 or the previous range's `to_value + 1`.
-                        example: 0
-                      to_value:
-                        type: integer
-                        description: |-
-                          Highest value of a tier.
-                          - This value is higher than the from_value of the same tier.
-                          - This value is null for the last tier.
-                        nullable: true
-                        example: 10
-                      flat_unit_amount:
-                        type: string
-                        description: Flat unit amount within a specified tier.
-                        example: '1.0'
-                      per_unit_amount:
-                        type: string
-                        description: Amount per unit within a specified tier.
-                        example: '1.0'
-                      per_unit_total_amount:
-                        type: string
-                        description: Total amount of received units to be charged within a specified tier.
-                        example: '10.0'
-                      total_with_flat_amount:
-                        type: string
-                        description: 'Total amount to be charged for a specific tier, taking into account the flat_unit_amount and the per_unit_total_amount.'
-                        example: '11.0'
-                graduated_percentage_ranges:
-                  type: array
-                  description: 'Graduated percentage ranges, used for a `graduated_percentage` charge model.'
-                  items:
-                    type: object
-                    required:
-                      - units
-                      - from_value
-                      - to_value
-                      - flat_unit_amount
-                      - rate
-                      - per_unit_total_amount
-                      - total_with_flat_amount
-                    properties:
-                      units:
-                        type: string
-                        pattern: '^[0-9]+.?[0-9]*$'
-                        example: '10.0'
-                        description: Total units received in Lago.
-                      from_value:
-                        type: integer
-                        description: Lower value of a tier. It is either 0 or the previous range's `to_value + 1`.
-                        example: 0
-                      to_value:
-                        type: integer
-                        description: |-
-                          Highest value of a tier.
-                          - This value is higher than the from_value of the same tier.
-                          - This value is null for the last tier.
-                        nullable: true
-                        example: 10
-                      flat_unit_amount:
-                        type: string
-                        description: Flat unit amount within a specified tier.
-                        example: '1.0'
-                      rate:
-                        type: string
-                        format: '^[0-9]+.?[0-9]*$'
-                        description: Percentage rate applied within a specified tier.
-                        example: '1.0'
-                      per_unit_total_amount:
-                        type: string
-                        description: Total amount of received units to be charged within a specified tier.
-                        example: '10.0'
-                      total_with_flat_amount:
-                        type: string
-                        description: 'Total amount to be charged for a specific tier, taking into account the flat_unit_amount and the per_unit_total_amount.'
-                        example: '11.0'
-                free_units:
-                  type: string
-                  pattern: '^[0-9]+.?[0-9]*$'
-                  example: '10.0'
-                  description: The quantity of units that are provided free of charge for each billing period in a `package` charge model.
-                paid_units:
-                  type: string
-                  pattern: '^[0-9]+.?[0-9]*$'
-                  example: '40.0'
-                  description: The quantity of units that are not provided free of charge for each billing period in a `package` charge model.
-                per_package_size:
-                  type: integer
-                  description: 'The quantity of units included, defined for Package or Percentage charge model.'
-                  example: 1000
-                per_package_unit_amount:
-                  type: string
-                  pattern: '^[0-9]+.?[0-9]*$'
-                  description: 'Total amount to charge for received paid_units, defined for Package or Percentage charge model.'
-                  example: '0.5'
-                units:
-                  type: string
-                  pattern: '^[0-9]+.?[0-9]*$'
-                  example: '20.0'
-                  description: The total units received in Lago for the Percentage charge model.
-                free_events:
-                  type: integer
-                  example: 10
-                  description: Total number of free events allowed for the Percentage charge model.
-                rate:
-                  type: string
-                  format: '^[0-9]+.?[0-9]*$'
-                  description: Percentage rate applied for the Percentage charge model.
-                  example: '1.0'
-                per_unit_total_amount:
-                  type: string
-                  description: Total amount of received units to be charged for the Percentage charge model.
-                  example: '10.0'
-                paid_events:
-                  type: integer
-                  example: 20
-                  description: Total number of paid events for the Percentage charge model.
-                fixed_fee_unit_amount:
-                  type: string
-                  description: Fixed fee unit price per received paid_event for the Percentage charge model.
-                  example: '1.0'
-                fixed_fee_total_amount:
-                  type: string
-                  description: Total amount to charge for received paid_events for the Percentage charge model.
-                  example: '20.0'
-                min_max_adjustment_total_amount:
-                  type: string
-                  description: Total adjustment amount linked to minimum and maximum spending per transaction for the Percentage charge model.
-                  example: '20.0'
-                volume_ranges:
-                  type: array
-                  description: 'Volume ranges, used for a `volume` charge model.'
-                  items:
-                    type: object
-                    required:
-                      - per_unit_amount
-                      - flat_unit_amount
-                      - per_unit_total_amount
-                    properties:
-                      per_unit_amount:
-                        type: string
-                        pattern: '^[0-9]+.?[0-9]*$'
-                        description: 'The flat amount for a whole tier, excluding tax, for a `volume` charge model.'
-                        example: '0.5'
-                      flat_unit_amount:
-                        type: string
-                        pattern: '^[0-9]+.?[0-9]*$'
-                        description: 'The unit price, excluding tax, for a specific tier of a `volume` charge model.'
-                        example: '10.0'
-                      per_unit_total_amount:
-                        type: string
-                        pattern: '^[0-9]+.?[0-9]*$'
-                        description: Total amount of received units to be charged.
-                        example: '10.0'
-            - description: List of all unit amount details for calculating the fee.
+          description: List of all unit amount details for calculating the fee.
+          type: object
+          properties:
+            graduated_ranges:
+              type: array
+              description: 'Graduated ranges, used for a `graduated` charge model.'
+              items:
+                type: object
+                required:
+                  - units
+                  - from_value
+                  - to_value
+                  - flat_unit_amount
+                  - per_unit_amount
+                  - per_unit_total_amount
+                  - total_with_flat_amount
+                properties:
+                  units:
+                    type: string
+                    pattern: '^[0-9]+.?[0-9]*$'
+                    example: '10.0'
+                    description: Total units received in Lago.
+                  from_value:
+                    type: integer
+                    description: Lower value of a tier. It is either 0 or the previous range's `to_value + 1`.
+                    example: 0
+                  to_value:
+                    type: integer
+                    description: |-
+                      Highest value of a tier.
+                      - This value is higher than the from_value of the same tier.
+                      - This value is null for the last tier.
+                    nullable: true
+                    example: 10
+                  flat_unit_amount:
+                    type: string
+                    description: Flat unit amount within a specified tier.
+                    example: '1.0'
+                  per_unit_amount:
+                    type: string
+                    description: Amount per unit within a specified tier.
+                    example: '1.0'
+                  per_unit_total_amount:
+                    type: string
+                    description: Total amount of received units to be charged within a specified tier.
+                    example: '10.0'
+                  total_with_flat_amount:
+                    type: string
+                    description: 'Total amount to be charged for a specific tier, taking into account the flat_unit_amount and the per_unit_total_amount.'
+                    example: '11.0'
+            graduated_percentage_ranges:
+              type: array
+              description: 'Graduated percentage ranges, used for a `graduated_percentage` charge model.'
+              items:
+                type: object
+                required:
+                  - units
+                  - from_value
+                  - to_value
+                  - flat_unit_amount
+                  - rate
+                  - per_unit_total_amount
+                  - total_with_flat_amount
+                properties:
+                  units:
+                    type: string
+                    pattern: '^[0-9]+.?[0-9]*$'
+                    example: '10.0'
+                    description: Total units received in Lago.
+                  from_value:
+                    type: integer
+                    description: Lower value of a tier. It is either 0 or the previous range's `to_value + 1`.
+                    example: 0
+                  to_value:
+                    type: integer
+                    description: |-
+                      Highest value of a tier.
+                      - This value is higher than the from_value of the same tier.
+                      - This value is null for the last tier.
+                    nullable: true
+                    example: 10
+                  flat_unit_amount:
+                    type: string
+                    description: Flat unit amount within a specified tier.
+                    example: '1.0'
+                  rate:
+                    type: string
+                    format: '^[0-9]+.?[0-9]*$'
+                    description: Percentage rate applied within a specified tier.
+                    example: '1.0'
+                  per_unit_total_amount:
+                    type: string
+                    description: Total amount of received units to be charged within a specified tier.
+                    example: '10.0'
+                  total_with_flat_amount:
+                    type: string
+                    description: 'Total amount to be charged for a specific tier, taking into account the flat_unit_amount and the per_unit_total_amount.'
+                    example: '11.0'
+            free_units:
+              type: string
+              pattern: '^[0-9]+.?[0-9]*$'
+              example: '10.0'
+              description: The quantity of units that are provided free of charge for each billing period in a `package` charge model.
+            paid_units:
+              type: string
+              pattern: '^[0-9]+.?[0-9]*$'
+              example: '40.0'
+              description: The quantity of units that are not provided free of charge for each billing period in a `package` charge model.
+            per_package_size:
+              type: integer
+              description: 'The quantity of units included, defined for Package or Percentage charge model.'
+              example: 1000
+            per_package_unit_amount:
+              type: string
+              pattern: '^[0-9]+.?[0-9]*$'
+              description: 'Total amount to charge for received paid_units, defined for Package or Percentage charge model.'
+              example: '0.5'
+            units:
+              type: string
+              pattern: '^[0-9]+.?[0-9]*$'
+              example: '20.0'
+              description: The total units received in Lago for the Percentage charge model.
+            free_events:
+              type: integer
+              example: 10
+              description: Total number of free events allowed for the Percentage charge model.
+            rate:
+              type: string
+              format: '^[0-9]+.?[0-9]*$'
+              description: Percentage rate applied for the Percentage charge model.
+              example: '1.0'
+            per_unit_total_amount:
+              type: string
+              description: Total amount of received units to be charged for the Percentage charge model.
+              example: '10.0'
+            paid_events:
+              type: integer
+              example: 20
+              description: Total number of paid events for the Percentage charge model.
+            fixed_fee_unit_amount:
+              type: string
+              description: Fixed fee unit price per received paid_event for the Percentage charge model.
+              example: '1.0'
+            fixed_fee_total_amount:
+              type: string
+              description: Total amount to charge for received paid_events for the Percentage charge model.
+              example: '20.0'
+            min_max_adjustment_total_amount:
+              type: string
+              description: Total adjustment amount linked to minimum and maximum spending per transaction for the Percentage charge model.
+              example: '20.0'
+            volume_ranges:
+              type: array
+              description: 'Volume ranges, used for a `volume` charge model.'
+              items:
+                type: object
+                required:
+                  - per_unit_amount
+                  - flat_unit_amount
+                  - per_unit_total_amount
+                properties:
+                  per_unit_amount:
+                    type: string
+                    pattern: '^[0-9]+.?[0-9]*$'
+                    description: 'The flat amount for a whole tier, excluding tax, for a `volume` charge model.'
+                    example: '0.5'
+                  flat_unit_amount:
+                    type: string
+                    pattern: '^[0-9]+.?[0-9]*$'
+                    description: 'The unit price, excluding tax, for a specific tier of a `volume` charge model.'
+                    example: '10.0'
+                  per_unit_total_amount:
+                    type: string
+                    pattern: '^[0-9]+.?[0-9]*$'
+                    description: Total amount of received units to be charged.
+                    example: '10.0'
         item:
           type: object
           description: Item attached to the fee
@@ -6512,10 +6479,9 @@ components:
           description: 'The total amount of revenue for a period, expressed in cents.'
           example: 50000
         currency:
-          allOf:
-            - $ref: '#/components/schemas/Currency'
-            - description: The currency of revenue analytics. Format must be ISO 4217.
-              example: USD
+          $ref: '#/components/schemas/Currency'
+          description: The currency of revenue analytics. Format must be ISO 4217.
+          example: USD
         invoices_count:
           type: integer
           description: Contains invoices count.
@@ -6709,10 +6675,9 @@ components:
           description: 'The total amount of MRR, expressed in cents.'
           example: 50000
         currency:
-          allOf:
-            - $ref: '#/components/schemas/Currency'
-            - description: The currency of MRR analytics. Format must be ISO 4217.
-              example: USD
+          $ref: '#/components/schemas/Currency'
+          description: The currency of MRR analytics. Format must be ISO 4217.
+          example: USD
     Mrrs:
       type: object
       required:
@@ -6770,10 +6735,9 @@ components:
           description: 'The total amount of revenue for a period, expressed in cents.'
           example: 50000
         currency:
-          allOf:
-            - $ref: '#/components/schemas/Currency'
-            - description: The currency of revenue analytics. Format must be ISO 4217.
-              example: USD
+          $ref: '#/components/schemas/Currency'
+          description: The currency of revenue analytics. Format must be ISO 4217.
+          example: USD
     InvoiceCollections:
       type: object
       required:
@@ -6803,10 +6767,9 @@ components:
           description: 'The total amount of revenue for a period, expressed in cents.'
           example: 50000
         currency:
-          allOf:
-            - $ref: '#/components/schemas/Currency'
-            - description: The currency of revenue analytics. Format must be ISO 4217.
-              example: USD
+          $ref: '#/components/schemas/Currency'
+          description: The currency of revenue analytics. Format must be ISO 4217.
+          example: USD
     InvoicedUsages:
       type: object
       required:
@@ -6866,7 +6829,7 @@ components:
               example: 1a901a90-1a90-1a90-1a90-1a901a901a90
             sequential_id:
               type: integer
-              description: "This ID helps in uniquely identifying and organizing the invoices associated with a specific customer. It provides a sequential numbering system specific to the customer, allowing for easy tracking and management of invoices within the customer's context."
+              description: 'This ID helps in uniquely identifying and organizing the invoices associated with a specific customer. It provides a sequential numbering system specific to the customer, allowing for easy tracking and management of invoices within the customer''s context.'
               example: 2
             number:
               type: string
@@ -6932,10 +6895,9 @@ components:
                 - `failed`: the payment of the invoice has failed or encountered an error during processing.
               example: succeeded
             currency:
-              allOf:
-                - $ref: '#/components/schemas/Currency'
-                - description: The currency of the invoice issued.
-                  example: EUR
+              $ref: '#/components/schemas/Currency'
+              description: The currency of the invoice issued.
+              example: EUR
             fees_amount_cents:
               type: integer
               description: 'The total sum of fees amount in cents. It calculates the cumulative amount of all the fees associated with the invoice, providing a consolidated value.'
@@ -6993,9 +6955,8 @@ components:
         - type: object
           properties:
             customer:
-              allOf:
-                - $ref: '#/components/schemas/CustomerObject'
-                - description: The customer on which the invoice applies. It refers to the customer account or entity associated with the invoice.
+              $ref: '#/components/schemas/CustomerObject'
+              description: The customer on which the invoice applies. It refers to the customer account or entity associated with the invoice.
             metadata:
               type: array
               items:
@@ -7066,10 +7027,9 @@ components:
               description: Unique identifier assigned to the customer in your application.
               example: hooli_1234
             currency:
-              allOf:
-                - $ref: '#/components/schemas/Currency'
-                - description: The currency of the invoice.
-                  example: EUR
+              $ref: '#/components/schemas/Currency'
+              description: The currency of the invoice.
+              example: EUR
             fees:
               type: array
               items:
@@ -7173,7 +7133,7 @@ components:
         invoice_grace_period:
           type: integer
           example: 3
-          description: "The grace period, expressed in days, for finalizing the invoice. This period refers to the additional time granted to your customers beyond the invoice due date to adjust usage and line items. Can be overwritten by the customer's grace period."
+          description: 'The grace period, expressed in days, for finalizing the invoice. This period refers to the additional time granted to your customers beyond the invoice due date to adjust usage and line items. Can be overwritten by the customer''s grace period.'
         document_locale:
           type: string
           example: en
@@ -7219,16 +7179,14 @@ components:
           description: The array containing your webhooks URLs.
           nullable: true
         country:
-          allOf:
-            - $ref: '#/components/schemas/Country'
-            - nullable: true
-              description: The country of your organization.
-              example: US
+          $ref: '#/components/schemas/Country'
+          nullable: true
+          description: The country of your organization.
+          example: US
         default_currency:
-          allOf:
-            - $ref: '#/components/schemas/Currency'
-            - description: The default currency of an organization.
-              example: USD
+          $ref: '#/components/schemas/Currency'
+          description: The default currency of an organization.
+          example: USD
         address_line1:
           type: string
           example: 100 Brex Street
@@ -7297,10 +7255,9 @@ components:
           description: The tax identification number of your organization.
           nullable: true
         timezone:
-          allOf:
-            - $ref: '#/components/schemas/Timezone'
-            - description: "Your organization's timezone, used for billing purposes in your own local time. Can be overwritten by the customer's timezone."
-              example: America/New_York
+          $ref: '#/components/schemas/Timezone'
+          description: 'Your organization''s timezone, used for billing purposes in your own local time. Can be overwritten by the customer''s timezone.'
+          example: America/New_York
         billing_configuration:
           $ref: '#/components/schemas/OrganizationBillingConfiguration'
         taxes:
@@ -7326,16 +7283,14 @@ components:
               description: 'The URL of your newest updated webhook endpoint. This URL allows your organization to receive important messages, notifications, or data from the Lago system. By configuring your webhook endpoint to this URL, you can ensure that your organization stays informed and receives relevant information in a timely manner.'
               nullable: true
             country:
-              allOf:
-                - $ref: '#/components/schemas/Country'
-                - nullable: true
-                  description: The country of your organization.
-                  example: US
+              $ref: '#/components/schemas/Country'
+              nullable: true
+              description: The country of your organization.
+              example: US
             default_currency:
-              allOf:
-                - $ref: '#/components/schemas/Currency'
-                - description: The default currency of an organization.
-                  example: USD
+              $ref: '#/components/schemas/Currency'
+              description: The default currency of an organization.
+              example: USD
             address_line1:
               type: string
               example: 100 Brex Street
@@ -7404,10 +7359,9 @@ components:
               description: The tax identification number of your organization.
               nullable: true
             timezone:
-              allOf:
-                - $ref: '#/components/schemas/Timezone'
-                - description: "Your organization's timezone, used for billing purposes in your own local time. Can be overwritten by the customer's timezone."
-                  example: America/New_York
+              $ref: '#/components/schemas/Timezone'
+              description: 'Your organization''s timezone, used for billing purposes in your own local time. Can be overwritten by the customer''s timezone.'
+              example: America/New_York
             email_settings:
               type: array
               description: 'Represents the email settings of the organization. It allows you to define which documents are sent by email. The field value determines the types of documents that trigger email notifications. Possible values for are `invoice.finalized` and `credit_note.created`. By configuring this field, you can specify whether invoices, credit notes, or both should be sent to recipients via email.'
@@ -7442,10 +7396,9 @@ components:
           description: 'The total amount of revenue for a period, expressed in cents.'
           example: 50000
         currency:
-          allOf:
-            - $ref: '#/components/schemas/Currency'
-            - description: The currency of revenue analytics. Format must be ISO 4217.
-              example: USD
+          $ref: '#/components/schemas/Currency'
+          description: The currency of revenue analytics. Format must be ISO 4217.
+          example: USD
         lago_invoice_ids:
           type: array
           items:
@@ -7519,10 +7472,9 @@ components:
           description: 'The sum of the total amounts of all the invoices included in the payment request, expressed in cents.'
           example: 100
         amount_currency:
-          allOf:
-            - $ref: '#/components/schemas/Currency'
-            - description: The currency of the payment request.
-              example: EUR
+          $ref: '#/components/schemas/Currency'
+          description: The currency of the payment request.
+          example: EUR
         payment_status:
           type: string
           enum:
@@ -7604,10 +7556,9 @@ components:
               description: 'The base cost of the plan, excluding any applicable taxes, that is billed on a recurring basis. This value is defined at 0 if your plan is a pay-as-you-go plan.'
               example: 10000
             amount_currency:
-              allOf:
-                - $ref: '#/components/schemas/Currency'
-                - description: "The currency of the plan. It indicates the monetary unit in which the plan's cost, including taxes and usage-based charges, is expressed."
-                  example: USD
+              $ref: '#/components/schemas/Currency'
+              description: 'The currency of the plan. It indicates the monetary unit in which the plan''s cost, including taxes and usage-based charges, is expressed.'
+              example: USD
             trial_period:
               type: number
               description: The duration in days during which the base cost of the plan is offered for free.
@@ -7618,7 +7569,7 @@ components:
               example: true
             bill_charges_monthly:
               type: boolean
-              description: "This field, when set to `true`, enables to invoice usage-based charges on monthly basis, even if the cadence of the plan is yearly. This allows customers to pay charges overage on a monthly basis. This can be set to true only if the plan's interval is `yearly`."
+              description: 'This field, when set to `true`, enables to invoice usage-based charges on monthly basis, even if the cadence of the plan is yearly. This allows customers to pay charges overage on a monthly basis. This can be set to true only if the plan''s interval is `yearly`.'
               nullable: true
               example: null
             tax_codes:
@@ -7692,9 +7643,8 @@ components:
                     description: 'The minimum spending amount required for the charge, measured in cents and excluding any applicable taxes. It indicates the minimum amount that needs to be charged for each billing period.'
                     example: 0
                   properties:
-                    allOf:
-                      - $ref: '#/components/schemas/ChargeProperties'
-                      - description: List of all thresholds utilized for calculating the charge.
+                    $ref: '#/components/schemas/ChargeProperties'
+                    description: List of all thresholds utilized for calculating the charge.
                   filters:
                     type: array
                     description: List of filters used to apply differentiated pricing based on additional event properties.
@@ -7791,10 +7741,9 @@ components:
           description: 'The base cost of the plan, excluding any applicable taxes, that is billed on a recurring basis. This value is defined at 0 if your plan is a pay-as-you-go plan.'
           example: 10000
         amount_currency:
-          allOf:
-            - $ref: '#/components/schemas/Currency'
-            - description: "The currency of the plan. It indicates the monetary unit in which the plan's cost, including taxes and usage-based charges, is expressed."
-              example: USD
+          $ref: '#/components/schemas/Currency'
+          description: 'The currency of the plan. It indicates the monetary unit in which the plan''s cost, including taxes and usage-based charges, is expressed.'
+          example: USD
         description:
           type: string
           description: The description on the plan.
@@ -7845,9 +7794,8 @@ components:
                 description: 'The minimum spending amount required for the charge, measured in cents and excluding any applicable taxes. It indicates the minimum amount that needs to be charged for each billing period.'
                 example: 0
               properties:
-                allOf:
-                  - $ref: '#/components/schemas/ChargeProperties'
-                  - description: List of all thresholds utilized for calculating the charge.
+                $ref: '#/components/schemas/ChargeProperties'
+                description: List of all thresholds utilized for calculating the charge.
               filters:
                 type: array
                 description: List of filters used to apply differentiated pricing based on additional event properties.
@@ -7903,10 +7851,9 @@ components:
               description: 'The base cost of the plan, excluding any applicable taxes, that is billed on a recurring basis. This value is defined at 0 if your plan is a pay-as-you-go plan.'
               example: 10000
             amount_currency:
-              allOf:
-                - $ref: '#/components/schemas/Currency'
-                - description: "The currency of the plan. It indicates the monetary unit in which the plan's cost, including taxes and usage-based charges, is expressed."
-                  example: USD
+              $ref: '#/components/schemas/Currency'
+              description: 'The currency of the plan. It indicates the monetary unit in which the plan''s cost, including taxes and usage-based charges, is expressed.'
+              example: USD
             trial_period:
               type: number
               description: The duration in days during which the base cost of the plan is offered for free.
@@ -7917,7 +7864,7 @@ components:
               example: true
             bill_charges_monthly:
               type: boolean
-              description: "This field, when set to `true`, enables to invoice usage-based charges on monthly basis, even if the cadence of the plan is yearly. This allows customers to pay charges overage on a monthly basis. This can be set to true only if the plan's interval is `yearly`."
+              description: 'This field, when set to `true`, enables to invoice usage-based charges on monthly basis, even if the cadence of the plan is yearly. This allows customers to pay charges overage on a monthly basis. This can be set to true only if the plan''s interval is `yearly`.'
               nullable: true
               example: null
             tax_codes:
@@ -7996,9 +7943,8 @@ components:
                     description: 'The minimum spending amount required for the charge, measured in cents and excluding any applicable taxes. It indicates the minimum amount that needs to be charged for each billing period.'
                     example: 0
                   properties:
-                    allOf:
-                      - $ref: '#/components/schemas/ChargeProperties'
-                      - description: List of all thresholds utilized for calculating the charge.
+                    $ref: '#/components/schemas/ChargeProperties'
+                    description: List of all thresholds utilized for calculating the charge.
                   filters:
                     type: array
                     description: List of filters used to apply differentiated pricing based on additional event properties.
@@ -8139,10 +8085,9 @@ components:
           description: 'The base cost of the plan, excluding any applicable taxes, that is billed on a recurring basis. This value is defined at 0 if your plan is a pay-as-you-go plan.'
           example: 10000
         amount_currency:
-          allOf:
-            - $ref: '#/components/schemas/Currency'
-            - description: "The currency of the plan. It indicates the monetary unit in which the plan's cost, including taxes and usage-based charges, is expressed."
-              example: USD
+          $ref: '#/components/schemas/Currency'
+          description: 'The currency of the plan. It indicates the monetary unit in which the plan''s cost, including taxes and usage-based charges, is expressed.'
+          example: USD
         trial_period:
           type: number
           description: The duration in days during which the base cost of the plan is offered for free.
@@ -8154,7 +8099,7 @@ components:
         bill_charges_monthly:
           type: boolean
           nullable: true
-          description: "This field, when set to `true`, enables to invoice usage-based charges on monthly basis, even if the cadence of the plan is yearly. This allows customers to pay charges overage on a monthly basis. This can be set to true only if the plan's interval is `yearly`."
+          description: 'This field, when set to `true`, enables to invoice usage-based charges on monthly basis, even if the cadence of the plan is yearly. This allows customers to pay charges overage on a monthly basis. This can be set to true only if the plan''s interval is `yearly`.'
           example: null
         active_subscriptions_count:
           type: integer
@@ -8329,7 +8274,7 @@ components:
             name:
               type: string
               example: Repository A
-              description: "The display name of the subscription on an invoice. This field allows for customization of the subscription's name for billing purposes, especially useful when a single customer has multiple subscriptions using the same plan."
+              description: 'The display name of the subscription on an invoice. This field allows for customization of the subscription''s name for billing purposes, especially useful when a single customer has multiple subscriptions using the same plan.'
             external_id:
               type: string
               example: my_sub_1234567890
@@ -8374,7 +8319,7 @@ components:
               type: string
               example: Repository B
               nullable: true
-              description: "The display name of the subscription on an invoice. This field allows for customization of the subscription's name for billing purposes, especially useful when a single customer has multiple subscriptions using the same plan."
+              description: 'The display name of the subscription on an invoice. This field allows for customization of the subscription''s name for billing purposes, especially useful when a single customer has multiple subscriptions using the same plan.'
             ending_at:
               type: string
               format: date-time
@@ -8429,7 +8374,7 @@ components:
         name:
           type: string
           example: Repository A
-          description: "The display name of the subscription on an invoice. This field allows for customization of the subscription's name for billing purposes, especially useful when a single customer has multiple subscriptions using the same plan."
+          description: 'The display name of the subscription on an invoice. This field allows for customization of the subscription''s name for billing purposes, especially useful when a single customer has multiple subscriptions using the same plan.'
           nullable: true
         plan_code:
           type: string
@@ -8573,12 +8518,11 @@ components:
         - tax
       properties:
         tax:
-          allOf:
-            - $ref: '#/components/schemas/TaxBaseInput'
-            - required:
-                - name
-                - code
-                - rate
+          $ref: '#/components/schemas/TaxBaseInput'
+          required:
+            - name
+            - code
+            - rate
     TaxesPaginated:
       type: object
       required:
@@ -8654,8 +8598,7 @@ components:
         - tax
       properties:
         tax:
-          allOf:
-            - $ref: '#/components/schemas/TaxBaseInput'
+          $ref: '#/components/schemas/TaxBaseInput'
     Timezone:
       type: string
       example: America/Los_Angeles
@@ -8884,10 +8827,9 @@ components:
               description: The rate of conversion between credits and the amount in the specified currency. It indicates the ratio or factor used to convert credits into the corresponding monetary value in the currency of the transaction.
               example: '1.5'
             currency:
-              allOf:
-                - $ref: '#/components/schemas/Currency'
-                - description: The currency of the wallet.
-                  example: USD
+              $ref: '#/components/schemas/Currency'
+              description: The currency of the wallet.
+              example: USD
             paid_credits:
               type: string
               pattern: '^[0-9]+.?[0-9]*$'
@@ -9052,10 +8994,9 @@ components:
           description: The status of the wallet. Possible values are `active` or `terminated`.
           example: active
         currency:
-          allOf:
-            - $ref: '#/components/schemas/Currency'
-            - description: The currency of the wallet.
-              example: USD
+          $ref: '#/components/schemas/Currency'
+          description: The currency of the wallet.
+          example: USD
         name:
           type: string
           description: The name of the wallet.

--- a/src/schemas/AddOnBaseInput.yaml
+++ b/src/schemas/AddOnBaseInput.yaml
@@ -17,10 +17,9 @@ properties:
     description: The cost of the add-on in cents, excluding any applicable taxes, that is billed to a customer. By creating a one-off invoice, you will be able to override this value.
     example: 50000
   amount_currency:
-    allOf:
-      - $ref: './Currency.yaml'
-      - description: The currency of the add-on.
-        example: 'USD'
+    $ref: './Currency.yaml'
+    description: The currency of the add-on.
+    example: 'USD'
   description:
     type: string
     nullable: true

--- a/src/schemas/AddOnCreateInput.yaml
+++ b/src/schemas/AddOnCreateInput.yaml
@@ -3,10 +3,9 @@ required:
   - add_on
 properties:
   add_on:
-    allOf:
-      - $ref: './AddOnBaseInput.yaml'
-      - required:
-        - name
-        - code
-        - amount_cents
-        - amount_currency
+    $ref: './AddOnBaseInput.yaml'
+    required:
+      - name
+      - code
+      - amount_cents
+      - amount_currency

--- a/src/schemas/AddOnObject.yaml
+++ b/src/schemas/AddOnObject.yaml
@@ -29,10 +29,9 @@ properties:
     description: The cost of the add-on in cents, excluding any applicable taxes, that is billed to a customer. By creating a one-off invoice, you will be able to override this value.
     example: 50000
   amount_currency:
-    allOf:
-      - $ref: './Currency.yaml'
-      - description: The currency of the add-on.
-        example: 'USD'
+    $ref: './Currency.yaml'
+    description: The currency of the add-on.
+    example: 'USD'
   description:
     type: string
     nullable: true

--- a/src/schemas/Address.yaml
+++ b/src/schemas/Address.yaml
@@ -17,11 +17,10 @@ properties:
     description: The city of the customer's billing address
     nullable: true
   country:
-    allOf:
-    - $ref: './Country.yaml'
-    - nullable: true
-      description: Country code of the customer's billing address. Format must be ISO 3166 (alpha-2)
-      example: 'US'
+    $ref: './Country.yaml'
+    nullable: true
+    description: Country code of the customer's billing address. Format must be ISO 3166 (alpha-2)
+    example: 'US'
   state:
     type: string
     example: 'CA'

--- a/src/schemas/AppliedCouponInput.yaml
+++ b/src/schemas/AppliedCouponInput.yaml
@@ -41,11 +41,10 @@ properties:
         description: The amount of the coupon in cents. This field is required only for coupon with `fixed_amount` type.
         example: 2000
       amount_currency:
-        allOf:
-          - $ref: "./Currency.yaml"
-          - nullable: true
-            description: The currency of the coupon. This field is required only for coupon with `fixed_amount` type.
-            example: "EUR"
+        $ref: "./Currency.yaml"
+        nullable: true
+        description: The currency of the coupon. This field is required only for coupon with `fixed_amount` type.
+        example: "EUR"
       percentage_rate:
         type: string
         pattern: "^[0-9]+.?[0-9]*$"

--- a/src/schemas/AppliedCouponObject.yaml
+++ b/src/schemas/AppliedCouponObject.yaml
@@ -55,11 +55,10 @@ properties:
     description: The remaining amount in cents for a `fixed_amount` coupon with a frequency set to `once`. This field indicates the remaining balance or value that can still be utilized from the coupon.
     example: 50
   amount_currency:
-    allOf:
-      - $ref: "./Currency.yaml"
-      - nullable: true
-        description: The currency of the coupon. This field is required only for coupon with `fixed_amount` type.
-        example: "EUR"
+    $ref: "./Currency.yaml"
+    nullable: true
+    description: The currency of the coupon. This field is required only for coupon with `fixed_amount` type.
+    example: "EUR"
   percentage_rate:
     type: string
     pattern: "^[0-9]+.?[0-9]*$"

--- a/src/schemas/BaseAppliedTax.yaml
+++ b/src/schemas/BaseAppliedTax.yaml
@@ -31,10 +31,9 @@ properties:
     description: Amount of the tax
     example: 2000
   amount_currency:
-    allOf:
-      - $ref: './Currency.yaml'
-      - description: Currency of the tax
-        example: 'USD'
+    $ref: './Currency.yaml'
+    description: Currency of the tax
+    example: 'USD'
   created_at:
     type: string
     format: 'date-time'

--- a/src/schemas/BillableMetricCreateInput.yaml
+++ b/src/schemas/BillableMetricCreateInput.yaml
@@ -3,9 +3,8 @@ required:
   - billable_metric
 properties:
   billable_metric:
-    allOf:
-    - $ref: './BillableMetricBaseInput.yaml'
-    - required:
+    $ref: './BillableMetricBaseInput.yaml'
+    required:
       - name
       - code
       - aggregation_type

--- a/src/schemas/ChargeFilterInput.yaml
+++ b/src/schemas/ChargeFilterInput.yaml
@@ -7,9 +7,8 @@ properties:
     example: AWS
     nullable: true
   properties:
-    allOf:
-      - $ref: "./ChargeProperties.yaml"
-      - description: List of all thresholds utilized for calculating the charge.
+    $ref: "./ChargeProperties.yaml"
+    description: List of all thresholds utilized for calculating the charge.
   values:
     type: object
     description: "List of possible filter values. The key and values must match one of the billable metric filters."

--- a/src/schemas/ChargeFilterObject.yaml
+++ b/src/schemas/ChargeFilterObject.yaml
@@ -11,9 +11,8 @@ properties:
     example: AWS
     nullable: true
   properties:
-    allOf:
-      - $ref: "./ChargeProperties.yaml"
-      - description: List of all thresholds utilized for calculating the charge.
+    $ref: "./ChargeProperties.yaml"
+    description: List of all thresholds utilized for calculating the charge.
   values:
     type: object
     description: "List of possible filter values. The key and values must match one of the billable metric filters."

--- a/src/schemas/ChargeObject.yaml
+++ b/src/schemas/ChargeObject.yaml
@@ -75,9 +75,8 @@ properties:
     description: The minimum spending amount required for the charge, measured in cents and excluding any applicable taxes. It indicates the minimum amount that needs to be charged for each billing period.
     example: 1200
   properties:
-    allOf:
-      - $ref: "./ChargeProperties.yaml"
-      - description: List of all thresholds utilized for calculating the charge.
+    $ref: "./ChargeProperties.yaml"
+    description: List of all thresholds utilized for calculating the charge.
   filters:
     type: array
     description: List of filters used to apply differentiated pricing based on additional event properties.

--- a/src/schemas/CouponBaseInput.yaml
+++ b/src/schemas/CouponBaseInput.yaml
@@ -30,11 +30,10 @@ properties:
     description: The amount of the coupon in cents. This field is required only for coupon with `fixed_amount` type.
     example: 5000
   amount_currency:
-    allOf:
-      - $ref: "./Currency.yaml"
-      - description: The currency of the coupon. This field is required only for coupon with `fixed_amount` type.
-        nullable: true
-        example: "USD"
+    $ref: "./Currency.yaml"
+    description: The currency of the coupon. This field is required only for coupon with `fixed_amount` type.
+    nullable: true
+    example: "USD"
   reusable:
     type: boolean
     description: Indicates whether the coupon can be reused or not. If set to `true`, the coupon is reusable, meaning it can be applied multiple times to the same customer. If set to `false`, the coupon can only be used once and is not reusable. If not specified, this field is set to `true` by default.

--- a/src/schemas/CouponCreateInput.yaml
+++ b/src/schemas/CouponCreateInput.yaml
@@ -3,9 +3,8 @@ required:
   - coupon
 properties:
   coupon:
-    allOf:
-    - $ref: './CouponBaseInput.yaml'
-    - required:
+    $ref: './CouponBaseInput.yaml'
+    required:
       - name
       - code
       - coupon_type

--- a/src/schemas/CouponObject.yaml
+++ b/src/schemas/CouponObject.yaml
@@ -46,11 +46,10 @@ properties:
     description: The amount of the coupon in cents. This field is required only for coupon with `fixed_amount` type.
     example: 5000
   amount_currency:
-    allOf:
-      - $ref: "./Currency.yaml"
-      - nullable: true
-        description: The currency of the coupon. This field is required only for coupon with `fixed_amount` type.
-        example: "USD"
+     $ref: "./Currency.yaml"
+     nullable: true
+     description: The currency of the coupon. This field is required only for coupon with `fixed_amount` type.
+     example: "USD"
   reusable:
     type: boolean
     description: Indicates whether the coupon can be reused or not. If set to `true`, the coupon is reusable, meaning it can be applied multiple times to the same customer. If set to `false`, the coupon can only be used once and is not reusable. If not specified, this field is set to `true` by default.

--- a/src/schemas/CouponUpdateInput.yaml
+++ b/src/schemas/CouponUpdateInput.yaml
@@ -3,5 +3,4 @@ required:
   - coupon
 properties:
   coupon:
-    allOf:
-    - $ref: './CouponBaseInput.yaml'
+    $ref: './CouponBaseInput.yaml'

--- a/src/schemas/CreditNoteEstimated.yaml
+++ b/src/schemas/CreditNoteEstimated.yaml
@@ -26,10 +26,9 @@ properties:
         description: The invoice unique number, related to the credit note.
         example: 'LAG-1234'
       currency:
-        allOf:
-          - $ref: './Currency.yaml'
-          - description: The currency of the credit note.
-            example: 'EUR'
+        $ref: './Currency.yaml'
+        description: The currency of the credit note.
+        example: 'EUR'
       taxes_amount_cents:
         type: integer
         description: The tax amount of the credit note, expressed in cents.
@@ -107,7 +106,6 @@ properties:
               description: Amount of the tax
               example: 2000
             amount_currency:
-              allOf:
-                - $ref: './Currency.yaml'
-                - description: Currency of the tax
-                  example: 'USD'
+              $ref: './Currency.yaml'
+              description: Currency of the tax
+              example: 'USD'

--- a/src/schemas/CreditNoteItemObject.yaml
+++ b/src/schemas/CreditNoteItemObject.yaml
@@ -15,11 +15,9 @@ properties:
     description: The credit note's item amount, expressed in cents.
     example: 100
   amount_currency:
-    allOf:
-      - $ref: './Currency.yaml'
-      - description: The credit note's item currency.
-        example: 'EUR'
+    $ref: './Currency.yaml'
+    description: The credit note's item currency.
+    example: 'EUR'
   fee:
-    allOf:
-      - $ref: './FeeObject.yaml'
-      - description: The fee object related to the credit note item.
+    $ref: './FeeObject.yaml'
+    description: The fee object related to the credit note item.

--- a/src/schemas/CreditNoteObject.yaml
+++ b/src/schemas/CreditNoteObject.yaml
@@ -93,10 +93,9 @@ properties:
     description: The description of the credit note.
     example: 'Free text'
   currency:
-    allOf:
-      - $ref: './Currency.yaml'
-      - description: The currency of the credit note.
-        example: 'EUR'
+    $ref: './Currency.yaml'
+    description: The currency of the credit note.
+    example: 'EUR'
   total_amount_cents:
     type: integer
     description: The total amount of the credit note, expressed in cents.

--- a/src/schemas/CreditObject.yaml
+++ b/src/schemas/CreditObject.yaml
@@ -17,10 +17,9 @@ properties:
     description: The amount of credit associated with the invoice, expressed in cents.
     example: 1200
   amount_currency:
-    allOf:
-      - $ref: "./Currency.yaml"
-      - description: The currency of the credit.
-        example: "EUR"
+    $ref: "./Currency.yaml"
+    description: The currency of the credit.
+    example: "EUR"
   before_taxes:
     type: boolean
     description: Indicates whether the credit is applied on the amount before taxes (coupons) or after taxes (credit notes). This flag helps determine the order in which credits are applied to the invoice calculation

--- a/src/schemas/CustomerBaseObject.yaml
+++ b/src/schemas/CustomerBaseObject.yaml
@@ -35,26 +35,23 @@ properties:
     description: 'The second line of the billing address'
     nullable: true
   applicable_timezone:
-    allOf:
-      - $ref: './Timezone.yaml'
-      - description: The customer's applicable timezone, used for billing purposes in their local time.
+    $ref: './Timezone.yaml'
+    description: The customer's applicable timezone, used for billing purposes in their local time.
   city:
     type: string
     example: 'Woodland Hills'
     description: The city of the customer's billing address
     nullable: true
   country:
-    allOf:
-    - $ref: './Country.yaml'
-    - nullable: true
-      description: Country code of the customer's billing address. Format must be ISO 3166 (alpha-2)
-      example: 'US'
+    $ref: './Country.yaml'
+    nullable: true
+    description: Country code of the customer's billing address. Format must be ISO 3166 (alpha-2)
+    example: 'US'
   currency:
-    allOf:
-    - $ref: './Currency.yaml'
-    - example: 'USD'
-      description: Currency of the customer. Format must be ISO 4217
-      nullable: true
+    $ref: './Currency.yaml'
+    example: 'USD'
+    description: Currency of the customer. Format must be ISO 4217
+    nullable: true
   email:
     type: string
     format: 'email'
@@ -117,10 +114,9 @@ properties:
     description: The tax identification number of the customer
     nullable: true
   timezone:
-    allOf:
-      - $ref: './Timezone.yaml'
-      - description: The customer's timezone, used for billing purposes in their local time. Overrides the organization's timezone
-        nullable: true
+    $ref: './Timezone.yaml'
+    description: The customer's timezone, used for billing purposes in their local time. Overrides the organization's timezone
+    nullable: true
   url:
     type: string
     example: 'http://hooli.com'

--- a/src/schemas/CustomerChargeUsageObject.yaml
+++ b/src/schemas/CustomerChargeUsageObject.yaml
@@ -22,10 +22,9 @@ properties:
     example: 123
     description: The amount in cents, tax excluded, consumed by the customer for a specific charge item.
   amount_currency:
-    allOf:
-      - $ref: "./Currency.yaml"
-      - description: The currency of a usage item consumed by the customer.
-        example: "EUR"
+    $ref: "./Currency.yaml"
+    description: The currency of a usage item consumed by the customer.
+    example: "EUR"
   charge:
     type: object
     description: Object listing all the properties for a specific charge item.

--- a/src/schemas/CustomerCreateInput.yaml
+++ b/src/schemas/CustomerCreateInput.yaml
@@ -27,16 +27,14 @@ properties:
         description: The city of the customer's billing address
         nullable: true
       country:
-        allOf:
-        - $ref: './Country.yaml'
-        - nullable: true
-          description: Country code of the customer's billing address. Format must be ISO 3166 (alpha-2)
-          example: 'US'
+        $ref: './Country.yaml'
+        nullable: true
+        description: Country code of the customer's billing address. Format must be ISO 3166 (alpha-2)
+        example: 'US'
       currency:
-        allOf:
-          - $ref: './Currency.yaml'
-          - description: Currency of the customer. Format must be ISO 4217
-            nullable: true
+        $ref: './Currency.yaml'
+        description: Currency of the customer. Format must be ISO 4217
+        nullable: true
       email:
         type: string
         format: 'email'
@@ -105,10 +103,9 @@ properties:
         description: The tax identification number of the customer
         nullable: true
       timezone:
-        allOf:
-          - $ref: './Timezone.yaml'
-          - description: The customer's timezone, used for billing purposes in their local time. Overrides the organization's timezone
-            nullable: true
+        $ref: './Timezone.yaml'
+        description: The customer's timezone, used for billing purposes in their local time. Overrides the organization's timezone
+        nullable: true
       url:
         type: string
         example: 'http://hooli.com'

--- a/src/schemas/CustomerUsageObject.yaml
+++ b/src/schemas/CustomerUsageObject.yaml
@@ -30,10 +30,9 @@ properties:
     example: '1a901a90-1a90-1a90-1a90-1a901a901a90'
     description: A unique identifier associated with the invoice related to this particular usage record.
   currency:
-    allOf:
-      - $ref: './Currency.yaml'
-      - description: The currency of the customer's current usage.
-        example: 'EUR'
+    $ref: './Currency.yaml'
+    description: The currency of the customer's current usage.
+    example: 'EUR'
   amount_cents:
     type: integer
     description: The amount in cents, tax excluded.

--- a/src/schemas/FeeObject.yaml
+++ b/src/schemas/FeeObject.yaml
@@ -88,10 +88,9 @@ properties:
     description: The cost of this specific fee, including any applicable taxes, with precision.
     example: "1.0212"
   amount_currency:
-    allOf:
-      - $ref: "./Currency.yaml"
-      - description: The currency of this specific fee. It indicates the monetary unit in which the fee's cost is expressed.
-        example: "EUR"
+    $ref: "./Currency.yaml"
+    description: The currency of this specific fee. It indicates the monetary unit in which the fee's cost is expressed.
+    example: "EUR"
   taxes_amount_cents:
     type: integer
     description: The cost of the tax associated with this specific fee.
@@ -117,10 +116,9 @@ properties:
     description: The cost of this specific fee, including any applicable taxes.
     example: 120
   total_amount_currency:
-    allOf:
-      - $ref: "./Currency.yaml"
-      - description: The currency of this specific fee, including any applicable taxes.
-        example: "EUR"
+    $ref: "./Currency.yaml"
+    description: The currency of this specific fee, including any applicable taxes.
+    example: "EUR"
   events_count:
     type: integer
     description: The number of events that have been sent and used to charge the customer. This field indicates the count or quantity of events that have been processed and considered in the charging process.
@@ -184,9 +182,8 @@ properties:
     description: Unique identifier assigned to the transaction. This field is specifically displayed when the fee type is `charge` and the payment for the fee is made in advance (`pay_in_advance` is set to `true`).
     example: "transaction_1234567890"
   amount_details:
-    allOf:
-      - $ref: "./FeeAmountDetails.yaml"
-      - description: List of all unit amount details for calculating the fee.
+    $ref: "./FeeAmountDetails.yaml"
+    description: List of all unit amount details for calculating the fee.
   item:
     type: object
     description: Item attached to the fee

--- a/src/schemas/GrossRevenueObject.yaml
+++ b/src/schemas/GrossRevenueObject.yaml
@@ -14,10 +14,9 @@ properties:
     description: The total amount of revenue for a period, expressed in cents.
     example: 50000
   currency:
-    allOf:
-      - $ref: './Currency.yaml'
-      - description: The currency of revenue analytics. Format must be ISO 4217.
-        example: 'USD'
+    $ref: './Currency.yaml'
+    description: The currency of revenue analytics. Format must be ISO 4217.
+    example: 'USD'
   invoices_count:
     type: integer
     description: Contains invoices count.

--- a/src/schemas/InvoiceBaseObject.yaml
+++ b/src/schemas/InvoiceBaseObject.yaml
@@ -91,10 +91,9 @@ properties:
       - `failed`: the payment of the invoice has failed or encountered an error during processing.
     example: succeeded
   currency:
-    allOf:
-      - $ref: "./Currency.yaml"
-      - description: The currency of the invoice issued.
-        example: "EUR"
+    $ref: "./Currency.yaml"
+    description: The currency of the invoice issued.
+    example: "EUR"
   fees_amount_cents:
     type: integer
     description: The total sum of fees amount in cents. It calculates the cumulative amount of all the fees associated with the invoice, providing a consolidated value.

--- a/src/schemas/InvoiceCollectionObject.yaml
+++ b/src/schemas/InvoiceCollectionObject.yaml
@@ -24,7 +24,6 @@ properties:
     description: The total amount of revenue for a period, expressed in cents.
     example: 50000
   currency:
-    allOf:
-      - $ref: './Currency.yaml'
-      - description: The currency of revenue analytics. Format must be ISO 4217.
-        example: 'USD'
+    $ref: './Currency.yaml'
+    description: The currency of revenue analytics. Format must be ISO 4217.
+    example: 'USD'

--- a/src/schemas/InvoiceObject.yaml
+++ b/src/schemas/InvoiceObject.yaml
@@ -3,9 +3,8 @@ allOf:
   - type: object
     properties:
       customer:
-        allOf:
-          - $ref: "./CustomerObject.yaml"
-          - description: The customer on which the invoice applies. It refers to the customer account or entity associated with the invoice.
+        $ref: "./CustomerObject.yaml"
+        description: The customer on which the invoice applies. It refers to the customer account or entity associated with the invoice.
       metadata:
         type: array
         items:

--- a/src/schemas/InvoiceOneOffCreateInput.yaml
+++ b/src/schemas/InvoiceOneOffCreateInput.yaml
@@ -13,10 +13,9 @@ properties:
         description: Unique identifier assigned to the customer in your application.
         example: 'hooli_1234'
       currency:
-        allOf:
-          - $ref: './Currency.yaml'
-          - description: The currency of the invoice.
-            example: 'EUR'
+        $ref: './Currency.yaml'
+        description: The currency of the invoice.
+        example: 'EUR'
       fees:
         type: array
         items:

--- a/src/schemas/InvoicedUsageObject.yaml
+++ b/src/schemas/InvoicedUsageObject.yaml
@@ -17,7 +17,6 @@ properties:
     description: The total amount of revenue for a period, expressed in cents.
     example: 50000
   currency:
-    allOf:
-      - $ref: './Currency.yaml'
-      - description: The currency of revenue analytics. Format must be ISO 4217.
-        example: 'USD'
+    $ref: './Currency.yaml'
+    description: The currency of revenue analytics. Format must be ISO 4217.
+    example: 'USD'

--- a/src/schemas/MrrObject.yaml
+++ b/src/schemas/MrrObject.yaml
@@ -11,7 +11,6 @@ properties:
     description: The total amount of MRR, expressed in cents.
     example: 50000
   currency:
-    allOf:
-      - $ref: './Currency.yaml'
-      - description: The currency of MRR analytics. Format must be ISO 4217.
-        example: 'USD'
+    $ref: './Currency.yaml'
+    description: The currency of MRR analytics. Format must be ISO 4217.
+    example: 'USD'

--- a/src/schemas/OrganizationObject.yaml
+++ b/src/schemas/OrganizationObject.yaml
@@ -38,16 +38,14 @@ properties:
     description: The array containing your webhooks URLs.
     nullable: true
   country:
-    allOf:
-    - $ref: './Country.yaml'
-    - nullable: true
-      description: The country of your organization.
-      example: 'US'
+    $ref: './Country.yaml'
+    nullable: true
+    description: The country of your organization.
+    example: 'US'
   default_currency:
-    allOf:
-    - $ref: './Currency.yaml'
-    - description: The default currency of an organization.
-      example: 'USD'
+    $ref: './Currency.yaml'
+    description: The default currency of an organization.
+    example: 'USD'
   address_line1:
     type: string
     example: '100 Brex Street'
@@ -116,10 +114,9 @@ properties:
     description: The tax identification number of your organization.
     nullable: true
   timezone:
-    allOf:
-      - $ref: './Timezone.yaml'
-      - description: Your organization's timezone, used for billing purposes in your own local time. Can be overwritten by the customer's timezone.
-        example: 'America/New_York'
+    $ref: './Timezone.yaml'
+    description: Your organization's timezone, used for billing purposes in your own local time. Can be overwritten by the customer's timezone.
+    example: 'America/New_York'
   billing_configuration:
     $ref: './OrganizationBillingConfiguration.yaml'
   taxes:

--- a/src/schemas/OrganizationUpdateInput.yaml
+++ b/src/schemas/OrganizationUpdateInput.yaml
@@ -11,16 +11,14 @@ properties:
         description: 'The URL of your newest updated webhook endpoint. This URL allows your organization to receive important messages, notifications, or data from the Lago system. By configuring your webhook endpoint to this URL, you can ensure that your organization stays informed and receives relevant information in a timely manner.'
         nullable: true
       country:
-        allOf:
-        - $ref: './Country.yaml'
-        - nullable: true
-          description: The country of your organization.
-          example: 'US'
+        $ref: './Country.yaml'
+        nullable: true
+        description: The country of your organization.
+        example: 'US'
       default_currency:
-        allOf:
-        - $ref: './Currency.yaml'
-        - description: The default currency of an organization.
-          example: 'USD'
+        $ref: './Currency.yaml'
+        description: The default currency of an organization.
+        example: 'USD'
       address_line1:
         type: string
         example: '100 Brex Street'
@@ -89,10 +87,9 @@ properties:
         description: The tax identification number of your organization.
         nullable: true
       timezone:
-        allOf:
-          - $ref: './Timezone.yaml'
-          - description: Your organization's timezone, used for billing purposes in your own local time. Can be overwritten by the customer's timezone.
-            example: 'America/New_York'
+        $ref: './Timezone.yaml'
+        description: Your organization's timezone, used for billing purposes in your own local time. Can be overwritten by the customer's timezone.
+        example: 'America/New_York'
       email_settings:
         type: array
         description: Represents the email settings of the organization. It allows you to define which documents are sent by email. The field value determines the types of documents that trigger email notifications. Possible values for are `invoice.finalized` and `credit_note.created`. By configuring this field, you can specify whether invoices, credit notes, or both should be sent to recipients via email.

--- a/src/schemas/OverdueBalanceObject.yaml
+++ b/src/schemas/OverdueBalanceObject.yaml
@@ -14,10 +14,9 @@ properties:
     description: The total amount of revenue for a period, expressed in cents.
     example: 50000
   currency:
-    allOf:
-      - $ref: './Currency.yaml'
-      - description: The currency of revenue analytics. Format must be ISO 4217.
-        example: 'USD'
+    $ref: './Currency.yaml'
+    description: The currency of revenue analytics. Format must be ISO 4217.
+    example: 'USD'
   lago_invoice_ids:
     type: array
     items:

--- a/src/schemas/PaymentRequestObject.yaml
+++ b/src/schemas/PaymentRequestObject.yaml
@@ -24,10 +24,9 @@ properties:
     description: The sum of the total amounts of all the invoices included in the payment request, expressed in cents.
     example: 100
   amount_currency:
-    allOf:
-      - $ref: "./Currency.yaml"
-      - description: The currency of the payment request.
-        example: "EUR"
+    $ref: "./Currency.yaml"
+    description: The currency of the payment request.
+    example: "EUR"
   payment_status:
     type: string
     enum:

--- a/src/schemas/PlanCreateInput.yaml
+++ b/src/schemas/PlanCreateInput.yaml
@@ -35,10 +35,9 @@ properties:
         description: The base cost of the plan, excluding any applicable taxes, that is billed on a recurring basis. This value is defined at 0 if your plan is a pay-as-you-go plan.
         example: 10000
       amount_currency:
-        allOf:
-          - $ref: "./Currency.yaml"
-          - description: The currency of the plan. It indicates the monetary unit in which the plan's cost, including taxes and usage-based charges, is expressed.
-            example: "USD"
+        $ref: "./Currency.yaml"
+        description: The currency of the plan. It indicates the monetary unit in which the plan's cost, including taxes and usage-based charges, is expressed.
+        example: "USD"
       trial_period:
         type: number
         description: The duration in days during which the base cost of the plan is offered for free.
@@ -122,9 +121,8 @@ properties:
               description: The minimum spending amount required for the charge, measured in cents and excluding any applicable taxes. It indicates the minimum amount that needs to be charged for each billing period.
               example: 0
             properties:
-              allOf:
-                - $ref: "./ChargeProperties.yaml"
-                - description: List of all thresholds utilized for calculating the charge.
+              $ref: "./ChargeProperties.yaml"
+              description: List of all thresholds utilized for calculating the charge.
             filters:
               type: array
               description: List of filters used to apply differentiated pricing based on additional event properties.

--- a/src/schemas/PlanObject.yaml
+++ b/src/schemas/PlanObject.yaml
@@ -50,10 +50,9 @@ properties:
     description: The base cost of the plan, excluding any applicable taxes, that is billed on a recurring basis. This value is defined at 0 if your plan is a pay-as-you-go plan.
     example: 10000
   amount_currency:
-    allOf:
-      - $ref: "./Currency.yaml"
-      - description: The currency of the plan. It indicates the monetary unit in which the plan's cost, including taxes and usage-based charges, is expressed.
-        example: "USD"
+    $ref: "./Currency.yaml"
+    description: The currency of the plan. It indicates the monetary unit in which the plan's cost, including taxes and usage-based charges, is expressed.
+    example: "USD"
   trial_period:
     type: number
     description: The duration in days during which the base cost of the plan is offered for free.

--- a/src/schemas/PlanOverridesObject.yaml
+++ b/src/schemas/PlanOverridesObject.yaml
@@ -6,10 +6,9 @@ properties:
     description: The base cost of the plan, excluding any applicable taxes, that is billed on a recurring basis. This value is defined at 0 if your plan is a pay-as-you-go plan.
     example: 10000
   amount_currency:
-    allOf:
-      - $ref: "./Currency.yaml"
-      - description: The currency of the plan. It indicates the monetary unit in which the plan's cost, including taxes and usage-based charges, is expressed.
-        example: "USD"
+    $ref: "./Currency.yaml"
+    description: The currency of the plan. It indicates the monetary unit in which the plan's cost, including taxes and usage-based charges, is expressed.
+    example: "USD"
   description:
     type: string
     description: The description on the plan.
@@ -59,9 +58,8 @@ properties:
           description: The minimum spending amount required for the charge, measured in cents and excluding any applicable taxes. It indicates the minimum amount that needs to be charged for each billing period.
           example: 0
         properties:
-          allOf:
-            - $ref: "./ChargeProperties.yaml"
-            - description: List of all thresholds utilized for calculating the charge.
+          $ref: "./ChargeProperties.yaml"
+          description: List of all thresholds utilized for calculating the charge.
         filters:
           type: array
           description: List of filters used to apply differentiated pricing based on additional event properties.

--- a/src/schemas/PlanUpdateInput.yaml
+++ b/src/schemas/PlanUpdateInput.yaml
@@ -35,10 +35,9 @@ properties:
         description: The base cost of the plan, excluding any applicable taxes, that is billed on a recurring basis. This value is defined at 0 if your plan is a pay-as-you-go plan.
         example: 10000
       amount_currency:
-        allOf:
-          - $ref: "./Currency.yaml"
-          - description: The currency of the plan. It indicates the monetary unit in which the plan's cost, including taxes and usage-based charges, is expressed.
-            example: "USD"
+        $ref: "./Currency.yaml"
+        description: The currency of the plan. It indicates the monetary unit in which the plan's cost, including taxes and usage-based charges, is expressed.
+        example: "USD"
       trial_period:
         type: number
         description: The duration in days during which the base cost of the plan is offered for free.
@@ -127,9 +126,8 @@ properties:
               description: The minimum spending amount required for the charge, measured in cents and excluding any applicable taxes. It indicates the minimum amount that needs to be charged for each billing period.
               example: 0
             properties:
-              allOf:
-                - $ref: "./ChargeProperties.yaml"
-                - description: List of all thresholds utilized for calculating the charge.
+              $ref: "./ChargeProperties.yaml"
+              description: List of all thresholds utilized for calculating the charge.
             filters:
               type: array
               description: List of filters used to apply differentiated pricing based on additional event properties.

--- a/src/schemas/TaxCreateInput.yaml
+++ b/src/schemas/TaxCreateInput.yaml
@@ -3,9 +3,8 @@ required:
   - tax
 properties:
   tax:
-    allOf:
-      - $ref: './TaxBaseInput.yaml'
-      - required:
+    $ref: './TaxBaseInput.yaml'
+    required:
         - name
         - code
         - rate

--- a/src/schemas/TaxUpdateInput.yaml
+++ b/src/schemas/TaxUpdateInput.yaml
@@ -3,5 +3,4 @@ required:
   - tax
 properties:
   tax:
-    allOf:
-      - $ref: './TaxBaseInput.yaml'
+    $ref: './TaxBaseInput.yaml'

--- a/src/schemas/WalletCreateInput.yaml
+++ b/src/schemas/WalletCreateInput.yaml
@@ -17,10 +17,9 @@ properties:
         description: The rate of conversion between credits and the amount in the specified currency. It indicates the ratio or factor used to convert credits into the corresponding monetary value in the currency of the transaction.
         example: '1.5'
       currency:
-        allOf:
-          - $ref: './Currency.yaml'
-          - description: The currency of the wallet.
-            example: 'USD'
+        $ref: './Currency.yaml'
+        description: The currency of the wallet.
+        example: 'USD'
       paid_credits:
         type: string
         pattern: '^[0-9]+.?[0-9]*$'

--- a/src/schemas/WalletObject.yaml
+++ b/src/schemas/WalletObject.yaml
@@ -38,10 +38,9 @@ properties:
     description: The status of the wallet. Possible values are `active` or `terminated`.
     example: "active"
   currency:
-    allOf:
-      - $ref: "./Currency.yaml"
-      - description: The currency of the wallet.
-        example: "USD"
+    $ref: "./Currency.yaml"
+    description: The currency of the wallet.
+    example: "USD"
   name:
     type: string
     description: The name of the wallet.


### PR DESCRIPTION
Remove all unnecessary `allOf` in each schemas. 

The change cleans schemas and avoid unnecessary class generated when I used the openapi-generators for java. 