### PR TITLE
misc: Deprecate counters at billable metric index level

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1908,7 +1908,7 @@ paths:
       tags:
         - invoices
       summary: Void an invoice
-      description: "This endpoint is used for voiding an invoice. You can void an invoice only when it's in a `finalized` status, and the payment status is not `succeeded`."
+      description: 'This endpoint is used for voiding an invoice. You can void an invoice only when it''s in a `finalized` status, and the payment status is not `succeeded`.'
       parameters:
         - $ref: '#/components/parameters/lago_invoice_id'
       operationId: voidInvoice
@@ -3284,7 +3284,7 @@ components:
           type: string
           format: date-time
           nullable: true
-          description: "The date and time after which the coupon will stop applying to customer's invoices. Once the expiration date is reached, the coupon will no longer be applicable, and any further invoices generated for the customer will not include the coupon discount."
+          description: 'The date and time after which the coupon will stop applying to customer''s invoices. Once the expiration date is reached, the coupon will no longer be applicable, and any further invoices generated for the customer will not include the coupon discount.'
           example: '2022-04-29T08:59:51Z'
         created_at:
           type: string
@@ -3386,7 +3386,7 @@ components:
         - billable_metric
       properties:
         billable_metric:
-          $ref: '#/components/schemas/BillableMetricObject'
+          $ref: '#/components/schemas/BillableMetricObjectExtended'
     BillableMetricObject:
       type: object
       required:
@@ -3481,14 +3481,34 @@ components:
           type: integer
           example: 4
           description: Number of active subscriptions using this billable metric.
+          deprecated: true
         draft_invoices_count:
           type: integer
           example: 10
           description: Number of draft invoices for which this billable metric is listed as an invoice item.
+          deprecated: true
         plans_count:
           type: integer
           example: 4
           description: Number of plans using this billable metric.
+          deprecated: true
+    BillableMetricObjectExtended:
+      allOf:
+        - $ref: '#/components/schemas/BillableMetricObject'
+        - type: object
+          properties:
+            active_subscriptions_count:
+              type: integer
+              example: 4
+              description: Number of active subscriptions using this billable metric.
+            draft_invoices_count:
+              type: integer
+              example: 10
+              description: Number of draft invoices for which this billable metric is listed as an invoice item.
+            plans_count:
+              type: integer
+              example: 4
+              description: Number of plans using this billable metric.
     BillableMetricBaseInput:
       type: object
       properties:
@@ -4336,7 +4356,7 @@ components:
               nullable: true
               items:
                 type: string
-              description: "An array of plan codes to which the coupon is applicable. By specifying the plan codes in this field, you can restrict the coupon's usage to specific plans only."
+              description: 'An array of plan codes to which the coupon is applicable. By specifying the plan codes in this field, you can restrict the coupon''s usage to specific plans only.'
               example:
                 - startup_plan
             billable_metric_codes:
@@ -4344,7 +4364,7 @@ components:
               nullable: true
               items:
                 type: string
-              description: "An array of billable metric codes to which the coupon is applicable. By specifying the billable metric codes in this field, you can restrict the coupon's usage to specific metrics only."
+              description: 'An array of billable metric codes to which the coupon is applicable. By specifying the billable metric codes in this field, you can restrict the coupon''s usage to specific metrics only.'
               example: []
     CouponCreateInput:
       type: object
@@ -4424,7 +4444,7 @@ components:
           example: true
         plan_codes:
           type: array
-          description: "An array of plan codes to which the coupon is applicable. By specifying the plan codes in this field, you can restrict the coupon's usage to specific plans only."
+          description: 'An array of plan codes to which the coupon is applicable. By specifying the plan codes in this field, you can restrict the coupon''s usage to specific plans only.'
           items:
             type: string
           example:
@@ -4435,7 +4455,7 @@ components:
           example: false
         billable_metric_codes:
           type: array
-          description: "An array of billable metric codes to which the coupon is applicable. By specifying the billable metric codes in this field, you can restrict the coupon's usage to specific metrics only."
+          description: 'An array of billable metric codes to which the coupon is applicable. By specifying the billable metric codes in this field, you can restrict the coupon''s usage to specific metrics only.'
           items:
             type: string
           example: []
@@ -4488,7 +4508,7 @@ components:
         terminated_at:
           type: string
           format: date-time
-          description: "This field indicates if the coupon has been terminated and is no longer usable. If it's not null, it won't be removed for existing customers using it, but it prevents the coupon from being applied in the future."
+          description: 'This field indicates if the coupon has been terminated and is no longer usable. If it''s not null, it won''t be removed for existing customers using it, but it prevents the coupon from being applied in the future.'
           example: '2022-08-08T23:59:59Z'
     CouponsPaginated:
       type: object
@@ -4616,7 +4636,7 @@ components:
                 properties:
                   amount_cents:
                     type: integer
-                    description: "The credit note's item amount, expressed in cents."
+                    description: 'The credit note''s item amount, expressed in cents.'
                     example: 100
                   lago_fee_id:
                     type: string
@@ -4715,11 +4735,11 @@ components:
               example: coupon
             code:
               type: string
-              description: "The code of the credit applied. It can be the code of the coupon attached to the credit, the credit note's number or the `progressive_billing` invoice number."
+              description: 'The code of the credit applied. It can be the code of the coupon attached to the credit, the credit note''s number or the `progressive_billing` invoice number.'
               example: startup_deal
             name:
               type: string
-              description: "The name of the credit applied. It can be the name of the coupon attached to the credit, the initial invoice's number linked to the credit note or the `progressive_billing` invoice number."
+              description: 'The name of the credit applied. It can be the name of the coupon attached to the credit, the initial invoice''s number linked to the credit note or the `progressive_billing` invoice number.'
               example: Startup Deal
         invoice:
           type: object
@@ -4769,11 +4789,11 @@ components:
         lago_id:
           type: string
           format: uuid
-          description: "The credit note's item unique identifier, created by Lago."
+          description: 'The credit note''s item unique identifier, created by Lago.'
           example: 1a901a90-1a90-1a90-1a90-1a901a901a90
         amount_cents:
           type: integer
-          description: "The credit note's item amount, expressed in cents."
+          description: 'The credit note''s item amount, expressed in cents.'
           example: 100
         amount_currency:
           allOf:
@@ -5247,7 +5267,7 @@ components:
         provider_customer_id:
           type: string
           example: cus_12345
-          description: "The customer ID within the payment provider's system. If this field is not provided, Lago has the option to create a new customer record within the payment provider's system on behalf of the customer"
+          description: 'The customer ID within the payment provider''s system. If this field is not provided, Lago has the option to create a new customer record within the payment provider''s system on behalf of the customer'
         sync:
           type: boolean
           example: true
@@ -5255,7 +5275,7 @@ components:
         sync_with_provider:
           type: boolean
           example: true
-          description: "Set this field to `true` if you want to create a customer record in the payment provider's system. This option is applicable only when the `provider_customer_id` is null and the `sync_with_provider` field is set to `true`. By default, the value is set to `false`"
+          description: 'Set this field to `true` if you want to create a customer record in the payment provider''s system. This option is applicable only when the `provider_customer_id` is null and the `sync_with_provider` field is set to `true`. By default, the value is set to `false`'
         document_locale:
           type: string
           example: fr
@@ -5294,11 +5314,11 @@ components:
         external_customer_id:
           type: string
           example: cus_12345
-          description: "The customer ID within the integration's system. If this field is not provided, Lago has the option to create a new customer record within the integration's system on behalf of the customer."
+          description: 'The customer ID within the integration''s system. If this field is not provided, Lago has the option to create a new customer record within the integration''s system on behalf of the customer.'
         sync_with_provider:
           type: boolean
           example: true
-          description: "Set this field to `true` if you want to create a customer record in the integration's system. This option is applicable only when the `external_customer_id` is null and the `sync_with_provider` field is set to `true`. By default, the value is set to `false`"
+          description: 'Set this field to `true` if you want to create a customer record in the integration''s system. This option is applicable only when the `external_customer_id` is null and the `sync_with_provider` field is set to `true`. By default, the value is set to `false`'
         subsidiary_id:
           type: string
           example: '2'
@@ -5573,7 +5593,7 @@ components:
             timezone:
               allOf:
                 - $ref: '#/components/schemas/Timezone'
-                - description: "The customer's timezone, used for billing purposes in their local time. Overrides the organization's timezone"
+                - description: 'The customer''s timezone, used for billing purposes in their local time. Overrides the organization''s timezone'
                   nullable: true
             url:
               type: string
@@ -5633,11 +5653,11 @@ components:
                   external_customer_id:
                     type: string
                     example: cus_12345
-                    description: "The customer ID within the integration's system. If this field is not provided, Lago has the option to create a new customer record within the integration's system on behalf of the customer."
+                    description: 'The customer ID within the integration''s system. If this field is not provided, Lago has the option to create a new customer record within the integration''s system on behalf of the customer.'
                   sync_with_provider:
                     type: boolean
                     example: true
-                    description: "Set this field to `true` if you want to create a customer record in the integration's system. This option is applicable only when the `external_customer_id` is null and the `sync_with_provider` field is set to `true`. By default, the value is set to `false`"
+                    description: 'Set this field to `true` if you want to create a customer record in the integration''s system. This option is applicable only when the `external_customer_id` is null and the `sync_with_provider` field is set to `true`. By default, the value is set to `false`'
                   subsidiary_id:
                     type: string
                     example: '2'
@@ -5720,11 +5740,11 @@ components:
             sequential_id:
               type: integer
               example: 1
-              description: "The unique identifier assigned to the customer within the organization's scope. This identifier is used to track and reference the customer's order of creation within the organization's system. It ensures that each customer has a distinct `sequential_id`` associated with them, allowing for easy identification and sorting based on the order of creation"
+              description: 'The unique identifier assigned to the customer within the organization''s scope. This identifier is used to track and reference the customer''s order of creation within the organization''s system. It ensures that each customer has a distinct `sequential_id`` associated with them, allowing for easy identification and sorting based on the order of creation'
             slug:
               type: string
               example: LAG-1234-001
-              description: "A concise and unique identifier for the customer, formed by combining the Organization's `name`, `id`, and customer's `sequential_id`"
+              description: 'A concise and unique identifier for the customer, formed by combining the Organization''s `name`, `id`, and customer''s `sequential_id`'
             external_id:
               type: string
               example: 5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba
@@ -5742,7 +5762,7 @@ components:
             applicable_timezone:
               allOf:
                 - $ref: '#/components/schemas/Timezone'
-                - description: "The customer's applicable timezone, used for billing purposes in their local time."
+                - description: 'The customer''s applicable timezone, used for billing purposes in their local time.'
             city:
               type: string
               example: Woodland Hills
@@ -5824,7 +5844,7 @@ components:
             timezone:
               allOf:
                 - $ref: '#/components/schemas/Timezone'
-                - description: "The customer's timezone, used for billing purposes in their local time. Overrides the organization's timezone"
+                - description: 'The customer''s timezone, used for billing purposes in their local time. Overrides the organization''s timezone'
                   nullable: true
             url:
               type: string
@@ -6134,7 +6154,7 @@ components:
           type: string
           format: date-time
           example: '2022-04-29T08:59:51Z'
-          description: "The creation date of the event's record in the Lago application, presented in the ISO 8601 datetime format, specifically in Coordinated Universal Time (UTC). It provides the precise timestamp of when the event's record was created within the Lago application"
+          description: 'The creation date of the event''s record in the Lago application, presented in the ISO 8601 datetime format, specifically in Coordinated Universal Time (UTC). It provides the precise timestamp of when the event''s record was created within the Lago application'
     Fee:
       type: object
       required:
@@ -6990,7 +7010,7 @@ components:
               example: 1a901a90-1a90-1a90-1a90-1a901a901a90
             sequential_id:
               type: integer
-              description: "This ID helps in uniquely identifying and organizing the invoices associated with a specific customer. It provides a sequential numbering system specific to the customer, allowing for easy tracking and management of invoices within the customer's context."
+              description: 'This ID helps in uniquely identifying and organizing the invoices associated with a specific customer. It provides a sequential numbering system specific to the customer, allowing for easy tracking and management of invoices within the customer''s context.'
               example: 2
             number:
               type: string
@@ -7297,7 +7317,7 @@ components:
         invoice_grace_period:
           type: integer
           example: 3
-          description: "The grace period, expressed in days, for finalizing the invoice. This period refers to the additional time granted to your customers beyond the invoice due date to adjust usage and line items. Can be overwritten by the customer's grace period."
+          description: 'The grace period, expressed in days, for finalizing the invoice. This period refers to the additional time granted to your customers beyond the invoice due date to adjust usage and line items. Can be overwritten by the customer''s grace period.'
         document_locale:
           type: string
           example: en
@@ -7423,7 +7443,7 @@ components:
         timezone:
           allOf:
             - $ref: '#/components/schemas/Timezone'
-            - description: "Your organization's timezone, used for billing purposes in your own local time. Can be overwritten by the customer's timezone."
+            - description: 'Your organization''s timezone, used for billing purposes in your own local time. Can be overwritten by the customer''s timezone.'
               example: America/New_York
         billing_configuration:
           $ref: '#/components/schemas/OrganizationBillingConfiguration'
@@ -7530,7 +7550,7 @@ components:
             timezone:
               allOf:
                 - $ref: '#/components/schemas/Timezone'
-                - description: "Your organization's timezone, used for billing purposes in your own local time. Can be overwritten by the customer's timezone."
+                - description: 'Your organization''s timezone, used for billing purposes in your own local time. Can be overwritten by the customer''s timezone.'
                   example: America/New_York
             email_settings:
               type: array
@@ -7730,7 +7750,7 @@ components:
             amount_currency:
               allOf:
                 - $ref: '#/components/schemas/Currency'
-                - description: "The currency of the plan. It indicates the monetary unit in which the plan's cost, including taxes and usage-based charges, is expressed."
+                - description: 'The currency of the plan. It indicates the monetary unit in which the plan''s cost, including taxes and usage-based charges, is expressed.'
                   example: USD
             trial_period:
               type: number
@@ -7742,7 +7762,7 @@ components:
               example: true
             bill_charges_monthly:
               type: boolean
-              description: "This field, when set to `true`, enables to invoice usage-based charges on monthly basis, even if the cadence of the plan is yearly. This allows customers to pay charges overage on a monthly basis. This can be set to true only if the plan's interval is `yearly`."
+              description: 'This field, when set to `true`, enables to invoice usage-based charges on monthly basis, even if the cadence of the plan is yearly. This allows customers to pay charges overage on a monthly basis. This can be set to true only if the plan''s interval is `yearly`.'
               nullable: true
               example: null
             tax_codes:
@@ -7917,7 +7937,7 @@ components:
         amount_currency:
           allOf:
             - $ref: '#/components/schemas/Currency'
-            - description: "The currency of the plan. It indicates the monetary unit in which the plan's cost, including taxes and usage-based charges, is expressed."
+            - description: 'The currency of the plan. It indicates the monetary unit in which the plan''s cost, including taxes and usage-based charges, is expressed.'
               example: USD
         description:
           type: string
@@ -8029,7 +8049,7 @@ components:
             amount_currency:
               allOf:
                 - $ref: '#/components/schemas/Currency'
-                - description: "The currency of the plan. It indicates the monetary unit in which the plan's cost, including taxes and usage-based charges, is expressed."
+                - description: 'The currency of the plan. It indicates the monetary unit in which the plan''s cost, including taxes and usage-based charges, is expressed.'
                   example: USD
             trial_period:
               type: number
@@ -8041,7 +8061,7 @@ components:
               example: true
             bill_charges_monthly:
               type: boolean
-              description: "This field, when set to `true`, enables to invoice usage-based charges on monthly basis, even if the cadence of the plan is yearly. This allows customers to pay charges overage on a monthly basis. This can be set to true only if the plan's interval is `yearly`."
+              description: 'This field, when set to `true`, enables to invoice usage-based charges on monthly basis, even if the cadence of the plan is yearly. This allows customers to pay charges overage on a monthly basis. This can be set to true only if the plan''s interval is `yearly`.'
               nullable: true
               example: null
             tax_codes:
@@ -8269,7 +8289,7 @@ components:
         amount_currency:
           allOf:
             - $ref: '#/components/schemas/Currency'
-            - description: "The currency of the plan. It indicates the monetary unit in which the plan's cost, including taxes and usage-based charges, is expressed."
+            - description: 'The currency of the plan. It indicates the monetary unit in which the plan''s cost, including taxes and usage-based charges, is expressed.'
               example: USD
         trial_period:
           type: number
@@ -8282,7 +8302,7 @@ components:
         bill_charges_monthly:
           type: boolean
           nullable: true
-          description: "This field, when set to `true`, enables to invoice usage-based charges on monthly basis, even if the cadence of the plan is yearly. This allows customers to pay charges overage on a monthly basis. This can be set to true only if the plan's interval is `yearly`."
+          description: 'This field, when set to `true`, enables to invoice usage-based charges on monthly basis, even if the cadence of the plan is yearly. This allows customers to pay charges overage on a monthly basis. This can be set to true only if the plan''s interval is `yearly`.'
           example: null
         active_subscriptions_count:
           type: integer
@@ -8457,7 +8477,7 @@ components:
             name:
               type: string
               example: Repository A
-              description: "The display name of the subscription on an invoice. This field allows for customization of the subscription's name for billing purposes, especially useful when a single customer has multiple subscriptions using the same plan."
+              description: 'The display name of the subscription on an invoice. This field allows for customization of the subscription''s name for billing purposes, especially useful when a single customer has multiple subscriptions using the same plan.'
             external_id:
               type: string
               example: my_sub_1234567890
@@ -8502,7 +8522,7 @@ components:
               type: string
               example: Repository B
               nullable: true
-              description: "The display name of the subscription on an invoice. This field allows for customization of the subscription's name for billing purposes, especially useful when a single customer has multiple subscriptions using the same plan."
+              description: 'The display name of the subscription on an invoice. This field allows for customization of the subscription''s name for billing purposes, especially useful when a single customer has multiple subscriptions using the same plan.'
             ending_at:
               type: string
               format: date-time
@@ -8557,7 +8577,7 @@ components:
         name:
           type: string
           example: Repository A
-          description: "The display name of the subscription on an invoice. This field allows for customization of the subscription's name for billing purposes, especially useful when a single customer has multiple subscriptions using the same plan."
+          description: 'The display name of the subscription on an invoice. This field allows for customization of the subscription''s name for billing purposes, especially useful when a single customer has multiple subscriptions using the same plan.'
           nullable: true
         plan_code:
           type: string

--- a/src/schemas/BillableMetric.yaml
+++ b/src/schemas/BillableMetric.yaml
@@ -3,4 +3,4 @@ required:
   - billable_metric
 properties:
   billable_metric:
-    $ref: './BillableMetricObject.yaml'
+    $ref: "./BillableMetricObjectExtended.yaml"

--- a/src/schemas/BillableMetricObject.yaml
+++ b/src/schemas/BillableMetricObject.yaml
@@ -91,11 +91,14 @@ properties:
     type: integer
     example: 4
     description: "Number of active subscriptions using this billable metric."
+    deprecated: true
   draft_invoices_count:
     type: integer
     example: 10
     description: "Number of draft invoices for which this billable metric is listed as an invoice item."
+    deprecated: true
   plans_count:
     type: integer
     example: 4
     description: "Number of plans using this billable metric."
+    deprecated: true

--- a/src/schemas/BillableMetricObjectExtended.yaml
+++ b/src/schemas/BillableMetricObjectExtended.yaml
@@ -1,0 +1,16 @@
+allOf:
+  - $ref: "./BillableMetricObject.yaml"
+  - type: object
+    properties:
+      active_subscriptions_count:
+        type: integer
+        example: 4
+        description: "Number of active subscriptions using this billable metric."
+      draft_invoices_count:
+        type: integer
+        example: 10
+        description: "Number of draft invoices for which this billable metric is listed as an invoice item."
+      plans_count:
+        type: integer
+        example: 4
+        description: "Number of plans using this billable metric."

--- a/src/schemas/_index.yaml
+++ b/src/schemas/_index.yaml
@@ -40,6 +40,8 @@ BillableMetric:
   $ref: "./BillableMetric.yaml"
 BillableMetricObject:
   $ref: "./BillableMetricObject.yaml"
+BillableMetricObjectExtended:
+  $ref: "./BillableMetricObjectExtended.yaml"
 BillableMetricBaseInput:
   $ref: "./BillableMetricBaseInput.yaml"
 BillableMetricCreateInput:


### PR DESCRIPTION
For some performance reason, it was decided to deprecate 3 counter fields in the response payload for `/api/v1/billable_metrics` API end-point.

The deprecated fields will be:
- active_subscriptions_count
- draft_invoices_count
- plans_count

To avoid duplicating object definition, the existing `BillableMetricObject` has been kept (with the deprecated fields waiting for removal) and a new `BillableMetricObjectExtended` was added to handle the response to `/api/v1/billable_metrics/:id` were the fields are not deprecated