### PR TITLE
fix(paymentRequest): requires an external_customer_id

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2107,7 +2107,7 @@ paths:
                     - external_customer_id
                     - lago_invoice_ids
                   properties:
-                    customer_external_id:
+                    external_customer_id:
                       type: string
                       example: 5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba
                       description: The customer external unique identifier (provided by your own application)

--- a/src/schemas/PaymentRequestCreateInput.yaml
+++ b/src/schemas/PaymentRequestCreateInput.yaml
@@ -9,19 +9,19 @@ properties:
       - external_customer_id
       - lago_invoice_ids
     properties:
-        customer_external_id:
+      external_customer_id:
+        type: string
+        example: "5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba"
+        description: The customer external unique identifier (provided by your own application)
+      email:
+        type: string
+        format: "email"
+        example: "dinesh@piedpiper.test"
+        description: The customer's email address used for sending dunning notifications
+      lago_invoice_ids:
+        type: array
+        description: A list of Lago IDs for the customer's overdue invoices to start the dunning process
+        items:
           type: string
-          example: "5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba"
-          description: The customer external unique identifier (provided by your own application)
-        email:
-          type: string
-          format: "email"
-          example: "dinesh@piedpiper.test"
-          description: The customer's email address used for sending dunning notifications
-        lago_invoice_ids:
-          type: array
-          description: A list of Lago IDs for the customer's overdue invoices to start the dunning process
-          items:
-            type: string
-            example: "1a901a90-1a90-1a90-1a90-1a901a901a90"
-            description: Unique identifier assigned to the invoice within the Lago application. This ID is exclusively created by Lago and serves as a unique identifier for the invoice's record within the Lago system.
+          example: "1a901a90-1a90-1a90-1a90-1a901a901a90"
+          description: Unique identifier assigned to the invoice within the Lago application. This ID is exclusively created by Lago and serves as a unique identifier for the invoice's record within the Lago system.


### PR DESCRIPTION
Fix for https://github.com/getlago/lago-go-client/issues/223

The API is expecting an `external_customer_id`, but the documentation is inconsistent, as it exposes a `customer_external_id` field