### PR TITLE
feat(wallet): GET /wallet_transactions/{lago_id}

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2941,6 +2941,33 @@ paths:
           $ref: '#/components/responses/Unauthorized'
         '422':
           $ref: '#/components/responses/UnprocessableEntity'
+  '/wallet_transactions/{lago_id}':
+    parameters:
+      - name: lago_id
+        in: path
+        description: Unique identifier assigned to the wallet transaction within the Lago application. This ID is exclusively created by Lago and serves as a unique identifier for the wallet's record within the Lago system.
+        required: true
+        schema:
+          type: string
+          format: uuid
+          example: bb0a27be-51f7-4f4f-aad0-2abc80534c0f
+    get:
+      tags:
+        - wallets
+      summary: Retrieve a wallet transaction
+      description: This endpoint is used to retrieve a specific wallet transactions.
+      operationId: findWalletTransaction
+      responses:
+        '200':
+          description: Wallet transaction
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/WalletTransactionObject'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
   '/wallets/{lago_id}/wallet_transactions':
     get:
       tags:

--- a/src/openapi.yaml
+++ b/src/openapi.yaml
@@ -211,6 +211,8 @@ paths:
     $ref: "./resources/wallet.yaml"
   /wallet_transactions:
     $ref: "./resources/wallet_top_up.yaml"
+  /wallet_transactions/{lago_id}:
+    $ref: "./resources/wallet_transaction.yaml"
   /wallets/{lago_id}/wallet_transactions:
     $ref: "./resources/wallet_transactions.yaml"
   /webhooks/public_key:

--- a/src/resources/wallet_transaction.yaml
+++ b/src/resources/wallet_transaction.yaml
@@ -1,0 +1,26 @@
+parameters:
+  - name: lago_id
+    in: path
+    description: Unique identifier assigned to the wallet transaction within the Lago application. This ID is exclusively created by Lago and serves as a unique identifier for the wallet's record within the Lago system.
+    required: true
+    schema:
+      type: string
+      format: 'uuid'
+      example: 'bb0a27be-51f7-4f4f-aad0-2abc80534c0f'
+get:
+  tags:
+    - wallets
+  summary: Retrieve a wallet transaction
+  description: This endpoint is used to retrieve a specific wallet transactions.
+  operationId: findWalletTransaction
+  responses:
+    '200':
+      description: Wallet transaction
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/WalletTransactionObject.yaml'
+    '401':
+      $ref: '../responses/Unauthorized.yaml'
+    '404':
+      $ref: '../responses/NotFound.yaml'


### PR DESCRIPTION
New endpoint to retrieve a single wallet transactions by ID.

The feature: https://github.com/getlago/lago-api/pull/3119

![CleanShot 2025-01-29 at 17 46 25@2x](https://github.com/user-attachments/assets/9115c0ee-a4e3-4a44-82d2-a894242ece0d)

![CleanShot 2025-01-30 at 09 57 26@2x](https://github.com/user-attachments/assets/57f6ac73-c1ae-458e-8244-4f1e47829a52)

![CleanShot 2025-01-30 at 09 57 56@2x](https://github.com/user-attachments/assets/3264a665-8143-4351-ba44-d876ab79a4f8)
