### PR TITLE
fix(customer): Rename external_id to external_customer_id for consistency

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1044,11 +1044,11 @@ paths:
                 $ref: '#/components/schemas/CustomersPaginated'
         '401':
           $ref: '#/components/responses/Unauthorized'
-  '/customers/{external_id}':
+  '/customers/{external_customer_id}':
     parameters:
-      - name: external_id
+      - name: external_customer_id
         in: path
-        description: External ID of the existing customer
+        description: The customer external unique identifier (provided by your own application)
         required: true
         schema:
           type: string

--- a/src/openapi.yaml
+++ b/src/openapi.yaml
@@ -141,7 +141,7 @@ paths:
     $ref: "./resources/credit_note_void.yaml"
   /customers:
     $ref: "./resources/customers.yaml"
-  /customers/{external_id}:
+  /customers/{external_customer_id}:
     $ref: "./resources/customer.yaml"
   /customers/{external_customer_id}/applied_coupons/{applied_coupon_id}:
     $ref: "./resources/customer_applied_coupon.yaml"

--- a/src/resources/customer.yaml
+++ b/src/resources/customer.yaml
@@ -1,7 +1,7 @@
 parameters:
-  - name: external_id
+  - name: external_customer_id
     in: path
-    description: External ID of the existing customer
+    description: The customer external unique identifier (provided by your own application)
     required: true
     schema:
       type: string


### PR DESCRIPTION
In the `/customers` endpoints, the path parameter `external_customer_id` was named `external_id` for 2 endpoints.

In Postman, you'd get 2 directories, making you think it was a different parameter.

## Before

![CleanShot 2025-01-30 at 10 38 49@2x](https://github.com/user-attachments/assets/1dd07311-e24b-4bce-b016-486a7b825868)

![CleanShot 2025-01-30 at 10 36 04@2x](https://github.com/user-attachments/assets/2b6444a7-c17b-4fc9-bab1-7d407ce6b690)

## After

![CleanShot 2025-01-30 at 10 38 32@2x](https://github.com/user-attachments/assets/12a358ec-38b1-4162-b4d9-79fab4f9c7ff)

