### PR TITLE
feat: add apply_taxes to current usage

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1186,6 +1186,15 @@ paths:
           schema:
             type: string
             example: sub_1234567890
+        - name: apply_taxes
+          in: query
+          description: |
+            Optional flag to determine if taxes should be applied. Defaults to `true` if not provided or if null.
+          required: false
+          schema:
+            type: boolean
+            default: true
+            example: true
       operationId: findCustomerCurrentUsage
       responses:
         '200':

--- a/src/resources/customer_current_usage.yaml
+++ b/src/resources/customer_current_usage.yaml
@@ -19,6 +19,16 @@ get:
       schema:
         type: string
         example: 'sub_1234567890'
+    - name: apply_taxes
+      in: query
+      description: >
+        Optional flag to determine if taxes should be applied.
+        Defaults to `true` if not provided or if null.
+      required: false
+      schema:
+        type: boolean
+        default: true
+        example: true
   operationId: findCustomerCurrentUsage
   responses:
     '200':


### PR DESCRIPTION
This PR introduces an optional `apply_taxes` query parameter to the 
GET `/api/v1/customers/{external_customer_id}/current_usage` endpoint. 
With this change, API consumers can now specify whether taxes should be applied when calculating a customer’s current usage. If the parameter is omitted or provided as null, it defaults to true (taxes applied), maintaining the existing behavior.
