### PR TITLE
fix(customer): Add support for provider payment methods

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -7080,6 +7080,10 @@ components:
           example:
             - card
             - sepa_debit
+            - us_bank_account
+            - bacs_debit
+            - link
+            - boleto
     IntegrationCustomer:
       type: object
       description: Configuration specific to the accounting and tax integrations. This object contains settings and parameters necessary for syncing documents and payments.

--- a/src/schemas/CustomerBillingConfiguration.yaml
+++ b/src/schemas/CustomerBillingConfiguration.yaml
@@ -44,3 +44,7 @@ properties:
     example:
       - card
       - sepa_debit
+      - us_bank_account
+      - bacs_debit
+      - link
+      - boleto


### PR DESCRIPTION
Related to https://github.com/getlago/lago-go-client/pull/228

This PR adds the missing `provider_payment_methods` values in the `CustomerBillingConfiguration` object