### PR TITLE
misc(event): Add warning about clickhouse idempotency logic

### DIFF
--- a/src/schemas/EventInputObject.yaml
+++ b/src/schemas/EventInputObject.yaml
@@ -7,7 +7,13 @@ properties:
   transaction_id:
     type: string
     example: "transaction_1234567890"
-    description: This field represents a unique identifier for the event. It is crucial for ensuring idempotency, meaning that each event can be uniquely identified and processed without causing any unintended side effects.
+    description: |
+      This field represents a unique identifier for the event.
+      It is crucial for ensuring idempotency, meaning that each event can be uniquely identified and processed without causing any unintended side effects.
+
+      WARNING: If the Lago organization is configured to use the new Clickhouse-based event pipeline (designed for high-volume processing), the idempotency logic is handled differently.
+      Event uniqueness is maintained with both `transaction_id` and `timestamp` fields.
+      If a new event arrives with identical values for these two fields as an existing event, the new one will overwrite the previous event rather than being rejected.
   external_subscription_id:
     type: string
     example: "sub_1234567890"


### PR DESCRIPTION
This PR adds a warning about the handling of the idempotency logic in Clickhouse that differs from the one in Postgres