### PR TITLE
fix(build) Openapi 3.1 supports null type instead of nullable

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -5402,19 +5402,21 @@ components:
             - `per_billing_entity`: document numbers are unique per billing entity
           example: per_customer
         document_number_prefix:
-          type: string
+          type:
+            - string
+            - 'null'
           example: ABC-123
           description: The prefix used in document numbers for this billing entity
-          nullable: true
         finalize_zero_amount_invoice:
           type: boolean
           example: true
           description: Whether to finalize invoices with zero amount for this billing entity
         invoice_footer:
-          type: string
+          type:
+            - string
+            - 'null'
           example: Thank you for your business
           description: The footer text to be displayed on invoices for this billing entity
-          nullable: true
         invoice_grace_period:
           type: integer
           example: 0
@@ -5428,55 +5430,64 @@ components:
           example: 0
           description: The net payment term (in days) for this billing entity
         address_line1:
-          type: string
+          type:
+            - string
+            - 'null'
           example: 5230 Penfield Ave
           description: The first line of the billing address
-          nullable: true
         address_line2:
-          type: string
+          type:
+            - string
+            - 'null'
           example: Suite 100
           description: The second line of the billing address
-          nullable: true
         city:
-          type: string
+          type:
+            - string
+            - 'null'
           example: Woodland Hills
           description: The city of the billing address
-          nullable: true
         state:
-          type: string
+          type:
+            - string
+            - 'null'
           example: CA
           description: The state of the billing address
-          nullable: true
         country:
           $ref: '#/components/schemas/Country'
           description: The country code of the billing address
           nullable: true
         zipcode:
-          type: string
+          type:
+            - string
+            - 'null'
           example: '91364'
           description: The zipcode of the billing address
-          nullable: true
         email:
-          type: string
+          type:
+            - string
+            - 'null'
           format: email
           example: billing@acme.com
           description: The email address of the billing entity
-          nullable: true
         legal_name:
-          type: string
+          type:
+            - string
+            - 'null'
           example: Acme Corporation
           description: The legal name of the billing entity
-          nullable: true
         legal_number:
-          type: string
+          type:
+            - string
+            - 'null'
           example: US123456789
           description: The legal registration number of the billing entity
-          nullable: true
         tax_identification_number:
-          type: string
+          type:
+            - string
+            - 'null'
           example: EU123456789
           description: The tax identification number of the billing entity
-          nullable: true
         timezone:
           $ref: '#/components/schemas/Timezone'
           description: The timezone of the billing entity
@@ -5495,11 +5506,12 @@ components:
           example: false
           description: Whether EU tax management is enabled for this billing entity
         logo_url:
-          type: string
+          type:
+            - string
+            - 'null'
           format: uri
           example: https://getlago.com/logo.png
           description: The URL of the billing entity's logo
-          nullable: true
         created_at:
           type: string
           format: date-time

--- a/src/schemas/BillingEntityCreateInput.yaml
+++ b/src/schemas/BillingEntityCreateInput.yaml
@@ -31,10 +31,11 @@ properties:
           - `per_customer`: document numbers are unique per customer
           - `per_billing_entity`: document numbers are unique per billing entity
       document_number_prefix:
-        type: string
+        type:
+          - string
+          - "null"
         example: "ABC-123"
         description: The prefix used in document numbers for this billing entity
-        nullable: true
       finalize_zero_amount_invoice:
         type: boolean
         example: true
@@ -59,55 +60,64 @@ properties:
         example: 0
         description: The net payment term (in days) for this billing entity
       address_line1:
-        type: string
+        type:
+          - string
+          - "null"
         example: "5230 Penfield Ave"
         description: The first line of the billing address
-        nullable: true
       address_line2:
-        type: string
+        type:
+          - string
+          - "null"
         example: "Suite 100"
         description: The second line of the billing address
-        nullable: true
       city:
-        type: string
+        type:
+          - string
+          - "null"
         example: "Woodland Hills"
         description: The city of the billing address
-        nullable: true
       state:
-        type: string
+        type:
+          - string
+          - "null"
         example: "CA"
         description: The state of the billing address
-        nullable: true
       country:
         $ref: './Country.yaml'
         description: The country code of the billing address
         nullable: true
       zipcode:
-        type: string
+        type:
+          - string
+          - "null"
         example: "91364"
         description: The zipcode of the billing address
-        nullable: true
       email:
-        type: string
+        type:
+          - string
+          - "null"
         format: email
         example: "billing@acme.com"
         description: The email address of the billing entity
-        nullable: true
       legal_name:
-        type: string
+        type:
+          - string
+          - "null"
         example: "Acme Corporation"
         description: The legal name of the billing entity
-        nullable: true
       legal_number:
-        type: string
+        type:
+          - string
+          - "null"
         example: "US123456789"
         description: The legal registration number of the billing entity
-        nullable: true
       tax_identification_number:
-        type: string
+        type:
+          - string
+          - "null"
         example: "EU123456789"
         description: The tax identification number of the billing entity
-        nullable: true
       timezone:
         $ref: './Timezone.yaml'
         description: The timezone of the billing entity
@@ -125,8 +135,9 @@ properties:
         example: false
         description: Whether EU tax management is enabled for this billing entity
       logo:
-        type: string
+        type:
+          - string
+          - "null"
         format: uri
         example: "data:image/png;base64,..."
         description: The base64 encoded logo image for the billing entity
-        nullable: true

--- a/src/schemas/BillingEntityObject.yaml
+++ b/src/schemas/BillingEntityObject.yaml
@@ -46,19 +46,21 @@ properties:
       - `per_billing_entity`: document numbers are unique per billing entity
     example: "per_customer"
   document_number_prefix:
-    type: string
+    type: 
+      - string
+      - 'null'
     example: "ABC-123"
     description: The prefix used in document numbers for this billing entity
-    nullable: true
   finalize_zero_amount_invoice:
     type: boolean
     example: true
     description: Whether to finalize invoices with zero amount for this billing entity
   invoice_footer:
-    type: string
+    type: 
+      - string
+      - 'null'
     example: "Thank you for your business"
     description: The footer text to be displayed on invoices for this billing entity
-    nullable: true
   invoice_grace_period:
     type: integer
     example: 0
@@ -72,55 +74,64 @@ properties:
     example: 0
     description: The net payment term (in days) for this billing entity
   address_line1:
-    type: string
+    type: 
+      - string
+      - 'null'
     example: "5230 Penfield Ave"
     description: The first line of the billing address
-    nullable: true
   address_line2:
-    type: string
+    type: 
+      - string
+      - 'null'
     example: "Suite 100"
     description: The second line of the billing address
-    nullable: true
   city:
-    type: string
+    type: 
+      - string
+      - 'null'
     example: "Woodland Hills"
     description: The city of the billing address
-    nullable: true
   state:
-    type: string
+    type: 
+      - string
+      - 'null'
     example: "CA"
     description: The state of the billing address
-    nullable: true
   country:
     $ref: './Country.yaml'
     description: The country code of the billing address
     nullable: true
   zipcode:
-    type: string
+    type: 
+      - string
+      - 'null'
     example: "91364"
     description: The zipcode of the billing address
-    nullable: true
   email:
-    type: string
+    type: 
+      - string
+      - 'null'
     format: email
     example: "billing@acme.com"
     description: The email address of the billing entity
-    nullable: true
   legal_name:
-    type: string
+    type: 
+      - string
+      - 'null'
     example: "Acme Corporation"
     description: The legal name of the billing entity
-    nullable: true
   legal_number:
-    type: string
+    type: 
+      - string
+      - 'null'
     example: "US123456789"
     description: The legal registration number of the billing entity
-    nullable: true
   tax_identification_number:
-    type: string
+    type: 
+      - string
+      - 'null'
     example: "EU123456789"
     description: The tax identification number of the billing entity
-    nullable: true
   timezone:
     $ref: './Timezone.yaml'
     description: The timezone of the billing entity
@@ -139,11 +150,12 @@ properties:
     example: false
     description: Whether EU tax management is enabled for this billing entity
   logo_url:
-    type: string
+    type: 
+      - string
+      - 'null'
     format: uri
     example: "https://getlago.com/logo.png"
     description: The URL of the billing entity's logo
-    nullable: true
   created_at:
     type: string
     format: date-time

--- a/src/schemas/BillingEntityUpdateInput.yaml
+++ b/src/schemas/BillingEntityUpdateInput.yaml
@@ -25,10 +25,11 @@ properties:
       - `per_customer`: document numbers are unique per customer
       - `per_billing_entity`: document numbers are unique per billing entity
   document_number_prefix:
-    type: string
+    type:
+      - string
+      - "null"
     example: "ABC-123"
     description: The prefix used in document numbers for this billing entity
-    nullable: true
   finalize_zero_amount_invoice:
     type: boolean
     example: true
@@ -53,55 +54,64 @@ properties:
     example: 0
     description: The net payment term (in days) for this billing entity
   address_line1:
-    type: string
+    type:
+      - string
+      - "null"
     example: "5230 Penfield Ave"
     description: The first line of the billing address
-    nullable: true
   address_line2:
-    type: string
+    type:
+      - string
+      - "null"
     example: "Suite 100"
     description: The second line of the billing address
-    nullable: true
   city:
-    type: string
+    type:
+      - string
+      - "null"
     example: "Woodland Hills"
     description: The city of the billing address
-    nullable: true
   state:
-    type: string
+    type:
+      - string
+      - "null"
     example: "CA"
     description: The state of the billing address
-    nullable: true
   country:
     $ref: './Country.yaml'
     description: The country code of the billing address
     nullable: true
   zipcode:
-    type: string
+    type:
+      - string
+      - "null"
     example: "91364"
     description: The zipcode of the billing address
-    nullable: true
   email:
-    type: string
+    type:
+      - string
+      - "null"
     format: email
     example: "billing@acme.com"
     description: The email address of the billing entity
-    nullable: true
   legal_name:
-    type: string
+    type:
+      - string
+      - "null"
     example: "Acme Corporation"
     description: The legal name of the billing entity
-    nullable: true
   legal_number:
-    type: string
+    type:
+      - string
+      - "null"
     example: "US123456789"
     description: The legal registration number of the billing entity
-    nullable: true
   tax_identification_number:
-    type: string
+    type:
+      - string
+      - "null"
     example: "EU123456789"
     description: The tax identification number of the billing entity
-    nullable: true
   timezone:
     $ref: './Timezone.yaml'
     description: The timezone of the billing entity
@@ -119,8 +129,9 @@ properties:
     example: false
     description: Whether EU tax management is enabled for this billing entity
   logo:
-    type: string
+    type:
+      - string
+      - "null"
     format: uri
     example: "data:image/png;base64,..."
     description: The base64 encoded logo image for the billing entity
-    nullable: true

--- a/src/schemas/CustomerCreateInput.yaml
+++ b/src/schemas/CustomerCreateInput.yaml
@@ -12,10 +12,11 @@ properties:
         example: "5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba"
         description: The customer external unique identifier (provided by your own application)
       billing_entity_code:
-        type: string
+        type:
+          - string
+          - "null"
         example: 'acme_corp'
         description: The unique code of the billing entity to associate with the customer. If not provided, the default billing entity will be used.
-        nullable: true
       address_line1:
         type:
           - string

--- a/src/schemas/InvoiceBaseObject.yaml
+++ b/src/schemas/InvoiceBaseObject.yaml
@@ -27,10 +27,11 @@ properties:
     description: Unique identifier assigned to the fee within the Lago application. This ID is exclusively created by Lago and serves as a unique identifier for the fee's record within the Lago system.
     example: "1a901a90-1a90-1a90-1a90-1a901a901a90"
   billing_entity_code:
-    type: string
+    type:
+      - string
+      - "null"
     example: "acme_corp"
     description: The unique code of the billing entity associated with the invoice
-    nullable: true
   sequential_id:
     type: integer
     description: This ID helps in uniquely identifying and organizing the invoices associated with a specific customer. It provides a sequential numbering system specific to the customer, allowing for easy tracking and management of invoices within the customer's context.

--- a/src/schemas/WalletCreateInput.yaml
+++ b/src/schemas/WalletCreateInput.yaml
@@ -118,9 +118,10 @@ properties:
               example: "2022-08-08T00:00:00Z"
               description: The effective start date for recurring top-ups. This date should be provided in ISO 8601 datetime format and expressed in Coordinated Universal Time (UTC).
             expiration_at:
-              type: string
+              type:
+                - string
+                - "null"
               format: date-time
-              nullable: true
               description: The expiration date and time for this specific recurring transaction rule. It follows the ISO 8601 datetime format and is expressed in Coordinated Universal Time (UTC).
               example: "2023-09-30T23:59:59Z"
             threshold_credits:

--- a/src/schemas/WalletUpdateInput.yaml
+++ b/src/schemas/WalletUpdateInput.yaml
@@ -82,9 +82,10 @@ properties:
               example: "2022-08-08T00:00:00Z"
               description: The effective start date for recurring top-ups. This date should be provided in ISO 8601 datetime format and expressed in Coordinated Universal Time (UTC).
             expiration_at:
-              type: string
+              type:
+                - string
+                - "null"
               format: date-time
-              nullable: true
               description: The expiration date and time for this specific recurring transaction rule. It follows the ISO 8601 datetime format and is expressed in Coordinated Universal Time (UTC).
               example: "2023-09-30T23:59:59Z"
             target_ongoing_balance:


### PR DESCRIPTION
fixes the following errors:

```
validating openapi.yaml...
[1] openapi.yaml:5408:11 at #/components/schemas/BillingEntityObject/properties/document_number_prefix/nullable

Property `nullable` is not expected here.

5406 |   example: ABC-123
5407 |   description: The prefix used in document numbers for this billing entity
5408 |   nullable: true
5409 | finalize_zero_amount_invoice:
5410 |   type: boolean

Error was generated by the struct rule.


[2] openapi.yaml:5417:11 at #/components/schemas/BillingEntityObject/properties/invoice_footer/nullable

Property `nullable` is not expected here.

5415 |   example: Thank you for your business
5416 |   description: The footer text to be displayed on invoices for this billing entity
5417 |   nullable: true
5418 | invoice_grace_period:
5419 |   type: integer

Error was generated by the struct rule.


[3] openapi.yaml:5434:11 at #/components/schemas/BillingEntityObject/properties/address_line1/nullable

Property `nullable` is not expected here.

5432 |   example: 5230 Penfield Ave
5433 |   description: The first line of the billing address
5434 |   nullable: true
5435 | address_line2:
5436 |   type: string

Error was generated by the struct rule.


[4] openapi.yaml:5439:11 at #/components/schemas/BillingEntityObject/properties/address_line2/nullable

Property `nullable` is not expected here.

5437 |   example: Suite 100
5438 |   description: The second line of the billing address
5439 |   nullable: true
5440 | city:
5441 |   type: string

Error was generated by the struct rule.


[5] openapi.yaml:5444:11 at #/components/schemas/BillingEntityObject/properties/city/nullable

Property `nullable` is not expected here.

5442 |   example: Woodland Hills
5443 |   description: The city of the billing address
5444 |   nullable: true
5445 | state:
5446 |   type: string

Error was generated by the struct rule.


[6] openapi.yaml:5449:11 at #/components/schemas/BillingEntityObject/properties/state/nullable

Property `nullable` is not expected here.

5447 |   example: CA
5448 |   description: The state of the billing address
5449 |   nullable: true
5450 | country:
5451 |   $ref: '#/components/schemas/Country'

Error was generated by the struct rule.


[7] openapi.yaml:5458:11 at #/components/schemas/BillingEntityObject/properties/zipcode/nullable

Property `nullable` is not expected here.

5456 |   example: '91364'
5457 |   description: The zipcode of the billing address
5458 |   nullable: true
5459 | email:
5460 |   type: string

Error was generated by the struct rule.


[8] openapi.yaml:5464:11 at #/components/schemas/BillingEntityObject/properties/email/nullable

Property `nullable` is not expected here.

5462 |   example: billing@acme.com
5463 |   description: The email address of the billing entity
5464 |   nullable: true
5465 | legal_name:
5466 |   type: string

Error was generated by the struct rule.


[9] openapi.yaml:5469:11 at #/components/schemas/BillingEntityObject/properties/legal_name/nullable

Property `nullable` is not expected here.

5467 |   example: Acme Corporation
5468 |   description: The legal name of the billing entity
5469 |   nullable: true
5470 | legal_number:
5471 |   type: string

Error was generated by the struct rule.


[10] openapi.yaml:5474:11 at #/components/schemas/BillingEntityObject/properties/legal_number/nullable

Property `nullable` is not expected here.

5472 |   example: US123456789
5473 |   description: The legal registration number of the billing entity
5474 |   nullable: true
5475 | tax_identification_number:
5476 |   type: string

Error was generated by the struct rule.


[11] openapi.yaml:5479:11 at #/components/schemas/BillingEntityObject/properties/tax_identification_number/nullable

Property `nullable` is not expected here.

5477 |   example: EU123456789
5478 |   description: The tax identification number of the billing entity
5479 |   nullable: true
5480 | timezone:
5481 |   $ref: '#/components/schemas/Timezone'

Error was generated by the struct rule.


[12] openapi.yaml:5502:11 at #/components/schemas/BillingEntityObject/properties/logo_url/nullable

Property `nullable` is not expected here.

5500 |   example: https://getlago.com/logo.png
5501 |   description: The URL of the billing entity's logo
5502 |   nullable: true
5503 | created_at:
5504 |   type: string

Error was generated by the struct rule.


[13] openapi.yaml:8794:15 at #/components/schemas/CustomerCreateInput/properties/customer/properties/billing_entity_code/nullable

Property `nullable` is not expected here.

8792 |   example: acme_corp
8793 |   description: The unique code of the billing entity to associate with the customer. If not provided, the default billing e...<2 chars>
8794 |   nullable: true
8795 | address_line1:
8796 |   type:

Error was generated by the struct rule.


[14] openapi.yaml:9553:11 at #/components/schemas/InvoiceBaseObject/properties/billing_entity_code/nullable

Property `nullable` is not expected here.

9551 |   example: acme_corp
9552 |   description: The unique code of the billing entity associated with the invoice
9553 |   nullable: true
9554 | sequential_id:
9555 |   type: integer

Error was generated by the struct rule.


[15] openapi.yaml:12703:21 at #/components/schemas/WalletCreateInput/properties/wallet/properties/recurring_transaction_rules/items/properties/expiration_at/nullable

Property `nullable` is not expected here.

12701 | type: string
12702 | format: date-time
12703 | nullable: true
12704 | description: The expiration date and time for this specific recurring transaction rule. It follows the ISO 8601 datetime f...<41 chars>
12705 | example: '2023-09-30T23:59:59Z'

Error was generated by the struct rule.


[16] openapi.yaml:12831:21 at #/components/schemas/WalletUpdateInput/properties/wallet/properties/recurring_transaction_rules/items/properties/expiration_at/nullable

Property `nullable` is not expected here.

12829 | type: string
12830 | format: date-time
12831 | nullable: true
12832 | description: The expiration date and time for this specific recurring transaction rule. It follows the ISO 8601 datetime f...<41 chars>
12833 | example: '2023-09-30T23:59:59Z'

Error was generated by the struct rule.


[17] openapi.yaml:13689:15 at #/components/schemas/BillingEntityCreateInput/properties/billing_entity/properties/document_number_prefix/nullable

Property `nullable` is not expected here.

13687 |   example: ABC-123
13688 |   description: The prefix used in document numbers for this billing entity
13689 |   nullable: true
13690 | finalize_zero_amount_invoice:
13691 |   type: boolean

Error was generated by the struct rule.


[18] openapi.yaml:13717:15 at #/components/schemas/BillingEntityCreateInput/properties/billing_entity/properties/address_line1/nullable

Property `nullable` is not expected here.

13715 |   example: 5230 Penfield Ave
13716 |   description: The first line of the billing address
13717 |   nullable: true
13718 | address_line2:
13719 |   type: string

Error was generated by the struct rule.


[19] openapi.yaml:13722:15 at #/components/schemas/BillingEntityCreateInput/properties/billing_entity/properties/address_line2/nullable

Property `nullable` is not expected here.

13720 |   example: Suite 100
13721 |   description: The second line of the billing address
13722 |   nullable: true
13723 | city:
13724 |   type: string

Error was generated by the struct rule.


[20] openapi.yaml:13727:15 at #/components/schemas/BillingEntityCreateInput/properties/billing_entity/properties/city/nullable

Property `nullable` is not expected here.

13725 |   example: Woodland Hills
13726 |   description: The city of the billing address
13727 |   nullable: true
13728 | state:
13729 |   type: string

Error was generated by the struct rule.


[21] openapi.yaml:13732:15 at #/components/schemas/BillingEntityCreateInput/properties/billing_entity/properties/state/nullable

Property `nullable` is not expected here.

13730 |   example: CA
13731 |   description: The state of the billing address
13732 |   nullable: true
13733 | country:
13734 |   $ref: '#/components/schemas/Country'

Error was generated by the struct rule.


[22] openapi.yaml:13741:15 at #/components/schemas/BillingEntityCreateInput/properties/billing_entity/properties/zipcode/nullable

Property `nullable` is not expected here.

13739 |   example: '91364'
13740 |   description: The zipcode of the billing address
13741 |   nullable: true
13742 | email:
13743 |   type: string

Error was generated by the struct rule.


[23] openapi.yaml:13747:15 at #/components/schemas/BillingEntityCreateInput/properties/billing_entity/properties/email/nullable

Property `nullable` is not expected here.

13745 |   example: billing@acme.com
13746 |   description: The email address of the billing entity
13747 |   nullable: true
13748 | legal_name:
13749 |   type: string

Error was generated by the struct rule.


[24] openapi.yaml:13752:15 at #/components/schemas/BillingEntityCreateInput/properties/billing_entity/properties/legal_name/nullable

Property `nullable` is not expected here.

13750 |   example: Acme Corporation
13751 |   description: The legal name of the billing entity
13752 |   nullable: true
13753 | legal_number:
13754 |   type: string

Error was generated by the struct rule.


[25] openapi.yaml:13757:15 at #/components/schemas/BillingEntityCreateInput/properties/billing_entity/properties/legal_number/nullable

Property `nullable` is not expected here.

13755 |   example: US123456789
13756 |   description: The legal registration number of the billing entity
13757 |   nullable: true
13758 | tax_identification_number:
13759 |   type: string

Error was generated by the struct rule.


[26] openapi.yaml:13762:15 at #/components/schemas/BillingEntityCreateInput/properties/billing_entity/properties/tax_identification_number/nullable

Property `nullable` is not expected here.

13760 |   example: EU123456789
13761 |   description: The tax identification number of the billing entity
13762 |   nullable: true
13763 | timezone:
13764 |   $ref: '#/components/schemas/Timezone'

Error was generated by the struct rule.


[27] openapi.yaml:13784:15 at #/components/schemas/BillingEntityCreateInput/properties/billing_entity/properties/logo/nullable

Property `nullable` is not expected here.

13782 |           example: data:image/png;base64,...
13783 |           description: The base64 encoded logo image for the billing entity
13784 |           nullable: true
13785 | BillingEntityUpdateInput:
13786 |   type: object

Error was generated by the struct rule.


[28] openapi.yaml:13816:11 at #/components/schemas/BillingEntityUpdateInput/properties/document_number_prefix/nullable

Property `nullable` is not expected here.

13814 |   example: ABC-123
13815 |   description: The prefix used in document numbers for this billing entity
13816 |   nullable: true
13817 | finalize_zero_amount_invoice:
13818 |   type: boolean

Error was generated by the struct rule.


[29] openapi.yaml:13844:11 at #/components/schemas/BillingEntityUpdateInput/properties/address_line1/nullable

Property `nullable` is not expected here.

13842 |   example: 5230 Penfield Ave
13843 |   description: The first line of the billing address
13844 |   nullable: true
13845 | address_line2:
13846 |   type: string

Error was generated by the struct rule.


[30] openapi.yaml:13849:11 at #/components/schemas/BillingEntityUpdateInput/properties/address_line2/nullable

Property `nullable` is not expected here.

13847 |   example: Suite 100
13848 |   description: The second line of the billing address
13849 |   nullable: true
13850 | city:
13851 |   type: string

Error was generated by the struct rule.


[31] openapi.yaml:13854:11 at #/components/schemas/BillingEntityUpdateInput/properties/city/nullable

Property `nullable` is not expected here.

13852 |   example: Woodland Hills
13853 |   description: The city of the billing address
13854 |   nullable: true
13855 | state:
13856 |   type: string

Error was generated by the struct rule.


[32] openapi.yaml:13859:11 at #/components/schemas/BillingEntityUpdateInput/properties/state/nullable

Property `nullable` is not expected here.

13857 |   example: CA
13858 |   description: The state of the billing address
13859 |   nullable: true
13860 | country:
13861 |   $ref: '#/components/schemas/Country'

Error was generated by the struct rule.


[33] openapi.yaml:13868:11 at #/components/schemas/BillingEntityUpdateInput/properties/zipcode/nullable

Property `nullable` is not expected here.

13866 |   example: '91364'
13867 |   description: The zipcode of the billing address
13868 |   nullable: true
13869 | email:
13870 |   type: string

Error was generated by the struct rule.


[34] openapi.yaml:13874:11 at #/components/schemas/BillingEntityUpdateInput/properties/email/nullable

Property `nullable` is not expected here.

13872 |   example: billing@acme.com
13873 |   description: The email address of the billing entity
13874 |   nullable: true
13875 | legal_name:
13876 |   type: string

Error was generated by the struct rule.


[35] openapi.yaml:13879:11 at #/components/schemas/BillingEntityUpdateInput/properties/legal_name/nullable

Property `nullable` is not expected here.

13877 |   example: Acme Corporation
13878 |   description: The legal name of the billing entity
13879 |   nullable: true
13880 | legal_number:
13881 |   type: string

Error was generated by the struct rule.


[36] openapi.yaml:13884:11 at #/components/schemas/BillingEntityUpdateInput/properties/legal_number/nullable

Property `nullable` is not expected here.

13882 |   example: US123456789
13883 |   description: The legal registration number of the billing entity
13884 |   nullable: true
13885 | tax_identification_number:
13886 |   type: string

Error was generated by the struct rule.


[37] openapi.yaml:13889:11 at #/components/schemas/BillingEntityUpdateInput/properties/tax_identification_number/nullable

Property `nullable` is not expected here.

13887 |   example: EU123456789
13888 |   description: The tax identification number of the billing entity
13889 |   nullable: true
13890 | timezone:
13891 |   $ref: '#/components/schemas/Timezone'

Error was generated by the struct rule.


[38] openapi.yaml:13911:11 at #/components/schemas/BillingEntityUpdateInput/properties/logo/nullable

Property `nullable` is not expected here.

13909 |       example: data:image/png;base64,...
13910 |       description: The base64 encoded logo image for the billing entity
13911 |       nullable: true
13912 | CustomerPaymentProvidernErrorObject:
13913 |   $ref: '#/components/schemas/CustomerPaymentProviderErrorObject'

Error was generated by the struct rule.


openapi.yaml: validated in 145ms

❌ Validation failed with 38 errors and 3 warnings.
run `redocly lint --generate-ignore-file` to add all problems to the ignore file.
```