### PR TITLE
fix: add invoice_id parameter to payments endpoint

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2386,7 +2386,7 @@ paths:
         - $ref: '#/components/parameters/page'
         - $ref: '#/components/parameters/per_page'
         - $ref: '#/components/parameters/external_customer_id'
-        - name: lago_invoice_id
+        - name: invoice_id
           in: query
           description: Unique identifier assigned to the invoice within the Lago application. This ID is exclusively created by Lago and serves as a unique identifier for the invoice's record within the Lago system.
           required: false

--- a/src/resources/payments.yaml
+++ b/src/resources/payments.yaml
@@ -34,7 +34,7 @@ get:
     - $ref: '../parameters/page.yaml'
     - $ref: '../parameters/per_page.yaml'
     - $ref: '../parameters/external_customer_id.yaml'
-    - name: lago_invoice_id
+    - name: invoice_id
       in: query
       description: Unique identifier assigned to the invoice within the Lago application. This ID is exclusively created by Lago and serves as a unique identifier for the invoice's record within the Lago system.
       required: false


### PR DESCRIPTION
Switch payments param from `lago_invoice_id` to `invoice_id`