### PR TITLE
feat(coupons): Add `coupon_code` filter for "List all applied coupons"

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -242,7 +242,7 @@ paths:
         - $ref: '#/components/parameters/per_page'
         - name: from_date
           in: query
-          description: Filter activity logs from an specific date.
+          description: Filter activity logs from a specific date.
           required: false
           explode: true
           schema:
@@ -251,7 +251,7 @@ paths:
             example: '2022-08-09'
         - name: to_date
           in: query
-          description: Filter activity logs up to an specific date.
+          description: Filter activity logs up to a specific date.
           required: false
           explode: true
           schema:
@@ -297,7 +297,6 @@ paths:
               type: string
             example:
               - dinesh@piedpiper.test
-              - brex@brex.com
         - $ref: '#/components/parameters/external_customer_id'
         - $ref: '#/components/parameters/external_subscription_id'
         - name: resource_ids
@@ -690,6 +689,18 @@ paths:
           schema:
             type: string
             example: 5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba
+        - name: coupon_code[]
+          in: query
+          description: The code of the coupon applied to the customer. Use it to filter applied coupons by their code.
+          required: false
+          explode: true
+          schema:
+            type: array
+            items:
+              type: string
+            example:
+              - BLACK_FRIDAY_2024
+              - CHRISTMAS_2024
       responses:
         '200':
           description: Applied Coupons

--- a/src/resources/applied_coupons.yaml
+++ b/src/resources/applied_coupons.yaml
@@ -54,6 +54,16 @@ get:
       schema:
         type: string
         example: '5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba'
+    - name: coupon_code[]
+      in: query
+      description: The code of the coupon applied to the customer. Use it to filter applied coupons by their code.
+      required: false
+      explode: true
+      schema:
+        type: array
+        items:
+          type: string
+        example: ['BLACK_FRIDAY_2024', 'CHRISTMAS_2024']
   responses:
     '200':
       description: Applied Coupons


### PR DESCRIPTION
## Context

Clients can review applied coupons using the relevant endpoint: https://getlago.com/docs/api-reference/coupons/get-all-applied. However, since there is no way to filter by coupon code, clients must page through all results to find redemptions for a specific coupon.

## Description

This PR documents the `coupon_code` filter added to the `GET /api/v1/applied_coupons` endpoint in https://github.com/getlago/lago-api/pull/3782.