### PR TITLE
feat(pricing_group_keys): Update documentation

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -242,7 +242,7 @@ paths:
         - $ref: '#/components/parameters/per_page'
         - name: from_date
           in: query
-          description: Filter activity logs from an specific date.
+          description: Filter activity logs from a specific date.
           required: false
           explode: true
           schema:
@@ -251,7 +251,7 @@ paths:
             example: '2022-08-09'
         - name: to_date
           in: query
-          description: Filter activity logs up to an specific date.
+          description: Filter activity logs up to a specific date.
           required: false
           explode: true
           schema:
@@ -297,7 +297,6 @@ paths:
               type: string
             example:
               - dinesh@piedpiper.test
-              - brex@brex.com
         - $ref: '#/components/parameters/external_customer_id'
         - $ref: '#/components/parameters/external_subscription_id'
         - name: resource_ids
@@ -11782,6 +11781,23 @@ components:
     ChargeProperties:
       type: object
       properties:
+        grouped_by:
+          type: array
+          description: |-
+            The list of event properties that are used to group the events on the invoice for a `standard` charge model.
+            **DEPRECATED** Replaced by pricing_group_keys
+          items:
+            type: string
+          example:
+            - agent_name
+          deprecated: true
+        pricing_group_keys:
+          type: array
+          description: The list of event properties that are used to group the events on the invoice.
+          items:
+            type: string
+          example:
+            - agent_name
         graduated_ranges:
           type: array
           description: Graduated ranges, sorted from bottom to top tiers, used for a `graduated` charge model.
@@ -11902,13 +11918,6 @@ components:
           format: ^[0-9]+.?[0-9]*$
           description: Specifies the minimum allowable spending for a single transaction. Working as a transaction floor.
           example: '1.75'
-        grouped_by:
-          type: array
-          description: The list of event properties that are used to group the events on the invoice for a `standard` charge model.
-          items:
-            type: string
-          example:
-            - agent_name
         volume_ranges:
           type: array
           description: Volume ranges, sorted from bottom to top tiers, used for a `volume` charge model.

--- a/src/schemas/ChargeProperties.yaml
+++ b/src/schemas/ChargeProperties.yaml
@@ -1,5 +1,22 @@
 type: object
 properties:
+  # Common attributes
+  grouped_by:
+    type: array
+    description: |-
+      The list of event properties that are used to group the events on the invoice for a `standard` charge model.
+      **DEPRECATED** Replaced by pricing_group_keys
+    items:
+      type: string
+    example: ["agent_name"]
+    deprecated: true
+  pricing_group_keys:
+    type: array
+    description: The list of event properties that are used to group the events on the invoice.
+    items:
+      type: string
+    example: ["agent_name"]
+
   # Graduated charge model
   graduated_ranges:
     type: array
@@ -129,14 +146,6 @@ properties:
     format: "^[0-9]+.?[0-9]*$"
     description: Specifies the minimum allowable spending for a single transaction. Working as a transaction floor.
     example: "1.75"
-
-  # Standard only charge model
-  grouped_by:
-    type: array
-    description: The list of event properties that are used to group the events on the invoice for a `standard` charge model.
-    items:
-      type: string
-    example: ["agent_name"]
 
   # Volume charge model
   volume_ranges:

--- a/src/schemas/ChargeProperties.yaml
+++ b/src/schemas/ChargeProperties.yaml
@@ -5,7 +5,7 @@ properties:
     type: array
     description: |-
       The list of event properties that are used to group the events on the invoice for a `standard` charge model.
-      **DEPRECATED** Replaced by pricing_group_keys
+      **DEPRECATED** Replaced by `pricing_group_keys`.
     items:
       type: string
     example: ["agent_name"]


### PR DESCRIPTION
## Context

This PR is related to https://github.com/getlago/lago-api/pull/3790

## Description

It updates the `ChargeProperties` object:
- Mark `group_by` field as deprecated
- Document the new `pricing_group_keys` and removes the charge model limitation