### PR TITLE
fix(issue-909):fix param name for list all payments

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2515,7 +2515,7 @@ paths:
         - $ref: '#/components/parameters/page'
         - $ref: '#/components/parameters/per_page'
         - $ref: '#/components/parameters/external_customer_id'
-        - name: lago_invoice_id
+        - name: invoice_id
           in: query
           description: Unique identifier assigned to the invoice within the Lago application. This ID is exclusively created by Lago and serves as a unique identifier for the invoice's record within the Lago system.
           required: false

--- a/src/resources/payments.yaml
+++ b/src/resources/payments.yaml
@@ -34,7 +34,7 @@ get:
     - $ref: '../parameters/page.yaml'
     - $ref: '../parameters/per_page.yaml'
     - $ref: '../parameters/external_customer_id.yaml'
-    - name: lago_invoice_id
+    - name: invoice_id
       in: query
       description: Unique identifier assigned to the invoice within the Lago application. This ID is exclusively created by Lago and serves as a unique identifier for the invoice's record within the Lago system.
       required: false


### PR DESCRIPTION
This issue fixes the ticket [ISSUE-909](https://linear.app/getlago/issue/ISSUE-909/update-filter-for-list-all-payments-endpoint-docs).

It changes the param name for `List all payments` from `lago_invoice_id` to `invoice_id`. 

Reference:[API param](https://github.com/getlago/lago-api/blob/43713815280fc8cce1d9cdff042067125654b84f/app/controllers/api/v1/payments_controller.rb#L64)