### PR TITLE
chore(preview): Add command to preview OpenAPI with live-reload

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@ Open API specification for Lago project
 
 ## Current Releases
 
-| Project            | Release Badge                                                                                       |
-|--------------------|-----------------------------------------------------------------------------------------------------|
-| **Lago**           | [![Lago Release](https://img.shields.io/github/v/release/getlago/lago)](https://github.com/getlago/lago/releases) |
-| **Lago OpenAPI**     | [![Lago OpenAPI Release](https://img.shields.io/github/v/release/getlago/lago-openapi)](https://github.com/getlago/lago-openapi/releases) |
+| Project          | Release Badge                                                                                                                             |
+| ---------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| **Lago**         | [![Lago Release](https://img.shields.io/github/v/release/getlago/lago)](https://github.com/getlago/lago/releases)                         |
+| **Lago OpenAPI** | [![Lago OpenAPI Release](https://img.shields.io/github/v/release/getlago/lago-openapi)](https://github.com/getlago/lago-openapi/releases) |
 
 ## Usage
 
@@ -31,27 +31,44 @@ Read more [here](https://www.getlago.com/blog/open-source-licensing-and-why-lago
 
 ## Local development
 
-#### Install dependencies
+### Install dependencies
 
 ```
 npm install
 ```
 
-#### Build openapi.yaml
+You may also need Docker to run some commands.
+
+### Build openapi.yaml
 
 ```
 npm run build
 ```
 
-#### Lint
+### Lint
 
 ```
 npm run test
 ```
 
-#### Running swagger in Docker to preview
+### Preview using Redoc
+
+To preview the OpenAPI specification using Redoc, you can use the following command:
 
 ```sh
-docker pull docker.swagger.io/swaggerapi/swagger-ui
-npm run build && docker run -p 8080:8080 -e SWAGGER_JSON=/swagger/openapi.yaml -v "$HOME/Lago/openapi:/swagger" swaggerapi/swagger-ui
+npm run preview:redocly
 ```
+
+This will watch for changes in the OpenAPI specification files and automatically rebuild and reload them.
+
+The Redoc documentation will be available at `http://localhost:8080/`.
+
+### Preview using Swagger UI
+
+To preview the OpenAPI specification using Swagger UI, as on <https://swagger.getlago.com>, you can use the following command:
+
+```sh
+npm run preview:swagger
+```
+
+The Swagger UI will be available at `http://localhost:8080/`.

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
   "scripts": {
     "build": "redocly bundle src/openapi.yaml --output openapi.yaml --ext yaml",
     "test": "npm run build && redocly lint openapi.yaml && spectral lint openapi.yaml",
-    "clean": "rm -r _build"
+    "clean": "rm -r _build",
+    "preview:swagger": "npm run build && docker run -p 8080:8080 -e SWAGGER_JSON=/swagger/openapi.yaml -v './openapi.yaml:/swagger/openapi.yaml' swaggerapi/swagger-ui",
+    "preview:redocly": "redocly preview-docs src/openapi.yaml --port 8080"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
The `README` already included a command to preview the Swagger documentation but this command required to build the documentation beforehand using Redocly CLI. This command was wrapped into a `npm run preview:swagger` command for simplified usage.

A new `npm run preview:redocly` command was added to be able to preview with file watches and live reload using Redocly CLI.