### PR TITLE
feat: add params to void invoice

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2349,9 +2349,19 @@ paths:
       tags:
         - invoices
       summary: Void an invoice
-      description: This endpoint is used for voiding an invoice. You can void an invoice only when it's in a `finalized` status, and the payment status is not `succeeded`.
+      description: |-
+        Void an invoice.
+
+        Supplying `generate_credit_note` (optionally with `refund_amount` and/or `credit_amount`) forces the void and creates a credit note. If the specified refund/credit amounts do not cover the full invoice total, the remainder is issued on a second credit note that is created and immediately voided.
       parameters:
         - $ref: '#/components/parameters/lago_invoice_id'
+      requestBody:
+        description: Void invoice payload
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/InvoiceVoidInput'
+        required: false
       operationId: voidInvoice
       responses:
         '200':
@@ -11175,6 +11185,25 @@ components:
           type: string
           description: The code of the billing entity to which will be associated a customer if the external_id is not provided. If billing_entity_code is not provided, default billing_entity of organization will be used.
           example: acme_corp
+    InvoiceVoidInput:
+      type: object
+      properties:
+        generate_credit_note:
+          type: boolean
+          description: Set to `true` to force voiding the invoice and generate a credit note.
+          example: true
+        refund_amount:
+          type: integer
+          description: Portion of the invoice amount (in cents) to be refunded to the customer in the generated credit note.
+          example: 2000
+          minimum: 0
+        credit_amount:
+          type: integer
+          description: Portion of the invoice amount (in cents) to be credited to the customer's balance in the generated credit note.
+          example: 1150
+          minimum: 0
+      required: []
+      description: Parameters available when voiding an invoice that optionally generate credit notes.
     OrganizationBillingConfiguration:
       type: object
       description: The custom billing settings for your organization.

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2350,9 +2350,9 @@ paths:
         - invoices
       summary: Void an invoice
       description: |-
-        Void an invoice.
-
-        Supplying `generate_credit_note` (optionally with `refund_amount` and/or `credit_amount`) forces the void and creates a credit note. If the specified refund/credit amounts do not cover the full invoice total, the remainder is issued on a second credit note that is created and immediately voided.
+        This endpoint is used for voiding an invoice.
+        • When no body parameters are provided, the invoice can be voided only if it is in a `finalized` status and its payment status is NOT `succeeded`.
+        • When `generate_credit_note` is provided (optionally with `refund_amount` and/or `credit_amount`), this validation is bypassed: the invoice is forcibly voided and a credit note is generated. If the specified refund/credit amounts do not cover the full invoice total, the remainder is issued on a second credit note that is created and immediately voided.
       parameters:
         - $ref: '#/components/parameters/lago_invoice_id'
       requestBody:

--- a/src/resources/invoice_void.yaml
+++ b/src/resources/invoice_void.yaml
@@ -3,9 +3,9 @@ post:
     - invoices
   summary: Void an invoice
   description: |-
-    Void an invoice.
-
-    Supplying `generate_credit_note` (optionally with `refund_amount` and/or `credit_amount`) forces the void and creates a credit note. If the specified refund/credit amounts do not cover the full invoice total, the remainder is issued on a second credit note that is created and immediately voided.
+    This endpoint is used for voiding an invoice.
+    • When no body parameters are provided, the invoice can be voided only if it is in a `finalized` status and its payment status is NOT `succeeded`.
+    • When `generate_credit_note` is provided (optionally with `refund_amount` and/or `credit_amount`), this validation is bypassed: the invoice is forcibly voided and a credit note is generated. If the specified refund/credit amounts do not cover the full invoice total, the remainder is issued on a second credit note that is created and immediately voided.
   parameters:
     - $ref: '../parameters/lago_invoice_id.yaml'
   requestBody:

--- a/src/resources/invoice_void.yaml
+++ b/src/resources/invoice_void.yaml
@@ -2,10 +2,19 @@ post:
   tags:
     - invoices
   summary: Void an invoice
-  description: This endpoint is used for voiding an invoice. You can void an invoice only when it's in a `finalized` status, and the payment status is not `succeeded`.
+  description: |-
+    Void an invoice.
+
+    Supplying `generate_credit_note` (optionally with `refund_amount` and/or `credit_amount`) forces the void and creates a credit note. If the specified refund/credit amounts do not cover the full invoice total, the remainder is issued on a second credit note that is created and immediately voided.
   parameters:
     - $ref: '../parameters/lago_invoice_id.yaml'
-
+  requestBody:
+    description: Void invoice payload
+    content:
+      application/json:
+        schema:
+          $ref: '../schemas/InvoiceVoidInput.yaml'
+    required: false
   operationId: voidInvoice
   responses:
     '200':

--- a/src/schemas/InvoiceVoidInput.yaml
+++ b/src/schemas/InvoiceVoidInput.yaml
@@ -1,0 +1,18 @@
+type: object
+properties:
+  generate_credit_note:
+    type: boolean
+    description: Set to `true` to force voiding the invoice and generate a credit note.
+    example: true
+  refund_amount:
+    type: integer
+    description: Portion of the invoice amount (in cents) to be refunded to the customer in the generated credit note.
+    example: 2000
+    minimum: 0
+  credit_amount:
+    type: integer
+    description: Portion of the invoice amount (in cents) to be credited to the customer's balance in the generated credit note.
+    example: 1150
+    minimum: 0
+required: []
+description: Parameters available when voiding an invoice that optionally generate credit notes.


### PR DESCRIPTION
Extend Void Invoice endpoint with credit-note workflow

Updated /invoices/{lago_id}/void doc:
Default behaviour unchanged – invoice must be finalized & payment NOT succeeded.

If generate_credit_note is sent, validation is bypassed: invoice is forcibly voided, credit note(s) created.
Remainder (when partial refund / credit) is placed on an auto-voided second credit note for bookkeeping.