### PR TITLE
fix(customer): fix array parameters description in customer API

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1301,7 +1301,7 @@ paths:
       parameters:
         - $ref: '#/components/parameters/page'
         - $ref: '#/components/parameters/per_page'
-        - name: account_type
+        - name: account_type[]
           in: query
           description: Filter customers by account type.
           required: false
@@ -1316,7 +1316,7 @@ paths:
             example:
               - customer
               - partner
-        - name: billing_entity_codes
+        - name: billing_entity_codes[]
           in: query
           description: Filter customers by billing entity codes.
           required: false

--- a/src/resources/customers.yaml
+++ b/src/resources/customers.yaml
@@ -33,7 +33,7 @@ get:
   parameters:
     - $ref: '../parameters/page.yaml'
     - $ref: '../parameters/per_page.yaml'
-    - name: account_type
+    - name: account_type[]
       in: query
       description: Filter customers by account type.
       required: false
@@ -46,7 +46,7 @@ get:
             - customer
             - partner
         example: [customer, partner]
-    - name: billing_entity_codes
+    - name: billing_entity_codes[]
       in: query
       description: Filter customers by billing entity codes.
       required: false


### PR DESCRIPTION
In the documentation, we say that the `account_type` and `billing_entity_codes` parameter is an array. But Rails expects the parameter name to be `account_type[]`.

The following doesn't work:

```http
GET /api/v1/customers?account_type=customer&account_type=partner HTTP/1.1
Host: api.lago.dev
Authorization: Bearer ***

HTTP/1.1 422 Unprocessable Entity

{
 "status": 422,
 "error": "Unprocessable Entity",
 "code": "validation_errors",
 "error_details": {
  "filters": {
   "account_type": [
    "must be an array"
   ]
  }
 }
}
```

While the following works:

```http
GET /api/v1/customers?account_type[]=customer&account_type[]=partner HTTP/1.1
Host: api.lago.dev
Authorization: Bearer ***

HTTP/1.1 200 OK

{
 "customers": [...],
 "meta": {...}
}
```

Note that sending it as CSV is not supported either:

```http
GET /api/v1/customers?account_type=customer,partner HTTP/1.1
Host: api.lago.dev
Authorization: Bearer ***

HTTP/1.1 422 Unprocessable Entity
{
 "status": 422,
 "error": "Unprocessable Entity",
 "code": "validation_errors",
 "error_details": {
  "filters": {
   "account_type": [
    "must be an array"
   ]
  }
 }
}
```

The same goes for the `billing_entity_codes` parameter, with the exception that we end up with a 500 error instead of a 422 due to a missing sanitization:

```http
GET /api/v1/customers?billing_entity_codes=hooli HTTP/1.1
Host: api.lago.dev
Authorization: Bearer ***

HTTP/1.1 500 Internal Server Error
```