### PR TITLE
Actually add new plan webhooks

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -4943,6 +4943,105 @@ webhooks:
       responses:
         '200':
           description: Return a 200 status to indicate that the data was received successfully
+  plan_created:
+    post:
+      operationId: planCreated
+      summary: A new plan has been created
+      description: A new plan has been created
+      parameters:
+        - $ref: '#/components/parameters/webhook_signature'
+        - $ref: '#/components/parameters/webhook_signature_algorithm'
+        - $ref: '#/components/parameters/webhook_unique_key'
+      requestBody:
+        description: Details of the new plan
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - webhook_type
+                - object_type
+                - plan
+              properties:
+                webhook_type:
+                  type: string
+                  enum:
+                    - plan.created
+                object_type:
+                  type: string
+                  enum:
+                    - plan
+                plan:
+                  $ref: '#/components/schemas/PlanObject'
+      responses:
+        '200':
+          description: Return a 200 status to indicate that the data was received successfully
+  plan_updated:
+    post:
+      operationId: planUpdated
+      summary: A plan has been updated
+      description: A plan has been updated
+      parameters:
+        - $ref: '#/components/parameters/webhook_signature'
+        - $ref: '#/components/parameters/webhook_signature_algorithm'
+        - $ref: '#/components/parameters/webhook_unique_key'
+      requestBody:
+        description: Details of the plan
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - webhook_type
+                - object_type
+                - plan
+              properties:
+                webhook_type:
+                  type: string
+                  enum:
+                    - plan.updated
+                object_type:
+                  type: string
+                  enum:
+                    - plan
+                plan:
+                  $ref: '#/components/schemas/PlanObject'
+      responses:
+        '200':
+          description: Return a 200 status to indicate that the data was received successfully
+  plan_deleted:
+    post:
+      operationId: planDeleted
+      summary: A plan has been deleted
+      description: A plan has been deleted
+      parameters:
+        - $ref: '#/components/parameters/webhook_signature'
+        - $ref: '#/components/parameters/webhook_signature_algorithm'
+        - $ref: '#/components/parameters/webhook_unique_key'
+      requestBody:
+        description: Details of the plan
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - webhook_type
+                - object_type
+                - plan
+              properties:
+                webhook_type:
+                  type: string
+                  enum:
+                    - plan.deleted
+                object_type:
+                  type: string
+                  enum:
+                    - plan
+                plan:
+                  $ref: '#/components/schemas/PlanObject'
+      responses:
+        '200':
+          description: Return a 200 status to indicate that the data was received successfully
   subscription_terminated:
     post:
       operationId: subscriptionTerminated

--- a/src/openapi.yaml
+++ b/src/openapi.yaml
@@ -338,6 +338,12 @@ webhooks:
     $ref: "./webhooks/payment_request_payment_failure.yaml"
   payment_request_payment_status_updated:
     $ref: "./webhooks/payment_request_payment_status_updated.yaml"
+  plan_created:
+    $ref: "./webhooks/plan_created.yaml"
+  plan_updated:
+    $ref: "./webhooks/plan_updated.yaml"
+  plan_deleted:
+    $ref: "./webhooks/plan_deleted.yaml"
   subscription_terminated:
     $ref: "./webhooks/subscription_terminated.yaml"
   subscription_started:


### PR DESCRIPTION
follows https://github.com/getlago/lago-openapi/pull/390 😬 😬 

I added a test recently to ensure that `./openapi.yaml` is built but it only works if you edited `./src/openapi.yaml` 😅 

![CleanShot 2025-06-27 at 10 14 55@2x](https://github.com/user-attachments/assets/9cc99437-c1fc-49ad-898a-0be53b14beba)

