### PR TITLE
fix(events): lago_customer_id is null in events create response

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1724,7 +1724,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Event'
+                $ref: '#/components/schemas/EventCreated'
         '400':
           $ref: '#/components/responses/BadRequest'
         '401':
@@ -1793,6 +1793,10 @@ paths:
       responses:
         '200':
           description: Event received
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EventsCreated'
         '400':
           $ref: '#/components/responses/BadRequest'
         '401':
@@ -10576,13 +10580,20 @@ components:
       properties:
         event:
           $ref: '#/components/schemas/EventInputObject'
-    Event:
+    EventCreated:
       type: object
       required:
         - event
       properties:
         event:
-          $ref: '#/components/schemas/EventObject'
+          allOf:
+            - $ref: '#/components/schemas/EventObject'
+          type: object
+          properties:
+            lago_customer_id:
+              type:
+                - 'null'
+              description: The value will always be null in this response as the event processing is done asynchronously
     EventBatchInput:
       type: object
       required:
@@ -10592,6 +10603,22 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/EventInputObject'
+    EventsCreated:
+      type: object
+      required:
+        - events
+      properties:
+        events:
+          type: array
+          items:
+            allOf:
+              - $ref: '#/components/schemas/EventObject'
+                type: object
+                properties:
+                  lago_customer_id:
+                    type:
+                      - 'null'
+                    description: The value will always be null in this response as the event processing is done asynchronously
     EventEstimateFeesInput:
       type: object
       required:
@@ -10623,6 +10650,13 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/FeeObject'
+    Event:
+      type: object
+      required:
+        - event
+      properties:
+        event:
+          $ref: '#/components/schemas/EventObject'
     FeesPaginated:
       allOf:
         - $ref: '#/components/schemas/Fees'

--- a/src/resources/events.yaml
+++ b/src/resources/events.yaml
@@ -17,7 +17,7 @@ post:
       content:
         application/json:
           schema:
-            $ref: "../schemas/Event.yaml"
+            $ref: "../schemas/EventCreated.yaml"
     "400":
       $ref: "../responses/BadRequest.yaml"
     "401":
@@ -27,7 +27,7 @@ post:
 
 get:
   tags:
-    - events 
+    - events
   summary: List all events
   description: This endpoint is used for retrieving all events.
   operationId: findAllEvents

--- a/src/resources/events_batch.yaml
+++ b/src/resources/events_batch.yaml
@@ -9,14 +9,18 @@ post:
     content:
       application/json:
         schema:
-          $ref: '../schemas/EventBatchInput.yaml'
+          $ref: "../schemas/EventBatchInput.yaml"
     required: true
   responses:
-    '200':
+    "200":
       description: Event received
-    '400':
-      $ref: '../responses/BadRequest.yaml'
-    '401':
-      $ref: '../responses/Unauthorized.yaml'
-    '422':
-      $ref: '../responses/UnprocessableEntity.yaml'
+      content:
+        application/json:
+          schema:
+            $ref: "../schemas/EventsCreated.yaml"
+    "400":
+      $ref: "../responses/BadRequest.yaml"
+    "401":
+      $ref: "../responses/Unauthorized.yaml"
+    "422":
+      $ref: "../responses/UnprocessableEntity.yaml"

--- a/src/schemas/EventCreated.yaml
+++ b/src/schemas/EventCreated.yaml
@@ -1,0 +1,13 @@
+type: object
+required:
+  - event
+properties:
+  event:
+    allOf:
+      - $ref: "./EventObject.yaml"
+    type: object
+    properties:
+      lago_customer_id:
+        type:
+          - "null"
+        description: The value will always be null in this response as the event processing is done asynchronously

--- a/src/schemas/EventsCreated.yaml
+++ b/src/schemas/EventsCreated.yaml
@@ -1,0 +1,15 @@
+type: object
+required:
+  - events
+properties:
+  events:
+    type: array
+    items:
+      allOf:
+        - $ref: "./EventObject.yaml"
+          type: object
+          properties:
+            lago_customer_id:
+              type:
+                - "null"
+              description: The value will always be null in this response as the event processing is done asynchronously

--- a/src/schemas/_index.yaml
+++ b/src/schemas/_index.yaml
@@ -164,12 +164,16 @@ Event:
   $ref: "./Event.yaml"
 EventBatchInput:
   $ref: "./EventBatchInput.yaml"
+EventCreated:
+  $ref: "./EventCreated.yaml"
 EventEstimateFeesInput:
   $ref: "./EventEstimateFeesInput.yaml"
 EventInput:
   $ref: "./EventInput.yaml"
 EventObject:
   $ref: "./EventObject.yaml"
+EventsCreated:
+  $ref: "./EventsCreated.yaml"
 EventErrorsObject:
   $ref: "./EventErrorsObject.yaml"
 EventsErrorsObject:


### PR DESCRIPTION
This PR fixes:
- The response of the `createEvent` operation to make it clear that the `lago_customer_id` value will always be `null`
- The response payload of the `createBatchEvents` as it was not defined