### PR TITLE
fix(credit_note): Add missing payloads

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -8677,6 +8677,30 @@ components:
         base_amount_cents:
           type: integer
           example: 100
+    CreditNoteErrorDetailsObject:
+      type: object
+      required:
+        - lago_id
+        - error_code
+        - details
+      properties:
+        lago_id:
+          type: string
+          format: uuid
+          description: The credit note error details unique identifier, created by Lago.
+          example: 1a901a90-1a90-1a90-1a90-1a901a901a90
+        error_code:
+          type: string
+          enum:
+            - not_provided
+            - tax_error
+            - tax_voiding_error
+            - invoice_generation_error
+          description: The type of the error.
+          example: tax_error
+        details:
+          type: object
+          description: The details of the error.
     CreditNoteObject:
       type: object
       required:
@@ -8847,6 +8871,12 @@ components:
           type: boolean
           example: false
           description: Indicates if the credit note belongs to self-billed invoice. Self-billing is a process where an organization creates the invoice on behalf of the partner.
+        error_details:
+          type:
+            - array
+            - 'null'
+          items:
+            $ref: '#/components/schemas/CreditNoteErrorDetailsObject'
     CreditNotesPaginated:
       type: object
       required:
@@ -9011,10 +9041,12 @@ components:
             - invoice_number
             - currency
             - taxes_amount_cents
+            - precise_taxes_amount_cents
             - sub_total_excluding_taxes_amount_cents
             - max_creditable_amount_cents
             - max_refundable_amount_cents
             - coupons_adjustment_amount_cents
+            - precise_coupons_adjustment_amount_cents
             - taxes_rate
             - items
           properties:
@@ -9035,6 +9067,10 @@ components:
               type: integer
               description: The tax amount of the credit note, expressed in cents.
               example: 20
+            precise_taxes_amount_cents:
+              type: number
+              description: The precise tax amount of the credit note, expressed in cents with decimal precision.
+              example: 20.1
             taxes_rate:
               type: number
               description: The tax rate associated with this specific credit note.
@@ -9055,6 +9091,10 @@ components:
               type: integer
               description: The pro-rated amount of the coupons applied to the source invoice.
               example: 20
+            precise_coupons_adjustment_amount_cents:
+              type: number
+              description: The precise pro-rated amount with decimal precision of the coupons applied to the source invoice.
+              example: 20.1
             items:
               type: array
               items:

--- a/src/schemas/CreditNoteErrorDetailsObject.yaml
+++ b/src/schemas/CreditNoteErrorDetailsObject.yaml
@@ -1,0 +1,23 @@
+type: object
+required:
+  - lago_id
+  - error_code
+  - details
+properties:
+  lago_id:
+    type: string
+    format: "uuid"
+    description: The credit note error details unique identifier, created by Lago.
+    example: "1a901a90-1a90-1a90-1a90-1a901a901a90"
+  error_code:
+    type: string
+    enum:
+      - not_provided
+      - tax_error
+      - tax_voiding_error
+      - invoice_generation_error
+    description: The type of the error.
+    example: tax_error
+  details:
+    type: object
+    description: The details of the error.

--- a/src/schemas/CreditNoteEstimated.yaml
+++ b/src/schemas/CreditNoteEstimated.yaml
@@ -9,10 +9,12 @@ properties:
       - invoice_number
       - currency
       - taxes_amount_cents
+      - precise_taxes_amount_cents
       - sub_total_excluding_taxes_amount_cents
       - max_creditable_amount_cents
       - max_refundable_amount_cents
       - coupons_adjustment_amount_cents
+      - precise_coupons_adjustment_amount_cents
       - taxes_rate
       - items
     properties:
@@ -33,6 +35,10 @@ properties:
         type: integer
         description: The tax amount of the credit note, expressed in cents.
         example: 20
+      precise_taxes_amount_cents:
+        type: number
+        description: "The precise tax amount of the credit note, expressed in cents with decimal precision."
+        example: 20.1
       taxes_rate:
         type: number
         description: The tax rate associated with this specific credit note.
@@ -53,6 +59,10 @@ properties:
         type: integer
         description: The pro-rated amount of the coupons applied to the source invoice.
         example: 20
+      precise_coupons_adjustment_amount_cents:
+        type: number
+        description: The precise pro-rated amount with decimal precision of the coupons applied to the source invoice.
+        example: 20.1
       items:
         type: array
         items:

--- a/src/schemas/CreditNoteObject.yaml
+++ b/src/schemas/CreditNoteObject.yaml
@@ -167,3 +167,9 @@ properties:
     type: boolean
     example: false
     description: Indicates if the credit note belongs to self-billed invoice. Self-billing is a process where an organization creates the invoice on behalf of the partner.
+  error_details:
+    type:
+      - array
+      - "null"
+    items:
+      $ref: "./CreditNoteErrorDetailsObject.yaml"

--- a/src/schemas/_index.yaml
+++ b/src/schemas/_index.yaml
@@ -110,6 +110,8 @@ CreditNotes:
   $ref: "./CreditNotes.yaml"
 CreditNoteCreateInput:
   $ref: "./CreditNoteCreateInput.yaml"
+CreditNoteErrorDetailsObject:
+  $ref: "./CreditNoteErrorDetailsObject.yaml"
 CreditNoteUpdateInput:
   $ref: "./CreditNoteUpdateInput.yaml"
 CreditNoteExtendedObject:


### PR DESCRIPTION
Fixes related to https://github.com/getlago/lago-go-client/pull/268 to align the OpenAPI schema with the REST API