### PR TITLE
(add):plan_amount_cents to fee-amount-details

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -7823,6 +7823,10 @@ components:
     FeeAmountDetails:
       type: object
       properties:
+        plan_amount_cents:
+          type: integer
+          description: The base cost of the plan, excluding any applicable taxes, that is billed on a recurring basis. This value is defined at 0 if your plan is a pay-as-you-go plan.
+          example: 10000
         graduated_ranges:
           type: array
           description: Graduated ranges, used for a `graduated` charge model.

--- a/src/schemas/FeeAmountDetails.yaml
+++ b/src/schemas/FeeAmountDetails.yaml
@@ -1,5 +1,10 @@
 type: object
 properties:
+  plan_amount_cents:
+    type: integer
+    description: The base cost of the plan, excluding any applicable taxes, that is billed on a recurring basis. This value is defined at 0 if your plan is a pay-as-you-go plan.
+    example: 10000
+
   # Graduated charge model
   graduated_ranges:
     type: array


### PR DESCRIPTION
Requested here 
https://getlago.slack.com/archives/C08FL5Y4E9H/p1752072472708829

and the value is being saved inside the `amount_details` here https://github.com/getlago/lago-api/blob/main/app/services/fees/subscription_service.rb#L58