### PR TITLE
(fix):api_logs/api_version is a string

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -549,17 +549,14 @@ paths:
               - failed
               - succeeded
               - 404
-        - name: api_version[]
+        - name: api_version
           in: query
           description: Filter results by API version
           required: false
           explode: true
           schema:
-            type: array
-            items:
-              type: string
-            example:
-              - v1
+            type: string
+            example: v1
         - name: request_paths
           in: query
           description: Filter results by the path of the request

--- a/src/resources/api_logs.yml
+++ b/src/resources/api_logs.yml
@@ -56,16 +56,14 @@ get:
               minimum: 100
               maximum: 599
         example: [failed, succeeded, 404]
-    - name: api_version[]
+    - name: api_version
       in: query
       description: Filter results by API version
       required: false
       explode: true
       schema:
-        type: array
-        items:
-          type: string
-        example: [v1]
+        type: string
+        example: v1
     - name: request_paths
       in: query
       description: Filter results by the path of the request


### PR DESCRIPTION
`api_version` of an `Clickhouse::ApiLog` expects a string, despite if receives an array of strings it will work as well, but OpenApi requires the controller attribute to be in plural if is declared as an array and the attribute is in singular.

```
warning  array-params-plural    Array parameter api_version[] should be plural   paths./api_logs.get.parameters[6].name
``` 

https://github.com/getlago/lago-api/blob/main/app/controllers/api/v1/api_logs_controller.rb#L60