### PR TITLE
doc: null value for logo resets it

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -6604,7 +6604,7 @@ components:
             - 'null'
           format: uri
           example: data:image/png;base64,...
-          description: The base64 encoded logo image for the billing entity
+          description: The base64 encoded logo image for the billing entity. Sending "null" will remove the logo, if any exist.
         invoice_custom_section_codes:
           type: array
           items:

--- a/src/schemas/BillingEntityUpdateInput.yaml
+++ b/src/schemas/BillingEntityUpdateInput.yaml
@@ -134,7 +134,7 @@ properties:
       - "null"
     format: uri
     example: "data:image/png;base64,..."
-    description: The base64 encoded logo image for the billing entity
+    description: The base64 encoded logo image for the billing entity. Sending "null" will remove the logo, if any exist.
   invoice_custom_section_codes:
     type: array
     items:


### PR DESCRIPTION
Recently update API to allow reseting the logo value of a Billing entity https://github.com/getlago/lago-api/pull/3957

Better mention it in doc