### PR TITLE
feat(api): Add projected units and projected amount cents to the customer usage models

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1586,8 +1586,8 @@ paths:
     get:
       tags:
         - customers
-      summary: Retrieve customer current usage
-      description: This endpoint enables the retrieval of the usage-based billing data for a customer within the current period.
+      summary: Retrieve customer current and projected usage
+      description: This endpoint enables the retrieval of the usage-based billing data for a customer within the current period. It also returns the projected usage for the current period based on the current usage.
       parameters:
         - name: external_customer_id
           in: path
@@ -10196,8 +10196,10 @@ components:
       required:
         - values
         - units
+        - projected_units
         - events_count
         - amount_cents
+        - projected_amount_cents
       items:
         type: object
         properties:
@@ -10206,10 +10208,19 @@ components:
             pattern: ^[0-9]+.?[0-9]*$
             example: '0.9'
             description: The number of units consumed for a specific charge filter related to a charge item.
+          projected_units:
+            type: string
+            pattern: ^[0-9]+.?[0-9]*$
+            example: '1.8'
+            description: The projected number of units that can be consumed for a specific charge filter related to a charge item.
           amount_cents:
             type: integer
             example: 1000
             description: The amount in cents, tax excluded, consumed for a specific charge filter related to a charge item.
+          projected_amount_cents:
+            type: integer
+            example: 2000
+            description: The projected amount in cents, tax excluded, that can be consumed for a specific charge filter related to a charge item.
           events_count:
             type: integer
             example: 10
@@ -10230,8 +10241,10 @@ components:
       description: Array of aggregated fees, grouped by the event properties defined in a `standard` charge model.
       required:
         - amount_cents
+        - projected_amount_cents
         - events_count
         - units
+        - projected_units
         - grouped_by
         - groups
       items:
@@ -10241,6 +10254,10 @@ components:
             type: integer
             example: 1000
             description: The amount in cents, tax excluded, consumed for a specific group related to a charge item.
+          projected_amount_cents:
+            type: integer
+            example: 2000
+            description: The projected amount in cents, tax excluded, that can be consumed for a specific group related to a charge item.
           events_count:
             type: integer
             example: 10
@@ -10250,6 +10267,11 @@ components:
             pattern: ^[0-9]+.?[0-9]*$
             example: '0.9'
             description: The number of units consumed for a specific group related to a charge item.
+          projected_units:
+            type: string
+            pattern: ^[0-9]+.?[0-9]*$
+            example: '1.8'
+            description: The projected number of units that can be consumed for a specific group related to a charge item.
           grouped_by:
             type: object
             description: Key value list of event properties aggregated by the charge model
@@ -10261,8 +10283,10 @@ components:
       type: object
       required:
         - units
+        - projected_units
         - events_count
         - amount_cents
+        - projected_amount_cents
         - amount_currency
         - charge
         - billable_metric
@@ -10273,6 +10297,11 @@ components:
           pattern: ^[0-9]+.?[0-9]*$
           example: '1.0'
           description: The number of units consumed by the customer for a specific charge item.
+        projected_units:
+          type: string
+          pattern: ^[0-9]+.?[0-9]*$
+          example: '2.0'
+          description: The projected number of units that can be consumed by the customer for a specific charge item.
         events_count:
           type: integer
           example: 10
@@ -10281,6 +10310,10 @@ components:
           type: integer
           example: 123
           description: The amount in cents, tax excluded, consumed by the customer for a specific charge item.
+        projected_amount_cents:
+          type: integer
+          example: 256
+          description: The projected amount in cents, tax excluded, that can be consumed by the customer for a specific charge item.
         amount_currency:
           $ref: '#/components/schemas/Currency'
           description: The currency of a usage item consumed by the customer.
@@ -10355,6 +10388,7 @@ components:
         - to_datetime
         - issuing_date
         - amount_cents
+        - projected_amount_cents
         - taxes_amount_cents
         - total_amount_cents
         - charges_usage
@@ -10389,6 +10423,10 @@ components:
           type: integer
           description: The amount in cents, tax excluded.
           example: 123
+        projected_amount_cents:
+          type: integer
+          description: The projected amount in cents, tax excluded.
+          example: 256
         taxes_amount_cents:
           type: integer
           description: The tax amount in cents.

--- a/src/resources/customer_current_usage.yaml
+++ b/src/resources/customer_current_usage.yaml
@@ -1,8 +1,8 @@
 get:
   tags:
     - customers
-  summary: Retrieve customer current usage
-  description: This endpoint enables the retrieval of the usage-based billing data for a customer within the current period.
+  summary: Retrieve customer current and projected usage
+  description: This endpoint enables the retrieval of the usage-based billing data for a customer within the current period. It also returns the projected usage for the current period based on the current usage.
   parameters:
     - name: external_customer_id
       in: path

--- a/src/schemas/CustomerChargeFiltersUsageObject.yaml
+++ b/src/schemas/CustomerChargeFiltersUsageObject.yaml
@@ -3,8 +3,10 @@ description: Array of filter object, representing multiple dimensions for a char
 required:
   - values
   - units
+  - projected_units
   - events_count
   - amount_cents
+  - projected_amount_cents
 items:
   type: object
   properties:
@@ -13,10 +15,19 @@ items:
       pattern: "^[0-9]+.?[0-9]*$"
       example: "0.9"
       description: The number of units consumed for a specific charge filter related to a charge item.
+    projected_units:
+      type: string
+      pattern: "^[0-9]+.?[0-9]*$"
+      example: "1.8"
+      description: The projected number of units that can be consumed for a specific charge filter related to a charge item.
     amount_cents:
       type: integer
       example: 1000
       description: The amount in cents, tax excluded, consumed for a specific charge filter related to a charge item.
+    projected_amount_cents:
+      type: integer
+      example: 2000
+      description: The projected amount in cents, tax excluded, that can be consumed for a specific charge filter related to a charge item.
     events_count:
       type: integer
       example: 10

--- a/src/schemas/CustomerChargeGroupedUsageObject.yaml
+++ b/src/schemas/CustomerChargeGroupedUsageObject.yaml
@@ -2,8 +2,10 @@ type: array
 description: Array of aggregated fees, grouped by the event properties defined in a `standard` charge model.
 required:
   - amount_cents
+  - projected_amount_cents
   - events_count
   - units
+  - projected_units
   - grouped_by
   - groups
 items:
@@ -13,6 +15,10 @@ items:
       type: integer
       example: 1000
       description: The amount in cents, tax excluded, consumed for a specific group related to a charge item.
+    projected_amount_cents:
+      type: integer
+      example: 2000
+      description: The projected amount in cents, tax excluded, that can be consumed for a specific group related to a charge item.
     events_count:
       type: integer
       example: 10
@@ -22,6 +28,11 @@ items:
       pattern: "^[0-9]+.?[0-9]*$"
       example: "0.9"
       description: The number of units consumed for a specific group related to a charge item.
+    projected_units:
+      type: string
+      pattern: "^[0-9]+.?[0-9]*$"
+      example: "1.8"
+      description: The projected number of units that can be consumed for a specific group related to a charge item.
     grouped_by:
       type: object
       description: Key value list of event properties aggregated by the charge model

--- a/src/schemas/CustomerChargeUsageObject.yaml
+++ b/src/schemas/CustomerChargeUsageObject.yaml
@@ -1,8 +1,10 @@
 type: object
 required:
   - units
+  - projected_units
   - events_count
   - amount_cents
+  - projected_amount_cents
   - amount_currency
   - charge
   - billable_metric
@@ -13,6 +15,11 @@ properties:
     pattern: "^[0-9]+.?[0-9]*$"
     example: "1.0"
     description: The number of units consumed by the customer for a specific charge item.
+  projected_units:
+    type: string
+    pattern: "^[0-9]+.?[0-9]*$"
+    example: "2.0"
+    description: The projected number of units that can be consumed by the customer for a specific charge item.
   events_count:
     type: integer
     example: 10
@@ -21,6 +28,10 @@ properties:
     type: integer
     example: 123
     description: The amount in cents, tax excluded, consumed by the customer for a specific charge item.
+  projected_amount_cents:
+    type: integer
+    example: 256
+    description: The projected amount in cents, tax excluded, that can be consumed by the customer for a specific charge item.
   amount_currency:
     $ref: "./Currency.yaml"
     description: The currency of a usage item consumed by the customer.

--- a/src/schemas/CustomerUsageObject.yaml
+++ b/src/schemas/CustomerUsageObject.yaml
@@ -4,6 +4,7 @@ required:
   - to_datetime
   - issuing_date
   - amount_cents
+  - projected_amount_cents
   - taxes_amount_cents
   - total_amount_cents
   - charges_usage
@@ -38,6 +39,10 @@ properties:
     type: integer
     description: The amount in cents, tax excluded.
     example: 123
+  projected_amount_cents:
+    type: integer
+    description: The projected amount in cents, tax excluded.
+    example: 256
   taxes_amount_cents:
     type: integer
     description: The tax amount in cents.


### PR DESCRIPTION
Added `projected_units` and `projected_amount_cents` to the:

1. `CustomerChargeUsageObject`
2. `CustomerChargeFiltersUsageObject`
3. `CustomerChargeGroupedUsageObject`

Also added projected_amount_cents to the main object which is: `CustomerUsageObject`.
Also changed the endpoint description, as it now returns also the projected data.