### PR TITLE
feat(subscription): Add `on_termination_invoice` to subscription

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3103,6 +3103,21 @@ paths:
               - credit
               - skip
             example: credit
+        - name: on_termination_invoice
+          in: query
+          description: |
+            When a subscription is terminated before the end of its billing period, we generate an invoice for the unbilled usage.
+            This field allows you to control the behavior of the invoice generation:
+
+            - `generate`: An invoice is generated for the unbilled usage.
+            - `skip`: No invoice is generated for the unbilled usage.
+          required: false
+          schema:
+            type: string
+            enum:
+              - generate
+              - skip
+            example: generate
       responses:
         '200':
           description: Subscription terminated
@@ -11593,6 +11608,8 @@ components:
         - plan_code
         - external_id
         - status
+        - on_termination_credit_note
+        - on_termination_invoice
       properties:
         lago_id:
           type: string
@@ -11729,7 +11746,7 @@ components:
             When a pay-in-advance subscription is terminated before the end of its billing period, we generate a credit note for the unused subscription time by default.
             This field allows you to control the behavior of the credit note generation:
 
-            - `credit`: A credit note is generated for the unused subscription time.
+            - `credit`: A credit note is generated for the unused subscription time. The unused amount is credited to the credit note wallet.
             - `skip`: No credit note is generated for the unused subscription time.
 
             _Note: This field is only applicable to pay-in-advance plans and will be `null` for pay-in-arrears plans._
@@ -11737,6 +11754,20 @@ components:
           enum:
             - credit
             - skip
+        on_termination_invoice:
+          type:
+            - string
+          example: generate
+          enum:
+            - generate
+            - skip
+          default: generate
+          description: |
+            When a subscription is terminated before the end of its billing period, we generate an invoice for the unbilled usage.
+            This field allows you to control the behavior of the invoice generation:
+
+            - `generate`: An invoice is generated for the unbilled usage.
+            - `skip`: No invoice is generated for the unbilled usage.
     ErrorDetailObject:
       type: object
       required:

--- a/src/resources/subscription.yaml
+++ b/src/resources/subscription.yaml
@@ -5,7 +5,7 @@ parameters:
     required: true
     schema:
       type: string
-      example: '5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba'
+      example: "5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba"
 get:
   tags:
     - subscriptions
@@ -29,16 +29,16 @@ get:
           - canceled
         example: active
   responses:
-    '200':
+    "200":
       description: Subscription
       content:
         application/json:
           schema:
-            $ref: '../schemas/Subscription.yaml'
-    '401':
-      $ref: '../responses/Unauthorized.yaml'
-    '404':
-      $ref: '../responses/NotFound.yaml'
+            $ref: "../schemas/Subscription.yaml"
+    "401":
+      $ref: "../responses/Unauthorized.yaml"
+    "404":
+      $ref: "../responses/NotFound.yaml"
 put:
   tags:
     - subscriptions
@@ -50,23 +50,23 @@ put:
     content:
       application/json:
         schema:
-          $ref: '../schemas/SubscriptionUpdateInput.yaml'
+          $ref: "../schemas/SubscriptionUpdateInput.yaml"
     required: true
   responses:
-    '200':
+    "200":
       description: Subscription updated
       content:
         application/json:
           schema:
-            $ref: '../schemas/Subscription.yaml'
-    '400':
-      $ref: '../responses/BadRequest.yaml'
-    '401':
-      $ref: '../responses/Unauthorized.yaml'
-    '404':
-      $ref: '../responses/NotFound.yaml'
-    '422':
-      $ref: '../responses/UnprocessableEntity.yaml'
+            $ref: "../schemas/Subscription.yaml"
+    "400":
+      $ref: "../responses/BadRequest.yaml"
+    "401":
+      $ref: "../responses/Unauthorized.yaml"
+    "404":
+      $ref: "../responses/NotFound.yaml"
+    "422":
+      $ref: "../responses/UnprocessableEntity.yaml"
 delete:
   tags:
     - subscriptions
@@ -81,7 +81,7 @@ delete:
       explode: true
       schema:
         type: string
-        example: 'pending'
+        example: "pending"
     - name: on_termination_credit_note
       in: query
       description: |
@@ -99,16 +99,31 @@ delete:
           - credit
           - skip
         example: "credit"
+    - name: on_termination_invoice
+      in: query
+      description: |
+        When a subscription is terminated before the end of its billing period, we generate an invoice for the unbilled usage.
+        This field allows you to control the behavior of the invoice generation:
+
+        - `generate`: An invoice is generated for the unbilled usage.
+        - `skip`: No invoice is generated for the unbilled usage.
+      required: false
+      schema:
+        type: string
+        enum:
+          - generate
+          - skip
+        example: "generate"
   responses:
-    '200':
+    "200":
       description: Subscription terminated
       content:
         application/json:
           schema:
-            $ref: '../schemas/Subscription.yaml'
-    '401':
-      $ref: '../responses/Unauthorized.yaml'
-    '404':
-      $ref: '../responses/NotFound.yaml'
-    '405':
-      $ref: '../responses/NotAllowed.yaml'
+            $ref: "../schemas/Subscription.yaml"
+    "401":
+      $ref: "../responses/Unauthorized.yaml"
+    "404":
+      $ref: "../responses/NotFound.yaml"
+    "405":
+      $ref: "../responses/NotAllowed.yaml"

--- a/src/schemas/SubscriptionObject.yaml
+++ b/src/schemas/SubscriptionObject.yaml
@@ -9,6 +9,8 @@ required:
   - plan_code
   - external_id
   - status
+  - on_termination_credit_note
+  - on_termination_invoice
 properties:
   lago_id:
     type: string
@@ -145,7 +147,7 @@ properties:
       When a pay-in-advance subscription is terminated before the end of its billing period, we generate a credit note for the unused subscription time by default.
       This field allows you to control the behavior of the credit note generation:
 
-      - `credit`: A credit note is generated for the unused subscription time.
+      - `credit`: A credit note is generated for the unused subscription time. The unused amount is credited to the credit note wallet.
       - `skip`: No credit note is generated for the unused subscription time.
 
       _Note: This field is only applicable to pay-in-advance plans and will be `null` for pay-in-arrears plans._
@@ -153,3 +155,17 @@ properties:
     enum:
       - credit
       - skip
+  on_termination_invoice:
+    type:
+      - string
+    example: "generate"
+    enum:
+      - generate
+      - skip
+    default: "generate"
+    description: |
+      When a subscription is terminated before the end of its billing period, we generate an invoice for the unbilled usage.
+      This field allows you to control the behavior of the invoice generation:
+
+      - `generate`: An invoice is generated for the unbilled usage.
+      - `skip`: No invoice is generated for the unbilled usage.


### PR DESCRIPTION
## Context

https://github.com/getlago/lago-api/pull/4047 added a `on_termination_invoice` query parameter and attribute on the `DELETE /api/v1/subscriptions/:external_id` endpoint.

## Description

This PR updates the OpenAPI accordingly.
