### PR TITLE
feat(subscription): Add `refund` to subscription's `on_termination_credit_note`

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3269,7 +3269,8 @@ paths:
             When a pay-in-advance subscription is terminated before the end of its billing period, we generate a credit note for the unused subscription time by default.
             This field allows you to control the behavior of the credit note generation:
 
-            - `credit`: A credit note is generated for the unused subscription time.
+            - `credit`: A credit note is generated for the unused subscription time. The unused amount is credited back to the customer.
+            - `refund`: A credit note is generated for the unused subscription time. If the invoice is paid or partially paid, the unused paid amount is refunded; any unpaid unused amount is credited back to the customer.
             - `skip`: No credit note is generated for the unused subscription time.
 
             _Note: This field is only applicable to pay-in-advance plans and is ignored for pay-in-arrears plans._
@@ -3278,6 +3279,7 @@ paths:
             type: string
             enum:
               - credit
+              - refund
               - skip
             example: credit
         - name: on_termination_invoice
@@ -12194,13 +12196,15 @@ components:
             When a pay-in-advance subscription is terminated before the end of its billing period, we generate a credit note for the unused subscription time by default.
             This field allows you to control the behavior of the credit note generation:
 
-            - `credit`: A credit note is generated for the unused subscription time. The unused amount is credited to the credit note wallet.
+            - `credit`: A credit note is generated for the unused subscription time. The unused amount is credited back to the customer.
+            - `refund`: A credit note is generated for the unused subscription time. If the invoice is paid or partially paid, the unused paid amount is refunded; any unpaid unused amount is credited back to the customer.
             - `skip`: No credit note is generated for the unused subscription time.
 
             _Note: This field is only applicable to pay-in-advance plans and will be `null` for pay-in-arrears plans._
           example: credit
           enum:
             - credit
+            - refund
             - skip
         on_termination_invoice:
           type:

--- a/src/resources/subscription.yaml
+++ b/src/resources/subscription.yaml
@@ -88,7 +88,8 @@ delete:
         When a pay-in-advance subscription is terminated before the end of its billing period, we generate a credit note for the unused subscription time by default.
         This field allows you to control the behavior of the credit note generation:
 
-        - `credit`: A credit note is generated for the unused subscription time.
+        - `credit`: A credit note is generated for the unused subscription time. The unused amount is credited back to the customer.
+        - `refund`: A credit note is generated for the unused subscription time. If the invoice is paid or partially paid, the unused paid amount is refunded; any unpaid unused amount is credited back to the customer.
         - `skip`: No credit note is generated for the unused subscription time.
 
         _Note: This field is only applicable to pay-in-advance plans and is ignored for pay-in-arrears plans._
@@ -97,6 +98,7 @@ delete:
         type: string
         enum:
           - credit
+          - refund
           - skip
         example: "credit"
     - name: on_termination_invoice

--- a/src/schemas/SubscriptionObject.yaml
+++ b/src/schemas/SubscriptionObject.yaml
@@ -147,13 +147,15 @@ properties:
       When a pay-in-advance subscription is terminated before the end of its billing period, we generate a credit note for the unused subscription time by default.
       This field allows you to control the behavior of the credit note generation:
 
-      - `credit`: A credit note is generated for the unused subscription time. The unused amount is credited to the credit note wallet.
+      - `credit`: A credit note is generated for the unused subscription time. The unused amount is credited back to the customer.
+      - `refund`: A credit note is generated for the unused subscription time. If the invoice is paid or partially paid, the unused paid amount is refunded; any unpaid unused amount is credited back to the customer.
       - `skip`: No credit note is generated for the unused subscription time.
 
       _Note: This field is only applicable to pay-in-advance plans and will be `null` for pay-in-arrears plans._
     example: "credit"
     enum:
       - credit
+      - refund
       - skip
   on_termination_invoice:
     type:


### PR DESCRIPTION
## Context

https://github.com/getlago/lago-api/pull/4026 added a `refund` value to `on_termination_credit_note` parameter on the `DELETE /api/v1/subscriptions/:external_id` endpoint.

## Description

This PR updates the OpenAPI accordingly.
