### PR TITLE
fix customer_usage.charges_usage[0].filters.values

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -10511,9 +10511,12 @@ components:
             type: object
             description: List of filter values applied to the usage.
             additionalProperties:
-              type: string
+              type: array
+              items:
+                type: string
             example:
-              region: us-east-1
+              region:
+                - us-east-1
     CustomerChargeGroupedUsageObject:
       type: array
       description: Array of aggregated fees, grouped by the event properties defined in a `standard` charge model.

--- a/src/schemas/CustomerChargeFiltersUsageObject.yaml
+++ b/src/schemas/CustomerChargeFiltersUsageObject.yaml
@@ -31,6 +31,9 @@ items:
       type: object
       description: "List of filter values applied to the usage."
       additionalProperties:
-        type: string
+        type: array
+        items:
+          type: string
       example:
-        region: us-east-1
+        region: 
+          - us-east-1


### PR DESCRIPTION
customer_usage.charges_usage[0].filters.values is always Record<string, string[]> but in the API docs it's currently typed as Record<string, string>. ([link here](https://getlago.com/docs/api-reference/customer-usage/get-current#response-filters-values))

customer_usage.grouped_usage[0].filters.values is always Record<string, string[]> but it's currently typed as Record<string, string> ([link here](https://getlago.com/docs/api-reference/customer-usage/get-current#response-filters-values))

This PR should fix it