### PR TITLE
misc: added Commitment as possible value to FeeObject.item_type enum

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -9935,6 +9935,7 @@ components:
                 - BillableMetric
                 - Subscription
                 - WalletTransaction
+                - Commitment
               description: The type of the fee item. Possible values are `AddOn`, `BillableMetric`, `WalletTransaction`, `Subscription` or `Commitment`.
               example: Subscription
             grouped_by:

--- a/src/schemas/FeeObject.yaml
+++ b/src/schemas/FeeObject.yaml
@@ -278,6 +278,7 @@ properties:
           - BillableMetric
           - Subscription
           - WalletTransaction
+          - Commitment
         description: The type of the fee item. Possible values are `AddOn`, `BillableMetric`, `WalletTransaction`, `Subscription` or `Commitment`.
         example: Subscription
       grouped_by:


### PR DESCRIPTION
# Description

FeeObject.item.item_type description mentions Commitment as a possible value but it's not present in the possible values in the enum. 

Ticket: Pylon #3920
