### PR TITLE
feat(wallet-transaction): Add a `name` to wallet transactions

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -9896,17 +9896,38 @@ components:
               example: startup
             name:
               type: string
-              description: The name of the fee item. It can be the name of the `add-on`, the `charge`, the `credit`, the `subscription` or the `commitment`.
+              description: |
+                The name of the fee item. The value depends on the type of the fee item:
+
+                - If the fee item is a `charge`, it is the billable metric name.
+                - If the fee item is a `add-on`, it is the add-on name.
+                - If the fee item is a `credit`, it is the wallet transaction name if set, or `credit` if not.
+                - If the fee item is a `fixed_charge`, it is the fixed charge add-on name.
+                - For all the other fee items, it is the subscription plan name.
               example: Startup
             description:
               type:
                 - string
                 - 'null'
-              description: The description of the fee item. It can be the description of the `add-on`, the `charge`, the `credit`, the `subscription` or the `commitment`.
+              description: |
+                The description of the fee item. The value depends on the type of the fee item:
+
+                - If the fee item is a `charge`, it is the billable metric description.
+                - If the fee item is a `add-on`, it is the add-on description.
+                - If the fee item is a `credit`, it is always `credit`.
+                - If the fee item is a `fixed_charge`, it is the fixed charge add-on description.
+                - For all the other fee items, it is the subscription plan description.
               example: Startup
             invoice_display_name:
               type: string
-              description: Specifies the name that will be displayed on an invoice. If no value is set for this field, the name of the actual charge will be used as the default display name.
+              description: |
+                Specifies the name that will be displayed on an invoice. If no value is set for this field, we'll fallback to a value that depends on the type of the fee items:
+
+                - If the fee item is a `charge`, we'll fallback to the `invoice_display_name` of the `charge` or the billable metric name if no `invoice_display_name` is set.
+                - If the fee item is a `add-on`, we'll fallback to the `invoice_name` of the `add-on` or the `name` of the `add-on`.
+                - If the fee item is a `credit`, we'll fallback to the wallet transaction name if set, or `credit` if not.
+                - If the fee item is a `fixed_charge`, we'll fallback to the `invoice_display_name` of the `fixed_charge` or the `invoice_name` of the `fixed_charge_add_on` if no `invoice_display_name` is set.
+                - For all the other fee items, we'll fallback to the `invoice_display_name` of the subscription plan.
               example: Setup Fee (SF1)
             filter_invoice_display_name:
               type:
@@ -16446,6 +16467,15 @@ components:
               format: uuid
               description: Unique identifier assigned to the wallet within the Lago application. This ID is exclusively created by Lago and serves as a unique identifier for the wallet's record within the Lago system.
               example: 1a901a90-1a90-1a90-1a90-1a901a901a90
+            name:
+              type:
+                - string
+                - 'null'
+              description: |
+                The name of the wallet transaction. It will appear on the invoice as the label for the fee. If not set, the label on the invoice will fallback to either `Prepaid credits - {{wallet_name}}` if the wallet name is set, or `Prepaid credits`.
+
+                Note that this name will apply to all transactions (`paid_credits`, `granted_credits` and `voided_credits`) created by this action.
+              example: Tokens for models 'high-fidelity-boost'
             paid_credits:
               type:
                 - string
@@ -16502,6 +16532,7 @@ components:
         - credit_amount
         - amount
         - created_at
+        - name
       properties:
         lago_id:
           type: string
@@ -16595,6 +16626,12 @@ components:
           format: date-time
           description: The date of the wallet transaction creation, represented in ISO 8601 datetime format and expressed in Coordinated Universal Time (UTC).
           example: '2022-04-29T08:59:51Z'
+        name:
+          type:
+            - string
+            - 'null'
+          description: The name of the wallet transaction. It will appear on the invoice as the label for the fee. If not set, the label on the invoice will fallback to either `Prepaid credits - {{wallet_name}}` if the wallet name is set, or `Prepaid credits`.
+          example: Tokens for models 'high-fidelity-boost'
     WalletTransactions:
       type: object
       required:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -9901,7 +9901,7 @@ components:
 
                 - If the fee item is a `charge`, it is the billable metric name.
                 - If the fee item is a `add-on`, it is the add-on name.
-                - If the fee item is a `credit`, it is the wallet transaction name if set, or `credit` if not.
+                - If the fee item is a `credit`, it is the wallet transaction name if set, or `"credit"` if not.
                 - If the fee item is a `fixed_charge`, it is the fixed charge add-on name.
                 - For all the other fee items, it is the subscription plan name.
               example: Startup
@@ -9914,7 +9914,7 @@ components:
 
                 - If the fee item is a `charge`, it is the billable metric description.
                 - If the fee item is a `add-on`, it is the add-on description.
-                - If the fee item is a `credit`, it is always `credit`.
+                - If the fee item is a `credit`, it is always `"credit"`.
                 - If the fee item is a `fixed_charge`, it is the fixed charge add-on description.
                 - For all the other fee items, it is the subscription plan description.
               example: Startup

--- a/src/schemas/FeeObject.yaml
+++ b/src/schemas/FeeObject.yaml
@@ -244,7 +244,7 @@ properties:
 
           - If the fee item is a `charge`, it is the billable metric name.
           - If the fee item is a `add-on`, it is the add-on name.
-          - If the fee item is a `credit`, it is the wallet transaction name if set, or `credit` if not.
+          - If the fee item is a `credit`, it is the wallet transaction name if set, or `"credit"` if not.
           - If the fee item is a `fixed_charge`, it is the fixed charge add-on name.
           - For all the other fee items, it is the subscription plan name.
         example: "Startup"
@@ -257,7 +257,7 @@ properties:
 
           - If the fee item is a `charge`, it is the billable metric description.
           - If the fee item is a `add-on`, it is the add-on description.
-          - If the fee item is a `credit`, it is always `credit`.
+          - If the fee item is a `credit`, it is always `"credit"`.
           - If the fee item is a `fixed_charge`, it is the fixed charge add-on description.
           - For all the other fee items, it is the subscription plan description.
         example: "Startup"

--- a/src/schemas/FeeObject.yaml
+++ b/src/schemas/FeeObject.yaml
@@ -239,17 +239,38 @@ properties:
         example: "startup"
       name:
         type: string
-        description: The name of the fee item. It can be the name of the `add-on`, the `charge`, the `credit`, the `subscription` or the `commitment`.
+        description: |
+          The name of the fee item. The value depends on the type of the fee item:
+
+          - If the fee item is a `charge`, it is the billable metric name.
+          - If the fee item is a `add-on`, it is the add-on name.
+          - If the fee item is a `credit`, it is the wallet transaction name if set, or `credit` if not.
+          - If the fee item is a `fixed_charge`, it is the fixed charge add-on name.
+          - For all the other fee items, it is the subscription plan name.
         example: "Startup"
       description:
         type:
           - string
           - "null"
-        description: The description of the fee item. It can be the description of the `add-on`, the `charge`, the `credit`, the `subscription` or the `commitment`.
+        description: |
+          The description of the fee item. The value depends on the type of the fee item:
+
+          - If the fee item is a `charge`, it is the billable metric description.
+          - If the fee item is a `add-on`, it is the add-on description.
+          - If the fee item is a `credit`, it is always `credit`.
+          - If the fee item is a `fixed_charge`, it is the fixed charge add-on description.
+          - For all the other fee items, it is the subscription plan description.
         example: "Startup"
       invoice_display_name:
         type: string
-        description: Specifies the name that will be displayed on an invoice. If no value is set for this field, the name of the actual charge will be used as the default display name.
+        description: |
+          Specifies the name that will be displayed on an invoice. If no value is set for this field, we'll fallback to a value that depends on the type of the fee items:
+
+          - If the fee item is a `charge`, we'll fallback to the `invoice_display_name` of the `charge` or the billable metric name if no `invoice_display_name` is set.
+          - If the fee item is a `add-on`, we'll fallback to the `invoice_name` of the `add-on` or the `name` of the `add-on`.
+          - If the fee item is a `credit`, we'll fallback to the wallet transaction name if set, or `credit` if not.
+          - If the fee item is a `fixed_charge`, we'll fallback to the `invoice_display_name` of the `fixed_charge` or the `invoice_name` of the `fixed_charge_add_on` if no `invoice_display_name` is set.
+          - For all the other fee items, we'll fallback to the `invoice_display_name` of the subscription plan.
         example: "Setup Fee (SF1)"
       filter_invoice_display_name:
         type:

--- a/src/schemas/WalletTransactionCreateInput.yaml
+++ b/src/schemas/WalletTransactionCreateInput.yaml
@@ -12,6 +12,15 @@ properties:
         format: "uuid"
         description: Unique identifier assigned to the wallet within the Lago application. This ID is exclusively created by Lago and serves as a unique identifier for the wallet's record within the Lago system.
         example: "1a901a90-1a90-1a90-1a90-1a901a901a90"
+      name:
+        type:
+          - string
+          - "null"
+        description: |
+          The name of the wallet transaction. It will appear on the invoice as the label for the fee. If not set, the label on the invoice will fallback to either `Prepaid credits - {{wallet_name}}` if the wallet name is set, or `Prepaid credits`.
+
+          Note that this name will apply to all transactions (`paid_credits`, `granted_credits` and `voided_credits`) created by this action.
+        example: "Tokens for models 'high-fidelity-boost'"
       paid_credits:
         type:
           - string

--- a/src/schemas/WalletTransactionObject.yaml
+++ b/src/schemas/WalletTransactionObject.yaml
@@ -9,6 +9,7 @@ required:
   - credit_amount
   - amount
   - created_at
+  - name
 properties:
   lago_id:
     type: string
@@ -102,3 +103,9 @@ properties:
     format: "date-time"
     description: The date of the wallet transaction creation, represented in ISO 8601 datetime format and expressed in Coordinated Universal Time (UTC).
     example: "2022-04-29T08:59:51Z"
+  name:
+    type:
+      - string
+      - "null"
+    description: The name of the wallet transaction. It will appear on the invoice as the label for the fee. If not set, the label on the invoice will fallback to either `Prepaid credits - {{wallet_name}}` if the wallet name is set, or `Prepaid credits`.
+    example: "Tokens for models 'high-fidelity-boost'"


### PR DESCRIPTION
## Context

When creating a wallet transaction, the name displayed on the invoice defaults to the wallet name. However, for organizations managing multiple types of top-ups, it would be beneficial to display specific naming on invoices that corresponds to the particular transaction being made.

## Description 

This is the documentation for changes introduced in https://github.com/getlago/lago-api/commit/eecb90fb60190504307c6d71337519e8fcf23a52. It adds a `name` attribute to the wallet transaction object and inputs. It also updates the description of the fees'a fields.