### PR TITLE
feat(wallet-transactions): Add wallet to wallet transaction webhooks

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -6211,7 +6211,7 @@ webhooks:
                   enum:
                     - wallet_transaction
                 wallet_transaction:
-                  $ref: '#/components/schemas/WalletTransactionObject'
+                  $ref: '#/components/schemas/WalletTransactionObjectExtended'
       responses:
         '200':
           description: Return a 200 status to indicate that the data was received successfully
@@ -6244,7 +6244,7 @@ webhooks:
                   enum:
                     - wallet_transaction
                 wallet_transaction:
-                  $ref: '#/components/schemas/WalletTransactionObject'
+                  $ref: '#/components/schemas/WalletTransactionObjectExtended'
       responses:
         '200':
           description: Return a 200 status to indicate that the data was received successfully
@@ -17303,6 +17303,13 @@ components:
               $ref: '#/components/schemas/CustomerObject'
             usage_threshold:
               $ref: '#/components/schemas/UsageThresholdObject'
+    WalletTransactionObjectExtended:
+      allOf:
+        - $ref: '#/components/schemas/WalletTransactionObject'
+        - type: object
+          properties:
+            wallet:
+              $ref: '#/components/schemas/WalletObject'
     WalletTransactionPaymentFailureObject:
       type: object
       required:

--- a/src/schemas/WalletTransactionObjectExtended.yaml
+++ b/src/schemas/WalletTransactionObjectExtended.yaml
@@ -1,0 +1,6 @@
+allOf:
+  - $ref: './WalletTransactionObject.yaml'
+  - type: object
+    properties:
+      wallet:
+        $ref: './WalletObject.yaml'

--- a/src/webhooks/wallet_transaction_created.yaml
+++ b/src/webhooks/wallet_transaction_created.yaml
@@ -26,7 +26,7 @@ post:
               enum:
                 - wallet_transaction
             wallet_transaction:
-              $ref: "../schemas/WalletTransactionObject.yaml"
+              $ref: "../schemas/WalletTransactionObjectExtended.yaml"
   responses:
     "200":
       description: Return a 200 status to indicate that the data was received successfully

--- a/src/webhooks/wallet_transaction_updated.yaml
+++ b/src/webhooks/wallet_transaction_updated.yaml
@@ -26,7 +26,7 @@ post:
               enum:
                 - wallet_transaction
             wallet_transaction:
-              $ref: "../schemas/WalletTransactionObject.yaml"
+              $ref: "../schemas/WalletTransactionObjectExtended.yaml"
   responses:
     "200":
       description: Return a 200 status to indicate that the data was received successfully


### PR DESCRIPTION
## Context

`wallet_transaction.created` and `wallet_transaction.updated` webhooks did not contain wallet object only the wallet id.
That required an extra request to be made to fetch the wallet.

## Description

This PR adds the whole `wallet` object to `wallet_transaction.created` and `wallet_transaction.updated` webhooks.