### PR TITLE
feat(invoice-filters): Add the options to query multiple statuses

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2562,27 +2562,34 @@ paths:
             type: string
             format: date
             example: '2022-08-09'
-        - name: status
+        - name: status[]
           in: query
-          description: Filter invoices by status. Possible values are `draft` or `finalized`.
+          description: Filter invoices by statuses. Possible values are `draft`, `failed`, `finalized`, `pending` and `voided`.
           required: false
           explode: true
           schema:
-            type: string
-            enum:
-              - draft
-              - finalized
-        - name: payment_status
+            type: array
+            items:
+              type: string
+              enum:
+                - draft
+                - finalized
+                - failed
+                - pending
+                - voided
+        - name: payment_status[]
           in: query
-          description: Filter invoices by payment status. Possible values are `pending`, `failed` or `succeeded`.
+          description: Filter invoices by payment statuses. Possible values are `pending`, `failed` or `succeeded`.
           required: false
           explode: true
           schema:
-            type: string
-            enum:
-              - pending
-              - failed
-              - succeeded
+            type: array
+            items:
+              type: string
+              enum:
+                - pending
+                - failed
+                - succeeded
         - name: payment_overdue
           in: query
           description: Filter invoices by payment_overdue. Possible values are `true` or `false`.

--- a/src/resources/invoices.yaml
+++ b/src/resources/invoices.yaml
@@ -68,27 +68,34 @@ get:
         type: string
         format: 'date'
         example: '2022-08-09'
-    - name: status
+    - name: status[]
       in: query
-      description: Filter invoices by status. Possible values are `draft` or `finalized`.
+      description: Filter invoices by statuses. Possible values are `draft`, `failed`, `finalized`, `pending` and `voided`.
       required: false
       explode: true
       schema:
-        type: string
-        enum:
-          - draft
-          - finalized
-    - name: payment_status
+        type: array
+        items:
+          type: string
+          enum:
+            - draft
+            - finalized
+            - failed
+            - pending
+            - voided
+    - name: payment_status[]
       in: query
-      description: Filter invoices by payment status. Possible values are `pending`, `failed` or `succeeded`.
+      description: Filter invoices by payment statuses. Possible values are `pending`, `failed` or `succeeded`.
       required: false
       explode: true
       schema:
-        type: string
-        enum:
-          - pending
-          - failed
-          - succeeded
+        type: array
+        items:
+          type: string
+          enum:
+            - pending
+            - failed
+            - succeeded
     - name: payment_overdue
       in: query
       description: Filter invoices by payment_overdue. Possible values are `true` or `false`.


### PR DESCRIPTION
## Problem

Through the API, we're currently able to filter per payment status but it's a single choice and not multiple choice — that said, user can't filter per multiple payment status (e.g. payment_status=pending,failed to retrieve all pending and failed ones in one go)

## Fix
We should be able to filter invoice by a set of payment_status: `pending`, `failed`, `succeeded`.
We should be able to filter invoice by all visible status: `draft`, `finalized`, `voided`, `failed` & `pending`

## Backend PR
https://github.com/getlago/lago-api/pull/4279