### PR TITLE
feat(wallet-transaction): Add `transaction_name` to recurring transaction rules

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -15857,15 +15857,21 @@ components:
       type: object
       description: Object that represents rule for wallet recurring transactions.
       required:
-        - lago_id
+        - created_at
+        - expiration_at
+        - granted_credits
         - interval
-        - trigger
+        - invoice_requires_successful_payment
+        - lago_id
         - method
         - paid_credits
-        - granted_credits
-        - threshold_credits
+        - started_at
+        - status
         - target_ongoing_balance
-        - created_at
+        - threshold_credits
+        - transaction_metadata
+        - transaction_name
+        - trigger
       properties:
         lago_id:
           type: string
@@ -15964,6 +15970,12 @@ components:
               value: example_value
             - key: another_key
               value: another_value
+        transaction_name:
+          type:
+            - string
+            - 'null'
+          description: The name of the wallet transactions triggered by this rule. It will appear on the invoice as the label for the fee. If not set, the label on the invoice will fallback to either `Prepaid credits - {{wallet_name}}` if the wallet name is set, or `Prepaid credits`.
+          example: Tokens for models 'high-fidelity-boost'
     WalletObject:
       type: object
       required:
@@ -16321,6 +16333,12 @@ components:
                         value: example_value
                       - key: another_key
                         value: another_value
+                  transaction_name:
+                    type:
+                      - string
+                      - 'null'
+                    description: The name of the wallet transactions triggered by this rule. It will appear on the invoice as the label for the fee. If not set, the label on the invoice will fallback to either `Prepaid credits - {{wallet_name}}` if the wallet name is set, or `Prepaid credits`.
+                    example: Tokens for models 'high-fidelity-boost'
     Wallet:
       type: object
       required:
@@ -16449,6 +16467,12 @@ components:
                         value: example_value
                       - key: another_key
                         value: another_value
+                  transaction_name:
+                    type:
+                      - string
+                      - 'null'
+                    description: The name of the wallet transactions triggered by this rule. It will appear on the invoice as the label for the fee. If not set, the label on the invoice will fallback to either `Prepaid credits - {{wallet_name}}` if the wallet name is set, or `Prepaid credits`.
+                    example: Tokens for models 'high-fidelity-boost'
             applies_to:
               type:
                 - object

--- a/src/schemas/WalletCreateInput.yaml
+++ b/src/schemas/WalletCreateInput.yaml
@@ -189,3 +189,9 @@ properties:
                   value: "example_value"
                 - key: "another_key"
                   value: "another_value"
+            transaction_name:
+              type:
+                - string
+                - "null"
+              description: The name of the wallet transactions triggered by this rule. It will appear on the invoice as the label for the fee. If not set, the label on the invoice will fallback to either `Prepaid credits - {{wallet_name}}` if the wallet name is set, or `Prepaid credits`.
+              example: "Tokens for models 'high-fidelity-boost'"

--- a/src/schemas/WalletRecurringTransactionRule.yaml
+++ b/src/schemas/WalletRecurringTransactionRule.yaml
@@ -1,15 +1,21 @@
 type: object
 description: Object that represents rule for wallet recurring transactions.
 required:
-  - lago_id
+  - created_at
+  - expiration_at
+  - granted_credits
   - interval
-  - trigger
+  - invoice_requires_successful_payment
+  - lago_id
   - method
   - paid_credits
-  - granted_credits
-  - threshold_credits
+  - started_at
+  - status
   - target_ongoing_balance
-  - created_at
+  - threshold_credits
+  - transaction_metadata
+  - transaction_name
+  - trigger
 properties:
   lago_id:
     type: string
@@ -108,3 +114,9 @@ properties:
         value: "example_value"
       - key: "another_key"
         value: "another_value"
+  transaction_name:
+    type:
+      - string
+      - "null"
+    description: The name of the wallet transactions triggered by this rule. It will appear on the invoice as the label for the fee. If not set, the label on the invoice will fallback to either `Prepaid credits - {{wallet_name}}` if the wallet name is set, or `Prepaid credits`.
+    example: "Tokens for models 'high-fidelity-boost'"

--- a/src/schemas/WalletUpdateInput.yaml
+++ b/src/schemas/WalletUpdateInput.yaml
@@ -118,6 +118,12 @@ properties:
                   value: "example_value"
                 - key: "another_key"
                   value: "another_value"
+            transaction_name:
+              type:
+                - string
+                - "null"
+              description: The name of the wallet transactions triggered by this rule. It will appear on the invoice as the label for the fee. If not set, the label on the invoice will fallback to either `Prepaid credits - {{wallet_name}}` if the wallet name is set, or `Prepaid credits`.
+              example: "Tokens for models 'high-fidelity-boost'"
       applies_to:
         type:
           - object


### PR DESCRIPTION
## Context

When creating a wallet transaction, the name displayed on the invoice defaults to the wallet name. However, for organizations managing multiple types of top-ups, it would be beneficial to display specific naming on invoices that corresponds to the particular transaction being made.

## Description 

This change adds a `name` attribute to the wallet transaction recurring rule object and inputs.