### PR TITLE
feat(wallet): Allow to set the name of a wallet's initial transactions

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -16523,6 +16523,12 @@ components:
                   value: example_value
                 - key: another_key
                   value: another_value
+            transaction_name:
+              type:
+                - string
+                - 'null'
+              description: The name of the wallet transactions triggered when creating the wallet. It will appear on the invoice as the label for the fee. If not set, the label on the invoice will fallback to either `Prepaid credits - {{wallet_name}}` if the wallet name is set, or `Prepaid credits`.
+              example: Tokens for models 'high-fidelity-boost'
             applies_to:
               type:
                 - object

--- a/src/schemas/WalletCreateInput.yaml
+++ b/src/schemas/WalletCreateInput.yaml
@@ -70,6 +70,12 @@ properties:
             value: "example_value"
           - key: "another_key"
             value: "another_value"
+      transaction_name:
+        type:
+          - string
+          - "null"
+        description: The name of the wallet transactions triggered when creating the wallet. It will appear on the invoice as the label for the fee. If not set, the label on the invoice will fallback to either `Prepaid credits - {{wallet_name}}` if the wallet name is set, or `Prepaid credits`.
+        example: "Tokens for models 'high-fidelity-boost'"
       applies_to:
         type:
           - object


### PR DESCRIPTION
## Roadmap Task

👉  https://getlago.canny.io/feature-requests/p/define-the-name-of-a-wallet-transaction-at-top-up

## Context

Follow up of https://github.com/getlago/lago-api/pull/4327.

## Description

This documents the possibility to provide a `name` for the wallet transactions created when creating a wallet via the `transaction_name` field.