### PR TITLE
fix(fee): Fix item_type documentation

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -10709,7 +10709,7 @@ components:
                 - BillableMetric
                 - Subscription
                 - WalletTransaction
-              description: The type of the fee item. Possible values are `AddOn`, `BillableMetric`, `WalletTransaction`, `Subscription` or `Commitment`.
+              description: The type of the fee item. Possible values are `AddOn`, `BillableMetric`, `WalletTransaction`, `Subscription`.
               example: Subscription
             grouped_by:
               type: object

--- a/src/schemas/FeeObject.yaml
+++ b/src/schemas/FeeObject.yaml
@@ -299,7 +299,7 @@ properties:
           - BillableMetric
           - Subscription
           - WalletTransaction
-        description: The type of the fee item. Possible values are `AddOn`, `BillableMetric`, `WalletTransaction`, `Subscription` or `Commitment`.
+        description: The type of the fee item. Possible values are `AddOn`, `BillableMetric`, `WalletTransaction`, `Subscription`.
         example: Subscription
       grouped_by:
         type: object


### PR DESCRIPTION
# Description

This PR fixes the code for https://github.com/getlago/lago-openapi/pull/437

FeeObject.item.item_type description mentions Commitment as a possible value but it's not present in the possible values in the enum. 

Ticket: Pylon #3920
