### PR TITLE
feat(webhook): flexible webhook events

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -22162,8 +22162,8 @@ components:
           example: 1a901a90-1a90-1a90-1a90-1a901a901a90
         webhook_url:
           type: string
-          description: The name of the wallet.
-          example: Prepaid
+          description: The URL of the webhook endpoint.
+          example: https://foo.bar
         signature_algo:
           type: string
           description: The signature algo for the webhook.
@@ -22171,6 +22171,22 @@ components:
           enum:
             - jwt
             - hmac
+        name:
+          type:
+            - string
+            - 'null'
+          description: The name of the webhook.
+          example: EC2-production
+        event_types:
+          type:
+            - array
+            - 'null'
+          description: A list of event types that will trigger the webhook. Passing null means that all event types will be sent.
+          items:
+            type: string
+          example:
+            - invoice.voided
+            - customer.created
         created_at:
           type: string
           format: date-time
@@ -22210,6 +22226,22 @@ components:
                 - jwt
                 - hmac
                 - null
+            name:
+              type:
+                - string
+                - 'null'
+              description: The name of the webhook.
+              example: EC2-production
+            event_types:
+              type:
+                - array
+                - 'null'
+              description: A list of event types that will trigger the webhook. Passing null means that all event types will be sent.
+              items:
+                type: string
+              example:
+                - invoice.voided
+                - customer.created
     WebhookEndpoint:
       type: object
       required:
@@ -22239,6 +22271,22 @@ components:
                 - jwt
                 - hmac
                 - null
+            name:
+              type:
+                - string
+                - 'null'
+              description: The name of the webhook.
+              example: EC2-production
+            event_types:
+              type:
+                - array
+                - 'null'
+              description: A list of event types that will trigger the webhook. Passing null means that all event types will be sent.
+              items:
+                type: string
+              example:
+                - invoice.voided
+                - customer.created
     TriggeredAlertObject:
       type: object
       required:

--- a/src/schemas/WebhookEndpointCreateInput.yaml
+++ b/src/schemas/WebhookEndpointCreateInput.yaml
@@ -19,3 +19,17 @@ properties:
           - jwt
           - hmac
           - null
+      name:
+        type:
+          - string
+          - "null"
+        description: The name of the webhook.
+        example: EC2-production
+      event_types:
+        type:
+          - array
+          - "null"
+        description: A list of event types that will trigger the webhook. Passing null means that all event types will be sent.
+        items:
+          type: string
+        example: ["invoice.voided", "customer.created"]

--- a/src/schemas/WebhookEndpointObject.yaml
+++ b/src/schemas/WebhookEndpointObject.yaml
@@ -17,8 +17,8 @@ properties:
     example: '1a901a90-1a90-1a90-1a90-1a901a901a90'
   webhook_url:
     type: string
-    description: The name of the wallet.
-    example: 'Prepaid'
+    description: The URL of the webhook endpoint.
+    example: "https://foo.bar"
   signature_algo:
     type: string
     description: The signature algo for the webhook.
@@ -26,6 +26,20 @@ properties:
     enum:
       - jwt
       - hmac
+  name:
+    type:
+      - string
+      - 'null'
+    description: The name of the webhook.
+    example: EC2-production
+  event_types:
+    type:
+      - array
+      - 'null'
+    description: A list of event types that will trigger the webhook. Passing null means that all event types will be sent.
+    items:
+      type: string
+    example: ['invoice.voided', 'customer.created']
   created_at:
     type: string
     format: 'date-time'

--- a/src/schemas/WebhookEndpointUpdateInput.yaml
+++ b/src/schemas/WebhookEndpointUpdateInput.yaml
@@ -19,3 +19,17 @@ properties:
           - jwt
           - hmac
           - null
+      name:
+        type:
+          - string
+          - "null"
+        description: The name of the webhook.
+        example: EC2-production
+      event_types:
+        type:
+          - array
+          - "null"
+        description: A list of event types that will trigger the webhook. Passing null means that all event types will be sent.
+        items:
+          type: string
+        example: ["invoice.voided", "customer.created"]


### PR DESCRIPTION
## Description

This PR adds two new attributes of the `WebhookEndpoint` resource: `event_types` and `name`.

See [lago-api PR#4981](https://github.com/getlago/lago-api/pull/4981) for additional details.