### PR TITLE
fix(webhook): update example signature in webhook_signature.yaml

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -8998,7 +8998,7 @@ components:
       required: true
       schema:
         type: string
-        example: "Ap¶5É¿\x9D\x9FÎ£6ÐfV£Ä\x15\x15ºõÔõÔ[D\x8BæAâÿüÚ"
+        example: 5a6e2c12a1d0c07e96b7d87eb8a80e5df9af5dc1bf6d7a8e3c0b2f4d6e8a1c3f
     webhook_signature_algorithm:
       name: X-Lago-Signature-Algorithm
       in: header

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -8994,11 +8994,14 @@ components:
     webhook_signature:
       name: X-Lago-Signature
       in: header
-      description: Signature of the webhook payload
+      description: |-
+        Signature of the webhook payload. The format depends on `X-Lago-Signature-Algorithm`:
+        `hmac` is the Base64 encoding of an HMAC-SHA256 digest of the payload,
+        `jwt` is an RS256 JSON Web Token (a string starting with `eyJ`).
       required: true
       schema:
         type: string
-        example: 5a6e2c12a1d0c07e96b7d87eb8a80e5df9af5dc1bf6d7a8e3c0b2f4d6e8a1c3f
+        example: AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8=
     webhook_signature_algorithm:
       name: X-Lago-Signature-Algorithm
       in: header

--- a/src/parameters/webhook_signature.yaml
+++ b/src/parameters/webhook_signature.yaml
@@ -4,4 +4,4 @@ description: Signature of the webhook payload
 required: true
 schema:
   type: string
-  example: "Ap\xB65\xC9\xBF\x9D\x9F\xCE\xA36\xD0fV\xA3\xC4\x15\x15\xBA\xF5\xD4\xF5\xD4[D\x8B\xE6A\xE2\xFF\xFC\xDA"
+  example: "5a6e2c12a1d0c07e96b7d87eb8a80e5df9af5dc1bf6d7a8e3c0b2f4d6e8a1c3f"

--- a/src/parameters/webhook_signature.yaml
+++ b/src/parameters/webhook_signature.yaml
@@ -1,7 +1,10 @@
 name: "X-Lago-Signature"
 in: header
-description: Signature of the webhook payload
+description: |-
+  Signature of the webhook payload. The format depends on `X-Lago-Signature-Algorithm`:
+  `hmac` is the Base64 encoding of an HMAC-SHA256 digest of the payload,
+  `jwt` is an RS256 JSON Web Token (a string starting with `eyJ`).
 required: true
 schema:
   type: string
-  example: "5a6e2c12a1d0c07e96b7d87eb8a80e5df9af5dc1bf6d7a8e3c0b2f4d6e8a1c3f"
+  example: "AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8="


### PR DESCRIPTION
The previous example contains raw binary/non-printable characters (escape sequences like \xB6, \xC9, etc.) which will break Swagger/OpenAPI code generation. I'll replace it with a proper hex-encoded HMAC signature string.
