### PR TITLE
fix(credit-note): include integration_customers in customer object

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -14208,13 +14208,78 @@ components:
                   amount_cents: 200
             metadata:
               $ref: '#/components/schemas/MetadataInput'
+    IntegrationCustomer:
+      type: object
+      required:
+        - lago_id
+        - type
+        - external_customer_id
+        - integration_code
+      description: Configuration specific to the accounting and tax integrations. This object contains settings and parameters necessary for syncing documents and payments.
+      properties:
+        lago_id:
+          type: string
+          format: uuid
+          example: 1a901a90-1a90-1a90-1a90-1a901a901a90
+          description: A unique identifier for the integration customer object in the Lago application.
+        type:
+          type: string
+          example: netsuite
+          description: |-
+            The integration type used for accounting and tax syncs.
+            Accepted values: `netsuite, anrok`.
+          enum:
+            - netsuite
+            - anrok
+            - xero
+            - hubspot
+            - salesforce
+        integration_code:
+          type: string
+          example: netsuite-eu-1
+          description: Unique code used to identify an integration connection.
+        external_customer_id:
+          type: string
+          example: cus_12345
+          description: The customer ID within the integration's system. If this field is not provided, Lago has the option to create a new customer record within the integration's system on behalf of the customer.
+        sync_with_provider:
+          type:
+            - boolean
+            - 'null'
+          example: true
+          description: Set this field to `true` if you want to create a customer record in the integration's system. This option is applicable only when the `external_customer_id` is null and the `sync_with_provider` field is set to `true`. By default, the value is set to `false`
+        subsidiary_id:
+          type: string
+          example: '2'
+          description: This optional field is needed only when working with `netsuite` connection.
+        targeted_object:
+          type:
+            - string
+            - 'null'
+          example: contacts
+          description: This optional field is present only when working with `hubspot` connection.
+        email:
+          type:
+            - string
+            - 'null'
+          example: dinesh@piedpiper.test
+          description: This optional field is present only when working with `hubspot` connection.
+    CustomerObject:
+      allOf:
+        - $ref: '#/components/schemas/CustomerBaseObject'
+        - type: object
+          properties:
+            integration_customers:
+              type: array
+              items:
+                $ref: '#/components/schemas/IntegrationCustomer'
     CreditNoteExtendedObject:
       allOf:
         - $ref: '#/components/schemas/CreditNoteObject'
         - type: object
           properties:
             customer:
-              $ref: '#/components/schemas/CustomerBaseObject'
+              $ref: '#/components/schemas/CustomerObject'
     CreditNoteExtended:
       type: object
       required:
@@ -14445,71 +14510,6 @@ components:
       properties:
         metadata:
           $ref: '#/components/schemas/MetadataObject'
-    IntegrationCustomer:
-      type: object
-      required:
-        - lago_id
-        - type
-        - external_customer_id
-        - integration_code
-      description: Configuration specific to the accounting and tax integrations. This object contains settings and parameters necessary for syncing documents and payments.
-      properties:
-        lago_id:
-          type: string
-          format: uuid
-          example: 1a901a90-1a90-1a90-1a90-1a901a901a90
-          description: A unique identifier for the integration customer object in the Lago application.
-        type:
-          type: string
-          example: netsuite
-          description: |-
-            The integration type used for accounting and tax syncs.
-            Accepted values: `netsuite, anrok`.
-          enum:
-            - netsuite
-            - anrok
-            - xero
-            - hubspot
-            - salesforce
-        integration_code:
-          type: string
-          example: netsuite-eu-1
-          description: Unique code used to identify an integration connection.
-        external_customer_id:
-          type: string
-          example: cus_12345
-          description: The customer ID within the integration's system. If this field is not provided, Lago has the option to create a new customer record within the integration's system on behalf of the customer.
-        sync_with_provider:
-          type:
-            - boolean
-            - 'null'
-          example: true
-          description: Set this field to `true` if you want to create a customer record in the integration's system. This option is applicable only when the `external_customer_id` is null and the `sync_with_provider` field is set to `true`. By default, the value is set to `false`
-        subsidiary_id:
-          type: string
-          example: '2'
-          description: This optional field is needed only when working with `netsuite` connection.
-        targeted_object:
-          type:
-            - string
-            - 'null'
-          example: contacts
-          description: This optional field is present only when working with `hubspot` connection.
-        email:
-          type:
-            - string
-            - 'null'
-          example: dinesh@piedpiper.test
-          description: This optional field is present only when working with `hubspot` connection.
-    CustomerObject:
-      allOf:
-        - $ref: '#/components/schemas/CustomerBaseObject'
-        - type: object
-          properties:
-            integration_customers:
-              type: array
-              items:
-                $ref: '#/components/schemas/IntegrationCustomer'
     ErrorDetailObject:
       type: object
       required:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -13875,6 +13875,71 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/CustomerMetadata'
+    IntegrationCustomer:
+      type: object
+      required:
+        - lago_id
+        - type
+        - external_customer_id
+        - integration_code
+      description: Configuration specific to the accounting and tax integrations. This object contains settings and parameters necessary for syncing documents and payments.
+      properties:
+        lago_id:
+          type: string
+          format: uuid
+          example: 1a901a90-1a90-1a90-1a90-1a901a901a90
+          description: A unique identifier for the integration customer object in the Lago application.
+        type:
+          type: string
+          example: netsuite
+          description: |-
+            The integration type used for accounting and tax syncs.
+            Accepted values: `netsuite, anrok`.
+          enum:
+            - netsuite
+            - anrok
+            - xero
+            - hubspot
+            - salesforce
+        integration_code:
+          type: string
+          example: netsuite-eu-1
+          description: Unique code used to identify an integration connection.
+        external_customer_id:
+          type: string
+          example: cus_12345
+          description: The customer ID within the integration's system. If this field is not provided, Lago has the option to create a new customer record within the integration's system on behalf of the customer.
+        sync_with_provider:
+          type:
+            - boolean
+            - 'null'
+          example: true
+          description: Set this field to `true` if you want to create a customer record in the integration's system. This option is applicable only when the `external_customer_id` is null and the `sync_with_provider` field is set to `true`. By default, the value is set to `false`
+        subsidiary_id:
+          type: string
+          example: '2'
+          description: This optional field is needed only when working with `netsuite` connection.
+        targeted_object:
+          type:
+            - string
+            - 'null'
+          example: contacts
+          description: This optional field is present only when working with `hubspot` connection.
+        email:
+          type:
+            - string
+            - 'null'
+          example: dinesh@piedpiper.test
+          description: This optional field is present only when working with `hubspot` connection.
+    CustomerObject:
+      allOf:
+        - $ref: '#/components/schemas/CustomerBaseObject'
+        - type: object
+          properties:
+            integration_customers:
+              type: array
+              items:
+                $ref: '#/components/schemas/IntegrationCustomer'
     MetadataObject:
       type:
         - object
@@ -14096,7 +14161,7 @@ components:
           example: false
           description: Indicates if the credit note belongs to self-billed invoice. Self-billing is a process where an organization creates the invoice on behalf of the partner.
         customer:
-          $ref: '#/components/schemas/CustomerBaseObject'
+          $ref: '#/components/schemas/CustomerObject'
         metadata:
           $ref: '#/components/schemas/MetadataObject'
         error_details:
@@ -14208,71 +14273,6 @@ components:
                   amount_cents: 200
             metadata:
               $ref: '#/components/schemas/MetadataInput'
-    IntegrationCustomer:
-      type: object
-      required:
-        - lago_id
-        - type
-        - external_customer_id
-        - integration_code
-      description: Configuration specific to the accounting and tax integrations. This object contains settings and parameters necessary for syncing documents and payments.
-      properties:
-        lago_id:
-          type: string
-          format: uuid
-          example: 1a901a90-1a90-1a90-1a90-1a901a901a90
-          description: A unique identifier for the integration customer object in the Lago application.
-        type:
-          type: string
-          example: netsuite
-          description: |-
-            The integration type used for accounting and tax syncs.
-            Accepted values: `netsuite, anrok`.
-          enum:
-            - netsuite
-            - anrok
-            - xero
-            - hubspot
-            - salesforce
-        integration_code:
-          type: string
-          example: netsuite-eu-1
-          description: Unique code used to identify an integration connection.
-        external_customer_id:
-          type: string
-          example: cus_12345
-          description: The customer ID within the integration's system. If this field is not provided, Lago has the option to create a new customer record within the integration's system on behalf of the customer.
-        sync_with_provider:
-          type:
-            - boolean
-            - 'null'
-          example: true
-          description: Set this field to `true` if you want to create a customer record in the integration's system. This option is applicable only when the `external_customer_id` is null and the `sync_with_provider` field is set to `true`. By default, the value is set to `false`
-        subsidiary_id:
-          type: string
-          example: '2'
-          description: This optional field is needed only when working with `netsuite` connection.
-        targeted_object:
-          type:
-            - string
-            - 'null'
-          example: contacts
-          description: This optional field is present only when working with `hubspot` connection.
-        email:
-          type:
-            - string
-            - 'null'
-          example: dinesh@piedpiper.test
-          description: This optional field is present only when working with `hubspot` connection.
-    CustomerObject:
-      allOf:
-        - $ref: '#/components/schemas/CustomerBaseObject'
-        - type: object
-          properties:
-            integration_customers:
-              type: array
-              items:
-                $ref: '#/components/schemas/IntegrationCustomer'
     CreditNoteExtendedObject:
       allOf:
         - $ref: '#/components/schemas/CreditNoteObject'

--- a/src/schemas/CreditNoteExtendedObject.yaml
+++ b/src/schemas/CreditNoteExtendedObject.yaml
@@ -3,4 +3,4 @@ allOf:
   - type: object
     properties:
       customer:
-        $ref: "./CustomerBaseObject.yaml"
+        $ref: "./CustomerObject.yaml"

--- a/src/schemas/CreditNoteObject.yaml
+++ b/src/schemas/CreditNoteObject.yaml
@@ -179,7 +179,7 @@ properties:
     example: false
     description: Indicates if the credit note belongs to self-billed invoice. Self-billing is a process where an organization creates the invoice on behalf of the partner.
   customer:
-    $ref: "../schemas/CustomerBaseObject.yaml"
+    $ref: "../schemas/CustomerObject.yaml"
   metadata:
     $ref: "./CreditNoteMetadataObject.yaml"
   error_details:


### PR DESCRIPTION
## Summary
- Updates `CreditNoteObject` and `CreditNoteExtendedObject` to reference `CustomerObject` instead of `CustomerBaseObject`
- This adds `integration_customers` to the `customer` field in **all** credit note responses — list, create, show, update and void

## Related
Follows lago-api changes:
- https://github.com/getlago/lago-api/commit/f83c781a5 — detail endpoint (`show`)
- https://github.com/getlago/lago-api/commit/fe4e75866d4be672f25344951e1a2fbe857310c3 — remaining detail endpoints **and the list endpoint** (`credit_note_index.rb`)

## Test plan
- [ ] Verify `CreditNoteExtendedObject.customer` resolves to a schema including `integration_customers` array
- [ ] Verify `CreditNoteObject.customer` (list / `CreditNotesPaginated`) also resolves to a schema including `integration_customers` array