### PR TITLE
fix: add billable_metric_code to alert batch input

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -20699,6 +20699,12 @@ components:
                     type: string
                     description: Unique code used to identify the alert.
                     example: storage_threshold_alert
+                  billable_metric_code:
+                    type:
+                      - string
+                      - 'null'
+                    description: The code of the billable metric associated with the alert. Only for alerts based on a billable metric.
+                    example: storage_usage
     Alert:
       type: object
       required:

--- a/src/schemas/AlertBatchCreateInput.yaml
+++ b/src/schemas/AlertBatchCreateInput.yaml
@@ -27,3 +27,9 @@ properties:
               type: string
               description: Unique code used to identify the alert.
               example: "storage_threshold_alert"
+            billable_metric_code:
+              type:
+                - string
+                - "null"
+              description: The code of the billable metric associated with the alert. Only for alerts based on a billable metric.
+              example: "storage_usage"


### PR DESCRIPTION
## Context

The `AlertBatchCreateInput` schema was missing the
`billable_metric_code` property. Because `@getlago/client` is
auto-generated from this spec, the field was absent from the
TypeScript types, forcing customers to use unsafe casts when calling
the batch-create endpoint. The Rails API already accepts the
parameter via `batch_create_params`; the single-resource
`AlertCreateInput` and `AlertUpdateInput` schemas already declare it,
so only the batch variant was out of date.

## Description

Declare an optional, nullable `billable_metric_code` property on
`AlertBatchCreateInput`, mirroring the wording and example used by
`AlertCreateInput` and regenerate the bundled `openapi.yaml`.