### PR TITLE
feat: document billable_metric.{created,updated,deleted} …

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -6792,6 +6792,123 @@ webhooks:
       responses:
         '200':
           description: Return a 200 status to indicate that the data was received successfully
+  billable_metric_created:
+    post:
+      operationId: billableMetricCreated
+      summary: A new billable metric has been created
+      description: A new billable metric has been created
+      parameters:
+        - $ref: '#/components/parameters/webhook_signature'
+        - $ref: '#/components/parameters/webhook_signature_algorithm'
+        - $ref: '#/components/parameters/webhook_unique_key'
+      requestBody:
+        description: Details of the new billable metric
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - webhook_type
+                - object_type
+                - organization_id
+                - billable_metric
+              properties:
+                webhook_type:
+                  type: string
+                  enum:
+                    - billable_metric.created
+                object_type:
+                  type: string
+                  enum:
+                    - billable_metric
+                organization_id:
+                  type: string
+                  format: uuid
+                  description: Unique identifier of the organization, created by Lago.
+                  example: 1a901a90-1a90-1a90-1a90-1a901a901a90
+                billable_metric:
+                  $ref: '#/components/schemas/BillableMetricObject'
+      responses:
+        '200':
+          description: Return a 200 status to indicate that the data was received successfully
+  billable_metric_updated:
+    post:
+      operationId: billableMetricUpdated
+      summary: A billable metric has been updated
+      description: A billable metric has been updated
+      parameters:
+        - $ref: '#/components/parameters/webhook_signature'
+        - $ref: '#/components/parameters/webhook_signature_algorithm'
+        - $ref: '#/components/parameters/webhook_unique_key'
+      requestBody:
+        description: Details of the billable metric
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - webhook_type
+                - object_type
+                - organization_id
+                - billable_metric
+              properties:
+                webhook_type:
+                  type: string
+                  enum:
+                    - billable_metric.updated
+                object_type:
+                  type: string
+                  enum:
+                    - billable_metric
+                organization_id:
+                  type: string
+                  format: uuid
+                  description: Unique identifier of the organization, created by Lago.
+                  example: 1a901a90-1a90-1a90-1a90-1a901a901a90
+                billable_metric:
+                  $ref: '#/components/schemas/BillableMetricObject'
+      responses:
+        '200':
+          description: Return a 200 status to indicate that the data was received successfully
+  billable_metric_deleted:
+    post:
+      operationId: billableMetricDeleted
+      summary: A billable metric has been deleted
+      description: A billable metric has been deleted
+      parameters:
+        - $ref: '#/components/parameters/webhook_signature'
+        - $ref: '#/components/parameters/webhook_signature_algorithm'
+        - $ref: '#/components/parameters/webhook_unique_key'
+      requestBody:
+        description: Details of the billable metric
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - webhook_type
+                - object_type
+                - organization_id
+                - billable_metric
+              properties:
+                webhook_type:
+                  type: string
+                  enum:
+                    - billable_metric.deleted
+                object_type:
+                  type: string
+                  enum:
+                    - billable_metric
+                organization_id:
+                  type: string
+                  format: uuid
+                  description: Unique identifier of the organization, created by Lago.
+                  example: 1a901a90-1a90-1a90-1a90-1a901a901a90
+                billable_metric:
+                  $ref: '#/components/schemas/BillableMetricObject'
+      responses:
+        '200':
+          description: Return a 200 status to indicate that the data was received successfully
   customer_created:
     post:
       operationId: customerCreated

--- a/src/openapi.yaml
+++ b/src/openapi.yaml
@@ -389,6 +389,12 @@ paths:
 webhooks:
   alert_triggered:
     $ref: "./webhooks/alert_triggered.yaml"
+  billable_metric_created:
+    $ref: "./webhooks/billable_metric_created.yaml"
+  billable_metric_updated:
+    $ref: "./webhooks/billable_metric_updated.yaml"
+  billable_metric_deleted:
+    $ref: "./webhooks/billable_metric_deleted.yaml"
   customer_created:
     $ref: "./webhooks/customer_created.yaml"
   customer_updated:

--- a/src/webhooks/billable_metric_created.yaml
+++ b/src/webhooks/billable_metric_created.yaml
@@ -1,0 +1,38 @@
+post:
+  operationId: billableMetricCreated
+  summary: A new billable metric has been created
+  description: A new billable metric has been created
+  parameters:
+    - $ref: "../parameters/webhook_signature.yaml"
+    - $ref: "../parameters/webhook_signature_algorithm.yaml"
+    - $ref: "../parameters/webhook_unique_key.yaml"
+  requestBody:
+    description: Details of the new billable metric
+    content:
+      application/json:
+        schema:
+          type: object
+          required:
+            - webhook_type
+            - object_type
+            - organization_id
+            - billable_metric
+          properties:
+            webhook_type:
+              type: string
+              enum:
+                - billable_metric.created
+            object_type:
+              type: string
+              enum:
+                - billable_metric
+            organization_id:
+              type: string
+              format: "uuid"
+              description: Unique identifier of the organization, created by Lago.
+              example: "1a901a90-1a90-1a90-1a90-1a901a901a90"
+            billable_metric:
+              $ref: "../schemas/BillableMetricObject.yaml"
+  responses:
+    "200":
+      description: Return a 200 status to indicate that the data was received successfully

--- a/src/webhooks/billable_metric_deleted.yaml
+++ b/src/webhooks/billable_metric_deleted.yaml
@@ -1,0 +1,38 @@
+post:
+  operationId: billableMetricDeleted
+  summary: A billable metric has been deleted
+  description: A billable metric has been deleted
+  parameters:
+    - $ref: "../parameters/webhook_signature.yaml"
+    - $ref: "../parameters/webhook_signature_algorithm.yaml"
+    - $ref: "../parameters/webhook_unique_key.yaml"
+  requestBody:
+    description: Details of the billable metric
+    content:
+      application/json:
+        schema:
+          type: object
+          required:
+            - webhook_type
+            - object_type
+            - organization_id
+            - billable_metric
+          properties:
+            webhook_type:
+              type: string
+              enum:
+                - billable_metric.deleted
+            object_type:
+              type: string
+              enum:
+                - billable_metric
+            organization_id:
+              type: string
+              format: "uuid"
+              description: Unique identifier of the organization, created by Lago.
+              example: "1a901a90-1a90-1a90-1a90-1a901a901a90"
+            billable_metric:
+              $ref: "../schemas/BillableMetricObject.yaml"
+  responses:
+    "200":
+      description: Return a 200 status to indicate that the data was received successfully

--- a/src/webhooks/billable_metric_updated.yaml
+++ b/src/webhooks/billable_metric_updated.yaml
@@ -1,0 +1,38 @@
+post:
+  operationId: billableMetricUpdated
+  summary: A billable metric has been updated
+  description: A billable metric has been updated
+  parameters:
+    - $ref: "../parameters/webhook_signature.yaml"
+    - $ref: "../parameters/webhook_signature_algorithm.yaml"
+    - $ref: "../parameters/webhook_unique_key.yaml"
+  requestBody:
+    description: Details of the billable metric
+    content:
+      application/json:
+        schema:
+          type: object
+          required:
+            - webhook_type
+            - object_type
+            - organization_id
+            - billable_metric
+          properties:
+            webhook_type:
+              type: string
+              enum:
+                - billable_metric.updated
+            object_type:
+              type: string
+              enum:
+                - billable_metric
+            organization_id:
+              type: string
+              format: "uuid"
+              description: Unique identifier of the organization, created by Lago.
+              example: "1a901a90-1a90-1a90-1a90-1a901a901a90"
+            billable_metric:
+              $ref: "../schemas/BillableMetricObject.yaml"
+  responses:
+    "200":
+      description: Return a 200 status to indicate that the data was received successfully


### PR DESCRIPTION
…webhooks

Add OpenAPI definitions for the three new billable-metric webhook events, mirroring the plan_{created,updated,deleted} pattern and reusing the existing BillableMetricObject schema.

Bundled openapi.yaml regenerated via 'npm run build'; 'npm test' is clean (only pre-existing warnings).
