### PR TITLE
feat(clickhouse): Document organization.events_store in REST API [ING-205]

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -18056,6 +18056,12 @@ components:
           type: boolean
           example: false
           description: Indicates whether invoices with a zero total amount should be finalized. If set to true, zero amount invoices will be finalized. If set to false, zero amount invoices will not be finalized.
+        events_store:
+          type: string
+          enum:
+            - clickhouse
+            - postgres
+          example: clickhouse
     Organization:
       type: object
       required:

--- a/src/schemas/OrganizationObject.yaml
+++ b/src/schemas/OrganizationObject.yaml
@@ -139,3 +139,9 @@ properties:
     type: boolean
     example: false
     description: Indicates whether invoices with a zero total amount should be finalized. If set to true, zero amount invoices will be finalized. If set to false, zero amount invoices will not be finalized.
+  events_store:
+    type: string
+    enum:
+      - clickhouse
+      - postgres
+    example: clickhouse


### PR DESCRIPTION
Related to https://github.com/getlago/lago-api/pull/5566

The PR documents the new `events_store` attribute on the organization object