### PR TITLE
[ING-30] feat: Document currency filter on list endpoints

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -4255,6 +4255,7 @@ paths:
       parameters:
         - $ref: '#/components/parameters/page'
         - $ref: '#/components/parameters/per_page'
+        - $ref: '#/components/parameters/currency'
         - $ref: '#/components/parameters/external_customer_id'
         - $ref: '#/components/parameters/payment_status'
         - name: billing_entity_codes[]
@@ -5214,6 +5215,7 @@ paths:
       parameters:
         - $ref: '#/components/parameters/page'
         - $ref: '#/components/parameters/per_page'
+        - $ref: '#/components/parameters/currency'
         - name: external_customer_id
           in: query
           description: The customer external unique identifier (provided by your own application)
@@ -6242,6 +6244,7 @@ paths:
       parameters:
         - $ref: '#/components/parameters/page'
         - $ref: '#/components/parameters/per_page'
+        - $ref: '#/components/parameters/currency'
         - name: external_customer_id
           in: query
           description: The customer external unique identifier (provided by your own application).
@@ -9175,6 +9178,15 @@ components:
         type: string
         format: uuid
         example: 1a901a90-1a90-1a90-1a90-1a901a901a90
+    currency:
+      name: currency
+      in: query
+      description: Filter the results by currency, expressed as an ISO 4217 code.
+      required: false
+      explode: true
+      schema:
+        type: string
+        example: EUR
     plan_code:
       name: code
       in: path

--- a/src/parameters/currency.yaml
+++ b/src/parameters/currency.yaml
@@ -1,0 +1,8 @@
+name: currency
+in: query
+description: Filter the results by currency, expressed as an ISO 4217 code.
+required: false
+explode: true
+schema:
+  type: string
+  example: EUR

--- a/src/resources/payment_requests.yaml
+++ b/src/resources/payment_requests.yaml
@@ -33,6 +33,7 @@ get:
   parameters:
     - $ref: '../parameters/page.yaml'
     - $ref: '../parameters/per_page.yaml'
+    - $ref: '../parameters/currency.yaml'
     - $ref: '../parameters/external_customer_id.yaml'
     - $ref: '../parameters/payment_status.yaml'
     - name: billing_entity_codes[]

--- a/src/resources/subscriptions.yaml
+++ b/src/resources/subscriptions.yaml
@@ -35,6 +35,7 @@ get:
   parameters:
     - $ref: '../parameters/page.yaml'
     - $ref: '../parameters/per_page.yaml'
+    - $ref: '../parameters/currency.yaml'
     - name: external_customer_id
       in: query
       description: The customer external unique identifier (provided by your own application)

--- a/src/resources/wallets.yaml
+++ b/src/resources/wallets.yaml
@@ -35,6 +35,7 @@ get:
   parameters:
     - $ref: "../parameters/page.yaml"
     - $ref: "../parameters/per_page.yaml"
+    - $ref: "../parameters/currency.yaml"
     - name: external_customer_id
       in: query
       description: The customer external unique identifier (provided by your own application).


### PR DESCRIPTION
## Context

The lago-api backend exposes an optional `currency` query parameter on the subscriptions, wallets, and payment_requests list endpoints (getlago/lago-api#5249), filtering respectively by plan amount currency, wallet balance currency, and payment request amount currency. The OpenAPI spec did not document it, so the published reference and downstream SDKs had no knowledge of the filter.

## Description

Adds a shared `currency` query parameter and references it from the `GET` parameters of the three list endpoints. It follows the existing filter-param convention (a file under `src/parameters/` referenced by path and hoisted into `components.parameters` at bundle time, like `payment_status` and `subscription_status`), and sets `explode: true` to match sibling query params. The bundled `openapi.yaml` is regenerated so the published spec stays in sync with the source.

## How to try locally

```
npm install
npm run test   # bundles src, then runs redocly + spectral lint
```

`GET /subscriptions`, `GET /wallets`, and `GET /payment_requests` now expose an optional `currency` query parameter.