### PR TITLE
[ING-218] fix(customer_usage): Align past usage response schema with API 

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -16636,7 +16636,6 @@ components:
         - amount_currency
         - charge
         - billable_metric
-        - groups
       properties:
         units:
           type: string
@@ -16685,7 +16684,9 @@ components:
                 - volume
               example: graduated
             invoice_display_name:
-              type: string
+              type:
+                - string
+                - 'null'
               description: Specifies the name that will be displayed on an invoice. If no value is set for this field, the name of the actual charge will be used as the default display name.
               example: Setup
         billable_metric:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -17075,7 +17075,7 @@ components:
         usage_periods:
           type: array
           items:
-            $ref: '#/components/schemas/CustomerUsage'
+            $ref: '#/components/schemas/CustomerUsageObject'
         meta:
           $ref: '#/components/schemas/PaginationMeta'
     CustomerCheckoutUrl:

--- a/src/schemas/CustomerChargeUsageObject.yaml
+++ b/src/schemas/CustomerChargeUsageObject.yaml
@@ -7,7 +7,6 @@ required:
   - amount_currency
   - charge
   - billable_metric
-  - groups
 properties:
   units:
     type: string
@@ -56,7 +55,9 @@ properties:
           - volume
         example: graduated
       invoice_display_name:
-        type: string
+        type:
+          - string
+          - "null"
         description: Specifies the name that will be displayed on an invoice. If no value is set for this field, the name of the actual charge will be used as the default display name.
         example: Setup
   billable_metric:

--- a/src/schemas/CustomerPastUsage.yaml
+++ b/src/schemas/CustomerPastUsage.yaml
@@ -6,6 +6,6 @@ properties:
   usage_periods:
     type: array
     items:
-      $ref: './CustomerUsage.yaml'
+      $ref: './CustomerUsageObject.yaml'
   meta:
     $ref: './PaginationMeta.yaml'


### PR DESCRIPTION
## Context

`GET /customers/{external_customer_id}/past_usage` is documented as wrapping each `usage_periods` item in a `customer_usage` object, but the API returns the usage fields directly at the top level of each item. Generated SDK types therefore do not match real responses. Validating a real payload against the spec also surfaced two smaller mismatches in the shared `CustomerChargeUsageObject` schema.

## Description

The `usage_periods` items in `CustomerPastUsage` now reference `CustomerUsageObject` directly instead of the `CustomerUsage` wrapper, matching the actual serializer output. The wrapper schema is unchanged since it still describes the current usage endpoint response.

In `CustomerChargeUsageObject` (shared by the past, current and projected usage docs), the stale `groups` entry was removed from the required list (no such property exists and the API never returns it) and `charge.invoice_display_name` is now nullable.