### PR TITLE
fix(schemas): nest required inside items for usage object arrays

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -16120,11 +16120,11 @@ components:
             recurring_transaction_rules:
               type: array
               description: List of recurring transaction rules. Currently, we only allow one recurring rule per wallet.
-              required:
-                - trigger
               items:
                 type: object
                 description: Object that represents rule for wallet recurring transactions.
+                required:
+                  - trigger
                 properties:
                   lago_id:
                     type: string
@@ -16539,14 +16539,14 @@ components:
     CustomerChargeFiltersUsageObject:
       type: array
       description: Array of filter object, representing multiple dimensions for a charge item.
-      required:
-        - values
-        - units
-        - total_aggregated_units
-        - events_count
-        - amount_cents
       items:
         type: object
+        required:
+          - values
+          - units
+          - total_aggregated_units
+          - events_count
+          - amount_cents
         properties:
           units:
             type: string
@@ -16587,15 +16587,14 @@ components:
     CustomerChargeGroupedUsageObject:
       type: array
       description: Array of aggregated fees, grouped by the event properties defined in a `standard` charge model.
-      required:
-        - amount_cents
-        - events_count
-        - units
-        - total_aggregated_units
-        - grouped_by
-        - groups
       items:
         type: object
+        required:
+          - amount_cents
+          - events_count
+          - units
+          - total_aggregated_units
+          - grouped_by
         properties:
           amount_cents:
             type: integer
@@ -16792,15 +16791,15 @@ components:
     CustomerProjectedChargeFiltersUsageObject:
       type: array
       description: Array of filter object, representing multiple dimensions for a charge item.
-      required:
-        - values
-        - units
-        - projected_units
-        - events_count
-        - amount_cents
-        - projected_amount_cents
       items:
         type: object
+        required:
+          - values
+          - units
+          - projected_units
+          - events_count
+          - amount_cents
+          - projected_amount_cents
         properties:
           units:
             type: string
@@ -16847,16 +16846,15 @@ components:
     CustomerProjectedChargeGroupedUsageObject:
       type: array
       description: Array of aggregated fees, grouped by the event properties defined in a `standard` charge model.
-      required:
-        - amount_cents
-        - projected_amount_cents
-        - events_count
-        - units
-        - projected_units
-        - grouped_by
-        - groups
       items:
         type: object
+        required:
+          - amount_cents
+          - projected_amount_cents
+          - events_count
+          - units
+          - projected_units
+          - grouped_by
         properties:
           amount_cents:
             type: integer

--- a/src/schemas/CustomerChargeFiltersUsageObject.yaml
+++ b/src/schemas/CustomerChargeFiltersUsageObject.yaml
@@ -1,13 +1,13 @@
 type: array
 description: Array of filter object, representing multiple dimensions for a charge item.
-required:
-  - values
-  - units
-  - total_aggregated_units
-  - events_count
-  - amount_cents
 items:
   type: object
+  required:
+    - values
+    - units
+    - total_aggregated_units
+    - events_count
+    - amount_cents
   properties:
     units:
       type: string

--- a/src/schemas/CustomerChargeGroupedUsageObject.yaml
+++ b/src/schemas/CustomerChargeGroupedUsageObject.yaml
@@ -1,14 +1,13 @@
 type: array
 description: Array of aggregated fees, grouped by the event properties defined in a `standard` charge model.
-required:
-  - amount_cents
-  - events_count
-  - units
-  - total_aggregated_units
-  - grouped_by
-  - groups
 items:
   type: object
+  required:
+    - amount_cents
+    - events_count
+    - units
+    - total_aggregated_units
+    - grouped_by
   properties:
     amount_cents:
       type: integer

--- a/src/schemas/CustomerProjectedChargeFiltersUsageObject.yaml
+++ b/src/schemas/CustomerProjectedChargeFiltersUsageObject.yaml
@@ -1,14 +1,14 @@
 type: array
 description: Array of filter object, representing multiple dimensions for a charge item.
-required:
-  - values
-  - units
-  - projected_units
-  - events_count
-  - amount_cents
-  - projected_amount_cents
 items:
   type: object
+  required:
+    - values
+    - units
+    - projected_units
+    - events_count
+    - amount_cents
+    - projected_amount_cents
   properties:
     units:
       type: string

--- a/src/schemas/CustomerProjectedChargeGroupedUsageObject.yaml
+++ b/src/schemas/CustomerProjectedChargeGroupedUsageObject.yaml
@@ -1,15 +1,14 @@
 type: array
 description: Array of aggregated fees, grouped by the event properties defined in a `standard` charge model.
-required:
-  - amount_cents
-  - projected_amount_cents
-  - events_count
-  - units
-  - projected_units
-  - grouped_by
-  - groups
 items:
   type: object
+  required:
+    - amount_cents
+    - projected_amount_cents
+    - events_count
+    - units
+    - projected_units
+    - grouped_by
   properties:
     amount_cents:
       type: integer

--- a/src/schemas/WalletUpdateInput.yaml
+++ b/src/schemas/WalletUpdateInput.yaml
@@ -39,11 +39,11 @@ properties:
       recurring_transaction_rules:
         type: array
         description: List of recurring transaction rules. Currently, we only allow one recurring rule per wallet.
-        required:
-          - trigger
         items:
           type: object
           description: Object that represents rule for wallet recurring transactions.
+          required:
+            - trigger
           properties:
             lago_id:
               type: string


### PR DESCRIPTION
Several array schemas declare `required` as a sibling of `items` rather than inside the item object:

```yaml
type: array
required:        # no effect at the array level
  - amount_cents
items:
  type: object
  properties:
    amount_cents: ...
```

Because the `required` keyword only applies to object schemas, the listed properties were not actually enforced in any generated client (JS/Python/Ruby/Go).

## Changes

- Move `required` into the `items` object for:
  - `CustomerChargeFiltersUsageObject`
  - `CustomerChargeGroupedUsageObject`
  - `CustomerProjectedChargeFiltersUsageObject`
  - `CustomerProjectedChargeGroupedUsageObject`
  - `WalletUpdateInput` (the `recurring_transaction_rules` array)
- Drop the stale `groups` entry from the two grouped usage objects — it is listed as required but is not a defined property (the schema uses `grouped_by` and `filters`).
- Regenerate `openapi.yaml`.

## Verification

- `npm run build` succeeds.
- `redocly lint` drops from 39 to 14 warnings (clears 25 `no-required-schema-properties-undefined`).
- `spectral lint` reports 0 errors.