### PR TITLE
[ING-238] feat(wallets): document grants_target_top_up on recurring transaction rules

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -15491,6 +15491,7 @@ components:
         - created_at
         - expiration_at
         - granted_credits
+        - grants_target_top_up
         - ignore_paid_top_up_limits
         - interval
         - invoice_requires_successful_payment
@@ -15556,6 +15557,12 @@ components:
           pattern: ^[0-9]+.?[0-9]*$
           description: The number of free granted credits. Required only if there is no paid credits.
           example: '10.0'
+        grants_target_top_up:
+          type:
+            - boolean
+            - 'null'
+          description: Applies only to `target` rules. When `true`, the recurring top-up grants free credits to reach the target ongoing balance instead of creating a paid top-up (and bypasses the paid top-up minimum). When `false`, the gap is filled with a paid top-up. `null` for `fixed` rules. Defaults to `false` for target rules when omitted.
+          example: false
         started_at:
           type:
             - string
@@ -16005,6 +16012,12 @@ components:
                     pattern: ^[0-9]+.?[0-9]*$
                     description: The number of free granted credits used for recurring top-up.
                     example: '10.0'
+                  grants_target_top_up:
+                    type:
+                      - boolean
+                      - 'null'
+                    description: Applies only to `target` rules. When `true`, the recurring top-up grants free credits to reach the target ongoing balance instead of creating a paid top-up (and bypasses the paid top-up minimum). When `false`, the gap is filled with a paid top-up. `null` for `fixed` rules. Defaults to `false` for target rules when omitted.
+                    example: false
                   method:
                     type: string
                     enum:
@@ -16201,6 +16214,12 @@ components:
                     pattern: ^[0-9]+.?[0-9]*$
                     description: The number of free granted credits. Required only if there is no paid credits.
                     example: '10.0'
+                  grants_target_top_up:
+                    type:
+                      - boolean
+                      - 'null'
+                    description: Applies only to `target` rules. When `true`, the recurring top-up grants free credits to reach the target ongoing balance instead of creating a paid top-up (and bypasses the paid top-up minimum). When `false`, the gap is filled with a paid top-up. `null` for `fixed` rules. Defaults to `false` for target rules when omitted.
+                    example: false
                   started_at:
                     type:
                       - string

--- a/src/schemas/WalletCreateInput.yaml
+++ b/src/schemas/WalletCreateInput.yaml
@@ -163,6 +163,12 @@ properties:
               pattern: "^[0-9]+.?[0-9]*$"
               description: The number of free granted credits used for recurring top-up.
               example: "10.0"
+            grants_target_top_up:
+              type:
+                - boolean
+                - "null"
+              description: "Applies only to `target` rules. When `true`, the recurring top-up grants free credits to reach the target ongoing balance instead of creating a paid top-up (and bypasses the paid top-up minimum). When `false`, the gap is filled with a paid top-up. `null` for `fixed` rules. Defaults to `false` for target rules when omitted."
+              example: false
             method:
               type: string
               enum:

--- a/src/schemas/WalletRecurringTransactionRule.yaml
+++ b/src/schemas/WalletRecurringTransactionRule.yaml
@@ -4,6 +4,7 @@ required:
   - created_at
   - expiration_at
   - granted_credits
+  - grants_target_top_up
   - ignore_paid_top_up_limits
   - interval
   - invoice_requires_successful_payment
@@ -69,6 +70,12 @@ properties:
     pattern: "^[0-9]+.?[0-9]*$"
     description: The number of free granted credits. Required only if there is no paid credits.
     example: "10.0"
+  grants_target_top_up:
+    type:
+      - boolean
+      - "null"
+    description: "Applies only to `target` rules. When `true`, the recurring top-up grants free credits to reach the target ongoing balance instead of creating a paid top-up (and bypasses the paid top-up minimum). When `false`, the gap is filled with a paid top-up. `null` for `fixed` rules. Defaults to `false` for target rules when omitted."
+    example: false
   started_at:
     type:
       - string

--- a/src/schemas/WalletUpdateInput.yaml
+++ b/src/schemas/WalletUpdateInput.yaml
@@ -97,6 +97,12 @@ properties:
               pattern: "^[0-9]+.?[0-9]*$"
               description: The number of free granted credits. Required only if there is no paid credits.
               example: "10.0"
+            grants_target_top_up:
+              type:
+                - boolean
+                - "null"
+              description: "Applies only to `target` rules. When `true`, the recurring top-up grants free credits to reach the target ongoing balance instead of creating a paid top-up (and bypasses the paid top-up minimum). When `false`, the gap is filled with a paid top-up. `null` for `fixed` rules. Defaults to `false` for target rules when omitted."
+              example: false
             started_at:
               type:
                 - string


### PR DESCRIPTION
## Context

Wallet recurring transaction rules of type `target` previously always created a paid top-up; there was no way to grant free credits through a target rule. The API now supports this via a nullable boolean `grants_target_top_up` on the recurring transaction rule (getlago/lago-api#5755). On a `target` rule, `true` makes the periodic gap-fill grant free credits to reach the target balance (and bypasses the paid top-up minimum) instead of creating a paid top-up; `false`, the default for target rules, keeps the current paid behaviour. The field is `null` for `fixed` rules.

## Description

Documents `grants_target_top_up` in the OpenAPI spec so consumers and generated SDKs reflect it:

- Adds the field to the recurring transaction rule schema (`WalletRecurringTransactionRule`) and to the inline recurring rule definitions on the wallet create and update inputs.
- Models it as a nullable boolean (`type: [boolean, "null"]`), matching the other nullable fields on the schema.
- Marks it `required` on the response schema, consistent with the other always-serialised fields there (e.g. `ignore_paid_top_up_limits`, `started_at`), since the API always returns the key.
- Regenerates the bundled `openapi.yaml`.

No spec version bump: handled separately at release time, per repo convention.

## How to try locally

```
npm run build && npm test
```

Then confirm the field renders on the wallet recurring transaction rule create / update / response schemas.

