### PR TITLE
update dunning_campaign.finished definition

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -22463,6 +22463,20 @@ components:
             - type: string
             - type: object
               additionalProperties: true
+    OverdueBalancePerCurrencyObject:
+      type: object
+      required:
+        - amount_cents
+        - currency
+      properties:
+        amount_cents:
+          type: integer
+          description: The amount of the overdue balance for this currency, expressed in cents.
+          example: 120
+        currency:
+          $ref: '#/components/schemas/Currency'
+          description: The currency of the overdue balance.
+          example: EUR
     DunningCampaignFinishedObject:
       type: object
       required:
@@ -22487,6 +22501,11 @@ components:
           $ref: '#/components/schemas/Currency'
           description: The currency of the balance.
           example: EUR
+        overdue_balances:
+          type: array
+          description: Overdue balance broken down per currency.
+          items:
+            $ref: '#/components/schemas/OverdueBalancePerCurrencyObject'
     EventErrorsObject:
       type: object
       required:

--- a/src/schemas/DunningCampaignFinishedObject.yaml
+++ b/src/schemas/DunningCampaignFinishedObject.yaml
@@ -21,3 +21,8 @@ properties:
     $ref: "./Currency.yaml"
     description: The currency of the balance.
     example: "EUR"
+  overdue_balances:
+    type: array
+    description: Overdue balance broken down per currency.
+    items:
+      $ref: "./OverdueBalancePerCurrencyObject.yaml"

--- a/src/schemas/OverdueBalancePerCurrencyObject.yaml
+++ b/src/schemas/OverdueBalancePerCurrencyObject.yaml
@@ -1,0 +1,13 @@
+type: object
+required:
+  - amount_cents
+  - currency
+properties:
+  amount_cents:
+    type: integer
+    description: The amount of the overdue balance for this currency, expressed in cents.
+    example: 120
+  currency:
+    $ref: "./Currency.yaml"
+    description: The currency of the overdue balance.
+    example: "EUR"


### PR DESCRIPTION
## Multi-currency support: `overdue_balances` on `dunning_campaign.finished` webhook

### What
Adds a new additive field `overdue_balances` to the `dunning_campaign.finished`
webhook payload to support multi-currency dunning. The field is an array breaking
down the overdue balance per currency.

Each item contains:
- `amount_cents` (integer)
- `currency` (`$ref` to the shared ISO 4217 `Currency` schema)

### Why
With multi-currency support, a customer's overdue balance can span more than one
currency. The existing scalar `overdue_balance_cents` / `overdue_balance_currency`
fields can only express a single currency, so we add a per-currency breakdown
alongside them.

### Backward compatibility
Fully additive. No fields renamed or removed. The existing
`overdue_balance_cents` and `overdue_balance_currency` fields are unchanged.