### PR TITLE
[ING-70] feat(multi-entity): billing_entity scoping across endpoints

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2391,6 +2391,18 @@ paths:
         - $ref: '#/components/parameters/page'
         - $ref: '#/components/parameters/per_page'
         - $ref: '#/components/parameters/payment_status'
+        - name: billing_entity_codes[]
+          in: query
+          description: Filter payment requests by billing entity codes.
+          required: false
+          explode: true
+          schema:
+            type: array
+            items:
+              type: string
+            example:
+              - billing_entity_code_1
+              - billing_entity_code_2
       responses:
         '200':
           description: PaymentRequests
@@ -2480,6 +2492,18 @@ paths:
             example:
               - active
               - pending
+        - name: billing_entity_codes[]
+          in: query
+          description: Filter subscriptions by billing entity codes.
+          required: false
+          explode: true
+          schema:
+            type: array
+            items:
+              type: string
+            example:
+              - billing_entity_code_1
+              - billing_entity_code_2
       responses:
         '200':
           description: List of subscriptions
@@ -2531,6 +2555,18 @@ paths:
       parameters:
         - $ref: '#/components/parameters/page'
         - $ref: '#/components/parameters/per_page'
+        - name: billing_entity_codes[]
+          in: query
+          description: Filter wallets by billing entity codes.
+          required: false
+          explode: true
+          schema:
+            type: array
+            items:
+              type: string
+            example:
+              - billing_entity_code_1
+              - billing_entity_code_2
       responses:
         '200':
           description: Wallets
@@ -4221,6 +4257,18 @@ paths:
         - $ref: '#/components/parameters/per_page'
         - $ref: '#/components/parameters/external_customer_id'
         - $ref: '#/components/parameters/payment_status'
+        - name: billing_entity_codes[]
+          in: query
+          description: Filter payment requests by billing entity codes.
+          required: false
+          explode: true
+          schema:
+            type: array
+            items:
+              type: string
+            example:
+              - billing_entity_code_1
+              - billing_entity_code_2
       responses:
         '200':
           description: PaymentRequests
@@ -5197,6 +5245,18 @@ paths:
             example:
               - active
               - pending
+        - name: billing_entity_codes[]
+          in: query
+          description: Filter subscriptions by billing entity codes.
+          required: false
+          explode: true
+          schema:
+            type: array
+            items:
+              type: string
+            example:
+              - billing_entity_code_1
+              - billing_entity_code_2
       responses:
         '200':
           description: List of subscriptions
@@ -6190,6 +6250,18 @@ paths:
           schema:
             type: string
             example: 5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba
+        - name: billing_entity_codes[]
+          in: query
+          description: Filter wallets by billing entity codes.
+          required: false
+          explode: true
+          schema:
+            type: array
+            items:
+              type: string
+            example:
+              - billing_entity_code_1
+              - billing_entity_code_2
       responses:
         '200':
           description: Wallets
@@ -15228,6 +15300,10 @@ components:
           type: string
           example: 5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba
           description: The customer external unique identifier (provided by your own application).
+        billing_entity_code:
+          type: string
+          example: default
+          description: The code of the billing entity associated with the subscription.
         billing_time:
           type: string
           description: The billing time for the subscription, which can be set as either `anniversary` or `calendar`. If not explicitly provided, it will default to `calendar`. The billing time determines the timing of recurring billing cycles for the subscription. By specifying `anniversary`, the billing cycle will be based on the specific date the subscription started (billed fully), while `calendar` sets the billing cycle at the first day of the week/month/year (billed with proration).
@@ -15579,6 +15655,10 @@ components:
           type: string
           description: The customer external unique identifier (provided by your own application)
           example: hooli_1234
+        billing_entity_code:
+          type: string
+          example: default
+          description: The code of the billing entity associated with the wallet.
         status:
           type: string
           enum:
@@ -15813,6 +15893,10 @@ components:
               type: string
               description: The customer external unique identifier (provided by your own application)
               example: hooli_1234
+            billing_entity_code:
+              type: string
+              example: default
+              description: The code of the billing entity associated with the wallet. If not provided, the customer's billing entity is used.
             expiration_at:
               type:
                 - string
@@ -16054,6 +16138,10 @@ components:
               type: boolean
               description: A boolean setting that, when set to true, delays issuing an invoice for a wallet top-up until a successful payment is made; if false, the invoice is issued immediately upon wallet top-up, regardless of the payment status. Default value of false.
               example: false
+            billing_entity_code:
+              type: string
+              example: default
+              description: The code of the billing entity associated with the wallet.
             invoice_custom_section:
               $ref: '#/components/schemas/InvoiceCustomSectionInput'
             recurring_transaction_rules:
@@ -17640,6 +17728,10 @@ components:
               type: string
               description: Unique identifier assigned to the customer in your application.
               example: hooli_1234
+            billing_entity_code:
+              type: string
+              example: default
+              description: The code of the billing entity to issue the invoice from. If not provided, the customer's billing entity is used.
             currency:
               $ref: '#/components/schemas/Currency'
               description: The currency of the invoice.
@@ -20891,6 +20983,10 @@ components:
 
                 - `true`: the subscription is included in the customer's standard invoice grouping (by billing entity, currency and payment method).
                 - `false`: the subscription is excluded from consolidation and always billed on its own dedicated invoice.
+            billing_entity_code:
+              type: string
+              example: default
+              description: The code of the billing entity associated with the subscription. Updates take effect on future invoices only.
     Subscription:
       type: object
       required:

--- a/src/resources/customer_payment_requests.yaml
+++ b/src/resources/customer_payment_requests.yaml
@@ -10,6 +10,16 @@ get:
     - $ref: "../parameters/page.yaml"
     - $ref: "../parameters/per_page.yaml"
     - $ref: "../parameters/payment_status.yaml"
+    - name: billing_entity_codes[]
+      in: query
+      description: Filter payment requests by billing entity codes.
+      required: false
+      explode: true
+      schema:
+        type: array
+        items:
+          type: string
+        example: [billing_entity_code_1, billing_entity_code_2]
   responses:
     "200":
       description: PaymentRequests

--- a/src/resources/customer_subscriptions.yaml
+++ b/src/resources/customer_subscriptions.yaml
@@ -32,6 +32,16 @@ get:
             - terminated
             - active
         example: [active, pending]
+    - name: billing_entity_codes[]
+      in: query
+      description: Filter subscriptions by billing entity codes.
+      required: false
+      explode: true
+      schema:
+        type: array
+        items:
+          type: string
+        example: [billing_entity_code_1, billing_entity_code_2]
 
   responses:
     "200":

--- a/src/resources/customer_wallets.yaml
+++ b/src/resources/customer_wallets.yaml
@@ -37,6 +37,16 @@ get:
   parameters:
     - $ref: "../parameters/page.yaml"
     - $ref: "../parameters/per_page.yaml"
+    - name: billing_entity_codes[]
+      in: query
+      description: Filter wallets by billing entity codes.
+      required: false
+      explode: true
+      schema:
+        type: array
+        items:
+          type: string
+        example: [billing_entity_code_1, billing_entity_code_2]
   responses:
     "200":
       description: Wallets

--- a/src/resources/payment_requests.yaml
+++ b/src/resources/payment_requests.yaml
@@ -35,6 +35,16 @@ get:
     - $ref: '../parameters/per_page.yaml'
     - $ref: '../parameters/external_customer_id.yaml'
     - $ref: '../parameters/payment_status.yaml'
+    - name: billing_entity_codes[]
+      in: query
+      description: Filter payment requests by billing entity codes.
+      required: false
+      explode: true
+      schema:
+        type: array
+        items:
+          type: string
+        example: [billing_entity_code_1, billing_entity_code_2]
   responses:
     '200':
       description: PaymentRequests

--- a/src/resources/subscriptions.yaml
+++ b/src/resources/subscriptions.yaml
@@ -64,6 +64,16 @@ get:
             - pending
             - terminated
         example: [active,pending]
+    - name: billing_entity_codes[]
+      in: query
+      description: Filter subscriptions by billing entity codes.
+      required: false
+      explode: true
+      schema:
+        type: array
+        items:
+          type: string
+        example: [billing_entity_code_1, billing_entity_code_2]
 
   responses:
     '200':

--- a/src/resources/wallets.yaml
+++ b/src/resources/wallets.yaml
@@ -43,6 +43,16 @@ get:
       schema:
         type: string
         example: "5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba"
+    - name: billing_entity_codes[]
+      in: query
+      description: Filter wallets by billing entity codes.
+      required: false
+      explode: true
+      schema:
+        type: array
+        items:
+          type: string
+        example: [billing_entity_code_1, billing_entity_code_2]
   responses:
     "200":
       description: Wallets

--- a/src/schemas/InvoiceOneOffCreateInput.yaml
+++ b/src/schemas/InvoiceOneOffCreateInput.yaml
@@ -12,6 +12,10 @@ properties:
         type: string
         description: Unique identifier assigned to the customer in your application.
         example: "hooli_1234"
+      billing_entity_code:
+        type: string
+        example: "default"
+        description: The code of the billing entity to issue the invoice from. If not provided, the customer's billing entity is used.
       currency:
         $ref: "./Currency.yaml"
         description: The currency of the invoice.

--- a/src/schemas/SubscriptionObject.yaml
+++ b/src/schemas/SubscriptionObject.yaml
@@ -41,6 +41,10 @@ properties:
     type: string
     example: "5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba"
     description: The customer external unique identifier (provided by your own application).
+  billing_entity_code:
+    type: string
+    example: "default"
+    description: The code of the billing entity associated with the subscription.
   billing_time:
     type: string
     description: The billing time for the subscription, which can be set as either `anniversary` or `calendar`. If not explicitly provided, it will default to `calendar`. The billing time determines the timing of recurring billing cycles for the subscription. By specifying `anniversary`, the billing cycle will be based on the specific date the subscription started (billed fully), while `calendar` sets the billing cycle at the first day of the week/month/year (billed with proration).

--- a/src/schemas/SubscriptionUpdateInput.yaml
+++ b/src/schemas/SubscriptionUpdateInput.yaml
@@ -47,3 +47,7 @@ properties:
 
           - `true`: the subscription is included in the customer's standard invoice grouping (by billing entity, currency and payment method).
           - `false`: the subscription is excluded from consolidation and always billed on its own dedicated invoice.
+      billing_entity_code:
+        type: string
+        example: "default"
+        description: The code of the billing entity associated with the subscription. Updates take effect on future invoices only.

--- a/src/schemas/WalletCreateInput.yaml
+++ b/src/schemas/WalletCreateInput.yaml
@@ -52,6 +52,10 @@ properties:
         type: string
         description: The customer external unique identifier (provided by your own application)
         example: "hooli_1234"
+      billing_entity_code:
+        type: string
+        example: "default"
+        description: The code of the billing entity associated with the wallet. If not provided, the customer's billing entity is used.
       expiration_at:
         type:
           - string

--- a/src/schemas/WalletObject.yaml
+++ b/src/schemas/WalletObject.yaml
@@ -31,6 +31,10 @@ properties:
     type: string
     description: The customer external unique identifier (provided by your own application)
     example: "hooli_1234"
+  billing_entity_code:
+    type: string
+    example: "default"
+    description: The code of the billing entity associated with the wallet.
   status:
     type: string
     enum:

--- a/src/schemas/WalletUpdateInput.yaml
+++ b/src/schemas/WalletUpdateInput.yaml
@@ -34,6 +34,10 @@ properties:
         type: boolean
         description: A boolean setting that, when set to true, delays issuing an invoice for a wallet top-up until a successful payment is made; if false, the invoice is issued immediately upon wallet top-up, regardless of the payment status. Default value of false.
         example: false
+      billing_entity_code:
+        type: string
+        example: "default"
+        description: The code of the billing entity associated with the wallet.
       invoice_custom_section:
         $ref: "./InvoiceCustomSectionInput.yaml"
       recurring_transaction_rules:


### PR DESCRIPTION
## Summary

Reflects the multi-entity billing API change in the spec. Callers can now pin a subscription, wallet, or one-off invoice to a specific billing entity within a multi-entity organization, read the resolved entity back from subscription and wallet responses (invoice and credit_note already exposed it), and filter the subscription, wallet, and payment_request list endpoints by `billing_entity_codes[]` (the invoice and credit_note lists already supported it).

## Changes

**Schemas — `billing_entity_code` (string) added to:**

- `SubscriptionUpdateInput` — `PUT /subscriptions/:external_id`. Mutable, takes effect on future invoices.
- `SubscriptionObject` — read back on every subscription response.
- `WalletCreateInput` — `POST /wallets` (also covers `POST /customers/:external_id/wallets`, which shares the schema). Defaults to the customer's billing entity.
- `WalletUpdateInput` — `PUT /wallets/:id`. The API permits it on update too.
- `WalletObject` — read back on every wallet response.
- `InvoiceOneOffCreateInput` — `POST /invoices` (one-off).

The `SubscriptionCreateInput`, `InvoicePreviewInput`, `InvoiceBaseObject`, and `CreditNoteObject` schemas already declared `billing_entity_code` before this PR.

**Resources — `billing_entity_codes[]` array query filter added to:**

- `GET /subscriptions` and `GET /customers/:external_customer_id/subscriptions`.
- `GET /wallets` and `GET /customers/:external_customer_id/wallets`.
- `GET /payment_requests` and `GET /customers/:external_customer_id/payment_requests`.

`GET /invoices` and `GET /credit_notes` already exposed the filter.

## Notes

No new schemas, parameters, or index entries — every edited file was already registered. The regenerated top-level `openapi.yaml` propagates the changes.

`SubscriptionObject.billing_entity_code` is added per the target API behaviour; the `SubscriptionSerializer` on the API side is part of the same in-flight work and should land together with — or just before — this PR.

## Verification

- `npm run build` — redocly bundle clean.
- `npm run test` — redocly + spectral lint clean (0 errors). The 6 spectral warnings reported are pre-existing (`status[]`, `coupon_code[]`, `account_type[]`, one unused component) — none introduced here. The new `billing_entity_codes[]` filter is plural and bracket-suffixed so it satisfies both `array-params-plural` and `array-params-brackets`.
