### PR TITLE
Event lago_id is an opaque identifier, not always a UUID

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -17416,9 +17416,8 @@ components:
           type:
             - string
             - 'null'
-          format: uuid
           example: 1a901a90-1a90-1a90-1a90-1a901a901a90
-          description: Unique identifier assigned to the event within the Lago application. This ID is exclusively created by Lago and serves as a unique identifier for the event's record within the Lago system
+          description: Unique identifier assigned to the event within the Lago application. This ID is exclusively created by Lago and serves as a unique identifier for the event's record within the Lago system. It is an opaque identifier and is not guaranteed to be a UUID; on organizations using the ClickHouse events store it is a composite string.
         transaction_id:
           type: string
           example: transaction_1234567890

--- a/src/schemas/EventObject.yaml
+++ b/src/schemas/EventObject.yaml
@@ -11,9 +11,8 @@ properties:
     type:
       - string
       - "null"
-    format: "uuid"
     example: "1a901a90-1a90-1a90-1a90-1a901a901a90"
-    description: Unique identifier assigned to the event within the Lago application. This ID is exclusively created by Lago and serves as a unique identifier for the event's record within the Lago system
+    description: Unique identifier assigned to the event within the Lago application. This ID is exclusively created by Lago and serves as a unique identifier for the event's record within the Lago system. It is an opaque identifier and is not guaranteed to be a UUID; on organizations using the ClickHouse events store it is a composite string.
   transaction_id:
     type: string
     example: "transaction_1234567890"


### PR DESCRIPTION
lago_id on events is not guaranteed to be a UUID. On organizations using the ClickHouse events store it is a composite string, so the uuid format constraint was inaccurate and rejected valid responses in strict clients (Go, Rust).

Removed format: uuid from EventObject.lago_id and clarified the description. lago_customer_id and lago_subscription_id keep format: uuid since they remain real UUIDs on both stores.

Follow-up to getlago/lago-rust-client#50 (reviewer request to sync the spec).