### PR TITLE
fix(docs): mention deprecation in param and property descriptions

### DIFF
--- a/.spectral.yml
+++ b/.spectral.yml
@@ -20,7 +20,7 @@ rules:
       - field: name
         function: plural
   deprecated-parameter-must-mention-in-description:
-    message: "Deprecated parameter at {{path}} must mention 'deprecated' in its description."
+    message: "Deprecated parameter at {{path}} must start with '**Deprecated**.' in its description."
     description: Deprecated parameters must mention the deprecation in their description.
     severity: error
     given: "$.paths.*.*.parameters[?(@ && @.deprecated == true)]"
@@ -30,9 +30,9 @@ rules:
       - field: description
         function: pattern
         functionOptions:
-          match: "/deprecated/i"
+          match: "/^\\*\\*Deprecated\\.\\*\\*/"
   deprecated-schema-property-must-mention-in-description:
-    message: "Deprecated schema property at {{path}} must mention 'deprecated' in its description."
+    message: "Deprecated schema property at {{path}} must start with '**Deprecated**.' in its description."
     description: Deprecated schema properties must mention the deprecation in their description.
     severity: error
     given: "$..properties[?(@ && @.deprecated == true)]"
@@ -42,4 +42,4 @@ rules:
       - field: description
         function: pattern
         functionOptions:
-          match: "/deprecated/i"
+          match: "/^\\*\\*Deprecated\\.\\*\\*/"

--- a/.spectral.yml
+++ b/.spectral.yml
@@ -19,3 +19,25 @@ rules:
     then:
       - field: name
         function: plural
+  deprecated-parameter-must-mention-in-description:
+    message: "Deprecated parameter at {{path}} must mention 'deprecated' in its description."
+    severity: error
+    given: "$.paths.*.*.parameters[?(@ && @.deprecated == true)]"
+    then:
+      - field: description
+        function: truthy
+      - field: description
+        function: pattern
+        functionOptions:
+          match: "/deprecated/i"
+  deprecated-schema-property-must-mention-in-description:
+    message: "Deprecated schema property at {{path}} must mention 'deprecated' in its description."
+    severity: error
+    given: "$..properties[?(@ && @.deprecated == true)]"
+    then:
+      - field: description
+        function: truthy
+      - field: description
+        function: pattern
+        functionOptions:
+          match: "/deprecated/i"

--- a/.spectral.yml
+++ b/.spectral.yml
@@ -21,6 +21,7 @@ rules:
         function: plural
   deprecated-parameter-must-mention-in-description:
     message: "Deprecated parameter at {{path}} must mention 'deprecated' in its description."
+    description: Deprecated parameters must mention the deprecation in their description.
     severity: error
     given: "$.paths.*.*.parameters[?(@ && @.deprecated == true)]"
     then:
@@ -32,6 +33,7 @@ rules:
           match: "/deprecated/i"
   deprecated-schema-property-must-mention-in-description:
     message: "Deprecated schema property at {{path}} must mention 'deprecated' in its description."
+    description: Deprecated schema properties must mention the deprecation in their description.
     severity: error
     given: "$..properties[?(@ && @.deprecated == true)]"
     then:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2971,7 +2971,7 @@ paths:
               cloud: aws
         - name: filter_by_charge_id
           in: query
-          description: Filter usage to a specific charge by its Lago ID (UUID).
+          description: '**Deprecated.** Filter usage to a specific charge by its Lago ID (UUID).'
           required: false
           deprecated: true
           schema:
@@ -2980,7 +2980,7 @@ paths:
             example: 1a901a90-1a90-1a90-1a90-1a901a901a90
         - name: filter_by_charge_code
           in: query
-          description: Filter usage to a specific charge by its code.
+          description: '**Deprecated.** Filter usage to a specific charge by its code.'
           required: false
           deprecated: true
           schema:
@@ -2989,7 +2989,7 @@ paths:
         - name: filter_by_group
           in: query
           description: |
-            Filter usage by pricing group. Pass key/value pairs as query parameters, e.g. `filter_by_group[cloud]=aws`.
+            **Deprecated.** Filter usage by pricing group. Pass key/value pairs as query parameters, e.g. `filter_by_group[cloud]=aws`.
           required: false
           deprecated: true
           style: deepObject
@@ -10341,7 +10341,7 @@ components:
         applied_to_organization:
           type: boolean
           deprecated: true
-          description: This field is deprecated and will be removed in a future version. When set to true, it applies the tax to the organization's default billing entity. To apply or remove a tax from any billing entity (including the default one), please use the `PUT /billing_entities/:code` endpoint instead.
+          description: '**Deprecated.** This field will be removed in a future version. When set to true, it applies the tax to the organization''s default billing entity. To apply or remove a tax from any billing entity (including the default one), please use the `PUT /billing_entities/:code` endpoint instead.'
           example: true
         created_at:
           type: string
@@ -10383,7 +10383,7 @@ components:
         applied_to_organization:
           type: boolean
           deprecated: true
-          description: This field is deprecated and will be removed in a future version. When set to true, it applies the invoice custom section to the organization's default billing entity. To apply or remove an invoice custom section from any billing entity (including the default one), please use the `PUT /billing_entities/:code` endpoint instead.
+          description: '**Deprecated.** This field will be removed in a future version. When set to true, it applies the invoice custom section to the organization''s default billing entity. To apply or remove an invoice custom section from any billing entity (including the default one), please use the `PUT /billing_entities/:code` endpoint instead.'
           example: true
         organization_id:
           type: string
@@ -15343,7 +15343,7 @@ components:
           deprecated: true
           type: string
           format: uuid
-          description: Unique identifier of the invoice custom section that was applied.
+          description: '**Deprecated.** Unique identifier of the invoice custom section that was applied.'
           example: 1a901a90-1a90-1a90-1a90-1a901a901a90
         invoice_custom_section:
           $ref: '#/components/schemas/InvoiceCustomSectionObject'
@@ -18824,7 +18824,7 @@ components:
           type: array
           description: |-
             The list of event properties that are used to group the events on the invoice for a `standard` charge model.
-            **DEPRECATED** Replaced by `pricing_group_keys`.
+            **Deprecated.** Replaced by `pricing_group_keys`.
           items:
             type: string
           example:
@@ -21704,7 +21704,7 @@ components:
         applied_to_organization:
           type: boolean
           deprecated: true
-          description: This field is deprecated and will be removed in a future version. When set to true, it applies the tax to the organization's default billing entity. To apply or remove a tax from any billing entity (including the default one), please use the `PUT /billing_entities/:code` endpoint instead.
+          description: '**Deprecated.** This field will be removed in a future version. When set to true, it applies the tax to the organization''s default billing entity. To apply or remove a tax from any billing entity (including the default one), please use the `PUT /billing_entities/:code` endpoint instead.'
           example: true
     TaxCreateInput:
       type: object
@@ -22594,6 +22594,7 @@ components:
           type: array
           items:
             type: string
+          description: '**Deprecated.** List of event transaction_id with a missing group key.'
           deprecated: true
     FeeTaxProviderErrorObject:
       type: object

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -18823,8 +18823,8 @@ components:
         grouped_by:
           type: array
           description: |-
-            The list of event properties that are used to group the events on the invoice for a `standard` charge model.
             **Deprecated.** Replaced by `pricing_group_keys`.
+            The list of event properties that are used to group the events on the invoice for a `standard` charge model.
           items:
             type: string
           example:

--- a/src/resources/customer_current_usage.yaml
+++ b/src/resources/customer_current_usage.yaml
@@ -67,7 +67,7 @@ get:
           cloud: 'aws'
     - name: filter_by_charge_id
       in: query
-      description: Filter usage to a specific charge by its Lago ID (UUID).
+      description: '**Deprecated.** Filter usage to a specific charge by its Lago ID (UUID).'
       required: false
       deprecated: true
       schema:
@@ -76,7 +76,7 @@ get:
         example: '1a901a90-1a90-1a90-1a90-1a901a901a90'
     - name: filter_by_charge_code
       in: query
-      description: Filter usage to a specific charge by its code.
+      description: '**Deprecated.** Filter usage to a specific charge by its code.'
       required: false
       deprecated: true
       schema:
@@ -85,7 +85,7 @@ get:
     - name: filter_by_group
       in: query
       description: >
-        Filter usage by pricing group. Pass key/value pairs as query parameters,
+        **Deprecated.** Filter usage by pricing group. Pass key/value pairs as query parameters,
         e.g. `filter_by_group[cloud]=aws`.
       required: false
       deprecated: true

--- a/src/schemas/AppliedInvoiceCustomSectionObject.yaml
+++ b/src/schemas/AppliedInvoiceCustomSectionObject.yaml
@@ -18,7 +18,7 @@ properties:
     deprecated: true
     type: string
     format: "uuid"
-    description: Unique identifier of the invoice custom section that was applied.
+    description: '**Deprecated.** Unique identifier of the invoice custom section that was applied.'
     example: "1a901a90-1a90-1a90-1a90-1a901a901a90"
   invoice_custom_section:
     $ref: "./InvoiceCustomSectionObject.yaml"

--- a/src/schemas/ChargeProperties.yaml
+++ b/src/schemas/ChargeProperties.yaml
@@ -4,8 +4,8 @@ properties:
   grouped_by:
     type: array
     description: |-
-      The list of event properties that are used to group the events on the invoice for a `standard` charge model.
       **Deprecated.** Replaced by `pricing_group_keys`.
+      The list of event properties that are used to group the events on the invoice for a `standard` charge model.
     items:
       type: string
     example: ["agent_name"]

--- a/src/schemas/ChargeProperties.yaml
+++ b/src/schemas/ChargeProperties.yaml
@@ -5,7 +5,7 @@ properties:
     type: array
     description: |-
       The list of event properties that are used to group the events on the invoice for a `standard` charge model.
-      **DEPRECATED** Replaced by `pricing_group_keys`.
+      **Deprecated.** Replaced by `pricing_group_keys`.
     items:
       type: string
     example: ["agent_name"]

--- a/src/schemas/EventsErrorsObject.yaml
+++ b/src/schemas/EventsErrorsObject.yaml
@@ -30,4 +30,5 @@ properties:
     type: array
     items:
       type: string
+    description: '**Deprecated.** List of event transaction_id with a missing group key.'
     deprecated: true

--- a/src/schemas/InvoiceCustomSectionObject.yaml
+++ b/src/schemas/InvoiceCustomSectionObject.yaml
@@ -32,7 +32,7 @@ properties:
   applied_to_organization:
     type: boolean
     deprecated: true
-    description: This field is deprecated and will be removed in a future version. When set to true, it applies the invoice custom section to the organization's default billing entity. To apply or remove an invoice custom section from any billing entity (including the default one), please use the `PUT /billing_entities/:code` endpoint instead.
+    description: "**Deprecated.** This field will be removed in a future version. When set to true, it applies the invoice custom section to the organization's default billing entity. To apply or remove an invoice custom section from any billing entity (including the default one), please use the `PUT /billing_entities/:code` endpoint instead."
     example: true
   organization_id:
     type: string

--- a/src/schemas/TaxBaseInput.yaml
+++ b/src/schemas/TaxBaseInput.yaml
@@ -22,5 +22,5 @@ properties:
   applied_to_organization:
     type: boolean
     deprecated: true
-    description: This field is deprecated and will be removed in a future version. When set to true, it applies the tax to the organization's default billing entity. To apply or remove a tax from any billing entity (including the default one), please use the `PUT /billing_entities/:code` endpoint instead.
+    description: "**Deprecated.** This field will be removed in a future version. When set to true, it applies the tax to the organization's default billing entity. To apply or remove a tax from any billing entity (including the default one), please use the `PUT /billing_entities/:code` endpoint instead."
     example: true

--- a/src/schemas/TaxObject.yaml
+++ b/src/schemas/TaxObject.yaml
@@ -33,7 +33,7 @@ properties:
   applied_to_organization:
     type: boolean
     deprecated: true
-    description: This field is deprecated and will be removed in a future version. When set to true, it applies the tax to the organization's default billing entity. To apply or remove a tax from any billing entity (including the default one), please use the `PUT /billing_entities/:code` endpoint instead.
+    description: "**Deprecated.** This field will be removed in a future version. When set to true, it applies the tax to the organization's default billing entity. To apply or remove a tax from any billing entity (including the default one), please use the `PUT /billing_entities/:code` endpoint instead."
     example: true
   created_at:
     type: string


### PR DESCRIPTION
## Context

`deprecated: true` on parameters and schema properties is not rendered by Mintlify; only operation-level deprecation gets a badge. As a result, 9 deprecated entries in the spec (the `filter_by_*` params on the current usage endpoint deprecated in #528, `applied_to_organization`, `invoice_custom_section_id`, `missing_group_key`, `grouped_by`) show no warning on the docs site.

## Description

A `**Deprecated.**` prefix was added to the description of each deprecated parameter and schema property. `missing_group_key` had no description at all, so one was added. Descriptions that already said "This field is deprecated and will be removed in a future version" were reworded to avoid saying "deprecated" twice, and the existing `**DEPRECATED**` note on `grouped_by` was normalized to the same style.

Two Spectral rules now enforce this for future changes: a deprecated parameter or schema property must have a description, and that description must mention the deprecation. A deprecated entry with no description at all is also an error. Operation-level deprecation (webhooks) is intentionally not covered, since Mintlify renders it natively.

The bundled `openapi.yaml` was regenerated with `npm run build`.

Fixes ING-224.
