### PR TITLE
feat(purchase_order_number): document field on subscriptions and wallets

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -15672,6 +15672,12 @@ components:
             $ref: '#/components/schemas/SubscriptionActivationRuleObject'
           description: |
             The activation rules attached to the subscription. A payment activation rule gates activation on a successful first payment, keeping the subscription in the `incomplete` state until the payment succeeds or the rule expires.
+        purchase_order_number:
+          type:
+            - string
+            - 'null'
+          example: PO-123
+          description: The purchase order number associated with the subscription. It will be added to invoices generated for this subscription.
     SubscriptionsPaginated:
       type: object
       required:
@@ -15828,6 +15834,12 @@ components:
         payment_method:
           $ref: '#/components/schemas/PaymentMethodReference'
           description: The payment method assigned to this recurring transaction rule for processing top-up payments.
+        purchase_order_number:
+          type:
+            - string
+            - 'null'
+          example: PO-123
+          description: The purchase order number associated with this recurring transaction rule. It will be added to invoices generated for the resulting wallet top-ups. If not set, falls back to the wallet's `purchase_order_number`.
     WalletObject:
       type: object
       required:
@@ -16016,6 +16028,12 @@ components:
         payment_method:
           $ref: '#/components/schemas/PaymentMethodReference'
           description: The payment method assigned to this wallet for processing top-up payments.
+        purchase_order_number:
+          type:
+            - string
+            - 'null'
+          example: PO-123
+          description: The purchase order number associated with the wallet. It will be added to invoices generated for wallet top-ups, unless a more specific purchase order number is set on the wallet transaction or recurring transaction rule that triggered the top-up.
         metadata:
           $ref: '#/components/schemas/MetadataObject'
     WalletsPaginated:
@@ -16140,6 +16158,12 @@ components:
                 - 'null'
               description: The name of the wallet transactions triggered when creating the wallet. It will appear on the invoice as the label for the fee. If not set, the label on the invoice will fallback to either `Prepaid credits - {{wallet_name}}` if the wallet name is set, or `Prepaid credits`.
               example: Tokens for models 'high-fidelity-boost'
+            purchase_order_number:
+              type:
+                - string
+                - 'null'
+              example: PO-123
+              description: The purchase order number associated with the wallet. It will be added to invoices generated for wallet top-ups, unless a more specific purchase order number is set on the wallet transaction or recurring transaction rule that triggered the top-up.
             applies_to:
               type:
                 - object
@@ -16293,6 +16317,12 @@ components:
                       - 'null'
                     description: The name of the wallet transactions triggered by this rule. It will appear on the invoice as the label for the fee. If not set, the label on the invoice will fallback to either `Prepaid credits - {{wallet_name}}` if the wallet name is set, or `Prepaid credits`.
                     example: Tokens for models 'high-fidelity-boost'
+                  purchase_order_number:
+                    type:
+                      - string
+                      - 'null'
+                    example: PO-123
+                    description: The purchase order number associated with this recurring transaction rule. It will be added to invoices generated for the resulting wallet top-ups. If not set, falls back to the wallet's `purchase_order_number`.
                   ignore_paid_top_up_limits:
                     type: boolean
                     description: When true, allows rule to topped up wallet with transactions that exceed the paid top-up limits. Defaults to false.
@@ -16355,6 +16385,12 @@ components:
               type: string
               example: default
               description: The code of the billing entity associated with the wallet.
+            purchase_order_number:
+              type:
+                - string
+                - 'null'
+              example: PO-123
+              description: The purchase order number associated with the wallet. It will be added to invoices generated for wallet top-ups, unless a more specific purchase order number is set on the wallet transaction or recurring transaction rule that triggered the top-up.
             invoice_custom_section:
               $ref: '#/components/schemas/InvoiceCustomSectionInput'
             recurring_transaction_rules:
@@ -16466,6 +16502,12 @@ components:
                       - 'null'
                     description: The name of the wallet transactions triggered by this rule. It will appear on the invoice as the label for the fee. If not set, the label on the invoice will fallback to either `Prepaid credits - {{wallet_name}}` if the wallet name is set, or `Prepaid credits`.
                     example: Tokens for models 'high-fidelity-boost'
+                  purchase_order_number:
+                    type:
+                      - string
+                      - 'null'
+                    example: PO-123
+                    description: The purchase order number associated with this recurring transaction rule. It will be added to invoices generated for the resulting wallet top-ups. If not set, falls back to the wallet's `purchase_order_number`.
                   invoice_custom_section:
                     $ref: '#/components/schemas/InvoiceCustomSectionInput'
                   payment_method:
@@ -21131,6 +21173,12 @@ components:
 
                 - `true` (default): the subscription is included in the customer's standard invoice grouping (by billing entity, currency and payment method).
                 - `false`: the subscription is excluded from consolidation and always billed on its own dedicated invoice.
+            purchase_order_number:
+              type:
+                - string
+                - 'null'
+              example: PO-123
+              description: The purchase order number associated with the subscription. It will be added to invoices generated for this subscription.
             activation_rules:
               type: array
               items:
@@ -21232,6 +21280,12 @@ components:
               type: string
               example: default
               description: The code of the billing entity associated with the subscription. Updates take effect on future invoices only.
+            purchase_order_number:
+              type:
+                - string
+                - 'null'
+              example: PO-123
+              description: The purchase order number associated with the subscription. It will be added to invoices generated for this subscription.
             activation_rules:
               type: array
               items:
@@ -21787,6 +21841,12 @@ components:
               type: boolean
               description: When true, allows topping up the wallet with transactions that exceed the paid top-up limits. Defaults to false.
               example: false
+            purchase_order_number:
+              type:
+                - string
+                - 'null'
+              example: PO-123
+              description: The purchase order number associated with this wallet transaction. It will be added to invoices generated for the resulting wallet top-up. If not set, falls back to the wallet's `purchase_order_number`.
             invoice_custom_section:
               $ref: '#/components/schemas/InvoiceCustomSectionInput'
             payment_method:
@@ -21980,6 +22040,12 @@ components:
         payment_method:
           $ref: '#/components/schemas/PaymentMethodReference'
           description: The payment method assigned to this wallet transaction for processing the payment.
+        purchase_order_number:
+          type:
+            - string
+            - 'null'
+          example: PO-123
+          description: The purchase order number associated with this wallet transaction. It will be added to invoices generated for the resulting wallet top-up. If not set, falls back to the wallet's `purchase_order_number`.
     WalletTransactions:
       type: object
       required:

--- a/src/schemas/SubscriptionCreateInput.yaml
+++ b/src/schemas/SubscriptionCreateInput.yaml
@@ -85,6 +85,12 @@ properties:
 
           - `true` (default): the subscription is included in the customer's standard invoice grouping (by billing entity, currency and payment method).
           - `false`: the subscription is excluded from consolidation and always billed on its own dedicated invoice.
+      purchase_order_number:
+        type:
+          - string
+          - "null"
+        example: "PO-123"
+        description: The purchase order number associated with the subscription. It will be added to invoices generated for this subscription.
       activation_rules:
         type: array
         items:

--- a/src/schemas/SubscriptionObject.yaml
+++ b/src/schemas/SubscriptionObject.yaml
@@ -242,3 +242,9 @@ properties:
       $ref: "./SubscriptionActivationRuleObject.yaml"
     description: |
       The activation rules attached to the subscription. A payment activation rule gates activation on a successful first payment, keeping the subscription in the `incomplete` state until the payment succeeds or the rule expires.
+  purchase_order_number:
+    type:
+      - string
+      - "null"
+    example: "PO-123"
+    description: The purchase order number associated with the subscription. It will be added to invoices generated for this subscription.

--- a/src/schemas/SubscriptionUpdateInput.yaml
+++ b/src/schemas/SubscriptionUpdateInput.yaml
@@ -52,6 +52,12 @@ properties:
         type: string
         example: "default"
         description: The code of the billing entity associated with the subscription. Updates take effect on future invoices only.
+      purchase_order_number:
+        type:
+          - string
+          - "null"
+        example: "PO-123"
+        description: The purchase order number associated with the subscription. It will be added to invoices generated for this subscription.
       activation_rules:
         type: array
         items:

--- a/src/schemas/WalletCreateInput.yaml
+++ b/src/schemas/WalletCreateInput.yaml
@@ -92,6 +92,12 @@ properties:
           - "null"
         description: The name of the wallet transactions triggered when creating the wallet. It will appear on the invoice as the label for the fee. If not set, the label on the invoice will fallback to either `Prepaid credits - {{wallet_name}}` if the wallet name is set, or `Prepaid credits`.
         example: "Tokens for models 'high-fidelity-boost'"
+      purchase_order_number:
+        type:
+          - string
+          - "null"
+        example: "PO-123"
+        description: The purchase order number associated with the wallet. It will be added to invoices generated for wallet top-ups, unless a more specific purchase order number is set on the wallet transaction or recurring transaction rule that triggered the top-up.
       applies_to:
         type:
           - object
@@ -244,6 +250,12 @@ properties:
                 - "null"
               description: The name of the wallet transactions triggered by this rule. It will appear on the invoice as the label for the fee. If not set, the label on the invoice will fallback to either `Prepaid credits - {{wallet_name}}` if the wallet name is set, or `Prepaid credits`.
               example: "Tokens for models 'high-fidelity-boost'"
+            purchase_order_number:
+              type:
+                - string
+                - "null"
+              example: "PO-123"
+              description: The purchase order number associated with this recurring transaction rule. It will be added to invoices generated for the resulting wallet top-ups. If not set, falls back to the wallet's `purchase_order_number`.
             ignore_paid_top_up_limits:
               type: boolean
               description: When true, allows rule to topped up wallet with transactions that exceed the paid top-up limits. Defaults to false.

--- a/src/schemas/WalletObject.yaml
+++ b/src/schemas/WalletObject.yaml
@@ -183,5 +183,11 @@ properties:
   payment_method:
     $ref: "./PaymentMethodReference.yaml"
     description: The payment method assigned to this wallet for processing top-up payments.
+  purchase_order_number:
+    type:
+      - string
+      - "null"
+    example: "PO-123"
+    description: The purchase order number associated with the wallet. It will be added to invoices generated for wallet top-ups, unless a more specific purchase order number is set on the wallet transaction or recurring transaction rule that triggered the top-up.
   metadata:
     $ref: "./MetadataObject.yaml"

--- a/src/schemas/WalletRecurringTransactionRule.yaml
+++ b/src/schemas/WalletRecurringTransactionRule.yaml
@@ -141,3 +141,9 @@ properties:
   payment_method:
     $ref: "./PaymentMethodReference.yaml"
     description: The payment method assigned to this recurring transaction rule for processing top-up payments.
+  purchase_order_number:
+    type:
+      - string
+      - "null"
+    example: "PO-123"
+    description: The purchase order number associated with this recurring transaction rule. It will be added to invoices generated for the resulting wallet top-ups. If not set, falls back to the wallet's `purchase_order_number`.

--- a/src/schemas/WalletTransactionCreateInput.yaml
+++ b/src/schemas/WalletTransactionCreateInput.yaml
@@ -50,6 +50,12 @@ properties:
         type: boolean
         description: When true, allows topping up the wallet with transactions that exceed the paid top-up limits. Defaults to false.
         example: false
+      purchase_order_number:
+        type:
+          - string
+          - "null"
+        example: "PO-123"
+        description: The purchase order number associated with this wallet transaction. It will be added to invoices generated for the resulting wallet top-up. If not set, falls back to the wallet's `purchase_order_number`.
       invoice_custom_section:
         $ref: "./InvoiceCustomSectionInput.yaml"
       payment_method:

--- a/src/schemas/WalletTransactionObject.yaml
+++ b/src/schemas/WalletTransactionObject.yaml
@@ -166,3 +166,9 @@ properties:
   payment_method:
     $ref: "./PaymentMethodReference.yaml"
     description: The payment method assigned to this wallet transaction for processing the payment.
+  purchase_order_number:
+    type:
+      - string
+      - "null"
+    example: "PO-123"
+    description: The purchase order number associated with this wallet transaction. It will be added to invoices generated for the resulting wallet top-up. If not set, falls back to the wallet's `purchase_order_number`.

--- a/src/schemas/WalletUpdateInput.yaml
+++ b/src/schemas/WalletUpdateInput.yaml
@@ -38,6 +38,12 @@ properties:
         type: string
         example: "default"
         description: The code of the billing entity associated with the wallet.
+      purchase_order_number:
+        type:
+          - string
+          - "null"
+        example: "PO-123"
+        description: The purchase order number associated with the wallet. It will be added to invoices generated for wallet top-ups, unless a more specific purchase order number is set on the wallet transaction or recurring transaction rule that triggered the top-up.
       invoice_custom_section:
         $ref: "./InvoiceCustomSectionInput.yaml"
       recurring_transaction_rules:
@@ -149,6 +155,12 @@ properties:
                 - "null"
               description: The name of the wallet transactions triggered by this rule. It will appear on the invoice as the label for the fee. If not set, the label on the invoice will fallback to either `Prepaid credits - {{wallet_name}}` if the wallet name is set, or `Prepaid credits`.
               example: "Tokens for models 'high-fidelity-boost'"
+            purchase_order_number:
+              type:
+                - string
+                - "null"
+              example: "PO-123"
+              description: The purchase order number associated with this recurring transaction rule. It will be added to invoices generated for the resulting wallet top-ups. If not set, falls back to the wallet's `purchase_order_number`.
             invoice_custom_section:
               $ref: "./InvoiceCustomSectionInput.yaml"
             payment_method:


### PR DESCRIPTION
Adds purchase_order_number to subscription create/update/response schemas, and to wallets, wallet transactions, and recurring transaction rules (create/update inputs and response objects), matching lago-api PR #5892 and #5914.
