### PR TITLE
feat(invoice): add web_url attribute to invoice schema

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -14925,7 +14925,9 @@ components:
           description: Contains the URL that provides direct access to the invoice PDF file. You can use this URL to download or view the PDF document of the invoice
           example: https://getlago.com/invoice/file
         web_url:
-          type: string
+          type:
+            - string
+            - 'null'
           format: uri
           description: Contains the URL to the invoice page in the Lago dashboard. It is `null` for invoices that are not visible in the dashboard (for example while still generating). Use it to link users directly to the invoice overview page.
           example: https://app.getlago.com/acme/customer/1a901a90-1a90-1a90-1a90-1a901a901a90/invoice/2b012b01-2b01-2b01-2b01-2b012b012b01/overview

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -14924,6 +14924,11 @@ components:
           format: uri
           description: Contains the URL that provides direct access to the invoice PDF file. You can use this URL to download or view the PDF document of the invoice
           example: https://getlago.com/invoice/file
+        web_url:
+          type: string
+          format: uri
+          description: Contains the URL to the invoice page in the Lago dashboard. It is `null` for invoices that are not visible in the dashboard (for example while still generating). Use it to link users directly to the invoice overview page.
+          example: https://app.getlago.com/acme/customer/1a901a90-1a90-1a90-1a90-1a901a901a90/invoice/2b012b01-2b01-2b01-2b01-2b012b012b01/overview
         created_at:
           type: string
           format: date-time

--- a/src/schemas/InvoiceBaseObject.yaml
+++ b/src/schemas/InvoiceBaseObject.yaml
@@ -176,7 +176,9 @@ properties:
     description: Contains the URL that provides direct access to the invoice PDF file. You can use this URL to download or view the PDF document of the invoice
     example: "https://getlago.com/invoice/file"
   web_url:
-    type: string
+    type:
+      - string
+      - "null"
     format: uri
     description: Contains the URL to the invoice page in the Lago dashboard. It is `null` for invoices that are not visible in the dashboard (for example while still generating). Use it to link users directly to the invoice overview page.
     example: "https://app.getlago.com/acme/customer/1a901a90-1a90-1a90-1a90-1a901a901a90/invoice/2b012b01-2b01-2b01-2b01-2b012b012b01/overview"

--- a/src/schemas/InvoiceBaseObject.yaml
+++ b/src/schemas/InvoiceBaseObject.yaml
@@ -175,6 +175,11 @@ properties:
     format: uri
     description: Contains the URL that provides direct access to the invoice PDF file. You can use this URL to download or view the PDF document of the invoice
     example: "https://getlago.com/invoice/file"
+  web_url:
+    type: string
+    format: uri
+    description: Contains the URL to the invoice page in the Lago dashboard. It is `null` for invoices that are not visible in the dashboard (for example while still generating). Use it to link users directly to the invoice overview page.
+    example: "https://app.getlago.com/acme/customer/1a901a90-1a90-1a90-1a90-1a901a901a90/invoice/2b012b01-2b01-2b01-2b01-2b012b012b01/overview"
   created_at:
     type: string
     format: "date-time"


### PR DESCRIPTION
## Context

The invoice API object exposes `file_url` (the PDF) but no link to the invoice page in the Lago dashboard, which the API now returns as `web_url`.

## Description

Document `web_url` on the invoice base object, next to `file_url`, and regenerate the bundled `openapi.yaml`.
