### PR TITLE
docs(subscriptions): document overridden and external_id filters on GET /subscriptions

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -5223,6 +5223,13 @@ paths:
           schema:
             type: string
             example: 5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba
+        - name: external_id
+          in: query
+          description: Filter subscriptions by their external unique identifier (provided by your own application).
+          required: false
+          schema:
+            type: string
+            example: my_sub_1234567890
         - name: plan_code
           in: query
           description: The unique code representing the plan to be attached to the customer. This code must correspond to the code property of one of the active plans.
@@ -5230,6 +5237,13 @@ paths:
           schema:
             type: string
             example: premium
+        - name: overridden
+          in: query
+          description: When set, filters subscriptions by whether their plan is an override of a parent plan. `true` returns only subscriptions on overridden plans; `false` returns only those on standard (non-overridden) plans.
+          required: false
+          schema:
+            type: boolean
+            example: true
         - name: status[]
           in: query
           description: 'If the field is not defined, Lago will return only `active` subscriptions. However, if you wish to fetch subscriptions by different status you can define them in a status[] query param. Available filter values: `pending`, `canceled`, `terminated`, `active`.'

--- a/src/resources/subscriptions.yaml
+++ b/src/resources/subscriptions.yaml
@@ -43,6 +43,13 @@ get:
       schema:
         type: string
         example: '5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba'
+    - name: external_id
+      in: query
+      description: Filter subscriptions by their external unique identifier (provided by your own application).
+      required: false
+      schema:
+        type: string
+        example: 'my_sub_1234567890'
     - name: plan_code
       in: query
       description: The unique code representing the plan to be attached to the customer. This code must correspond to the code property of one of the active plans.
@@ -50,6 +57,13 @@ get:
       schema:
         type: string
         example: 'premium'
+    - name: overridden
+      in: query
+      description: 'When set, filters subscriptions by whether their plan is an override of a parent plan. `true` returns only subscriptions on overridden plans; `false` returns only those on standard (non-overridden) plans.'
+      required: false
+      schema:
+        type: boolean
+        example: true
     - name: status[]
       in: query
       description: 'If the field is not defined, Lago will return only `active` subscriptions. However, if you wish to fetch subscriptions by different status you can define them in a status[] query param. Available filter values: `pending`, `canceled`, `terminated`, `active`.'


### PR DESCRIPTION
**What**
Adds two previously-undocumented query filters to `GET /subscriptions` in the OpenAPI spec: `external_id` (string) and `overridden` (boolean).

**Why**
Both filters are accepted by the API (`SubscriptionsQuery` / `subscription_index.rb`) but were missing from the reference, so they never rendered on the public API docs. Reported by a customer.

**Impact**
Docs-only / spec addition — no API behavior change. `external_id` filters by subscription external id; `overridden` filters by whether the subscription's plan is a parent-plan override.

Closes Pylon #5993.

_Note: the legacy typo alias `overriden` is intentionally not documented._