### PR TITLE
docs: mark external_customer_id optional on GET /wallets

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -6247,8 +6247,8 @@ paths:
         - $ref: '#/components/parameters/currency'
         - name: external_customer_id
           in: query
-          description: The customer external unique identifier (provided by your own application).
-          required: true
+          description: Filter wallets by customer external unique identifier (provided by your own application). When omitted, all wallets for the organization are returned.
+          required: false
           explode: true
           schema:
             type: string

--- a/src/resources/wallets.yaml
+++ b/src/resources/wallets.yaml
@@ -38,8 +38,8 @@ get:
     - $ref: "../parameters/currency.yaml"
     - name: external_customer_id
       in: query
-      description: The customer external unique identifier (provided by your own application).
-      required: true
+      description: Filter wallets by customer external unique identifier (provided by your own application). When omitted, all wallets for the organization are returned.
+      required: false
       explode: true
       schema:
         type: string


### PR DESCRIPTION
**What changed**
Set `external_customer_id` to `required: false` on `GET /wallets` (`findAllWallets`) and reworded its description as an optional filter.

**Why**
The parameter was made optional in the API in late May 2026 (#5559), but the OpenAPI spec still marked it `required: true`, so `api-reference/wallets/get-all` incorrectly showed it as required. In `lago-api`, `external_customer_id` is a permitted filter that flows through `.compact` into `WalletsQuery`; when omitted, all wallets for the organization are returned.

**Impact**
Docs-only. The api-reference page will show `external_customer_id` as optional, matching current API behavior.

Closes Pylon #5991

🤖 Generated with [Claude Code](https://claude.com/claude-code)