### PR TITLE
feat: openapi doc for endpoint to delete draft invoice

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3932,6 +3932,25 @@ paths:
           $ref: '#/components/responses/Unauthorized'
         '404':
           $ref: '#/components/responses/NotFound'
+    delete:
+      tags:
+        - invoices
+      summary: Delete a draft invoice
+      description: 'This endpoint is used for permanently deleting a `draft` invoice. Deleting a draft invoice removes it entirely: it never becomes accounts receivable, consumes no invoice number, and disappears from every list, export, and analytics surface. Only invoices in the `draft` status can be deleted; for a `finalized` invoice, void it instead.'
+      operationId: deleteInvoice
+      responses:
+        '200':
+          description: Invoice deleted
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Invoice'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '405':
+          $ref: '#/components/responses/NotAllowed'
   /invoices/{lago_id}/download:
     post:
       tags:
@@ -8121,6 +8140,45 @@ webhooks:
                   type: string
                   enum:
                     - invoice.voided
+                object_type:
+                  type: string
+                  enum:
+                    - invoice
+                organization_id:
+                  type: string
+                  format: uuid
+                  description: Unique identifier of the organization, created by Lago.
+                  example: 1a901a90-1a90-1a90-1a90-1a901a901a90
+                invoice:
+                  $ref: '#/components/schemas/InvoiceObjectExtended'
+      responses:
+        '200':
+          description: Return a 200 status to indicate that the data was received successfully
+  invoice_deleted:
+    post:
+      operationId: invoiceDeleted
+      summary: A draft invoice has been deleted
+      description: A draft invoice has been deleted
+      parameters:
+        - $ref: '#/components/parameters/webhook_signature'
+        - $ref: '#/components/parameters/webhook_signature_algorithm'
+        - $ref: '#/components/parameters/webhook_unique_key'
+      requestBody:
+        description: Details of the invoice
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - webhook_type
+                - object_type
+                - organization_id
+                - invoice
+              properties:
+                webhook_type:
+                  type: string
+                  enum:
+                    - invoice.deleted
                 object_type:
                   type: string
                   enum:
@@ -14830,6 +14888,7 @@ components:
             - voided
             - failed
             - pending
+            - deleted
           description: |-
             The status of the invoice. It indicates the current state of the invoice and can have following values:
             - `draft`: the invoice is in the draft state, waiting for the end of the grace period to be finalized. During this period, events can still be ingested and added to the invoice.
@@ -14837,6 +14896,7 @@ components:
             - `voided`: the invoice has been issued and subsequently voided. In this state, events cannot be ingested or added to the invoice anymore.
             - `pending`: the invoice remains pending until the taxes are fetched from the external provider.
             - `failed`: during an attempt of finalization of the invoice, an error happened. This invoice will have an array of error_details, explaining, in which part of the system an error happened and how it's possible to fix it. This invoice can't be edited or updated, only retried. This action will discard current error_details and will create new ones if the finalization failed again.
+            - `deleted`: the draft invoice has been permanently deleted. This status is only returned by the delete endpoint and its webhook; a deleted invoice is no longer retrievable afterwards.
           example: finalized
         payment_status:
           type: string

--- a/src/openapi.yaml
+++ b/src/openapi.yaml
@@ -455,6 +455,8 @@ webhooks:
     $ref: "./webhooks/invoice_drafted.yaml"
   invoice_voided:
     $ref: "./webhooks/invoice_voided.yaml"
+  invoice_deleted:
+    $ref: "./webhooks/invoice_deleted.yaml"
   invoice_payment_dispute_lost:
     $ref: "./webhooks/invoice_payment_dispute_lost.yaml"
   invoice_payment_status_updated:

--- a/src/resources/invoice.yaml
+++ b/src/resources/invoice.yaml
@@ -45,3 +45,23 @@ get:
       $ref: '../responses/Unauthorized.yaml'
     '404':
       $ref: '../responses/NotFound.yaml'
+delete:
+  tags:
+    - invoices
+  summary: Delete a draft invoice
+  description: |-
+    This endpoint is used for permanently deleting a `draft` invoice. Deleting a draft invoice removes it entirely: it never becomes accounts receivable, consumes no invoice number, and disappears from every list, export, and analytics surface. Only invoices in the `draft` status can be deleted; for a `finalized` invoice, void it instead.
+  operationId: deleteInvoice
+  responses:
+    '200':
+      description: Invoice deleted
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/Invoice.yaml'
+    '401':
+      $ref: '../responses/Unauthorized.yaml'
+    '404':
+      $ref: '../responses/NotFound.yaml'
+    '405':
+      $ref: '../responses/NotAllowed.yaml'

--- a/src/schemas/InvoiceBaseObject.yaml
+++ b/src/schemas/InvoiceBaseObject.yaml
@@ -81,6 +81,7 @@ properties:
       - voided
       - failed
       - pending
+      - deleted
     description: |-
       The status of the invoice. It indicates the current state of the invoice and can have following values:
       - `draft`: the invoice is in the draft state, waiting for the end of the grace period to be finalized. During this period, events can still be ingested and added to the invoice.
@@ -88,6 +89,7 @@ properties:
       - `voided`: the invoice has been issued and subsequently voided. In this state, events cannot be ingested or added to the invoice anymore.
       - `pending`: the invoice remains pending until the taxes are fetched from the external provider.
       - `failed`: during an attempt of finalization of the invoice, an error happened. This invoice will have an array of error_details, explaining, in which part of the system an error happened and how it's possible to fix it. This invoice can't be edited or updated, only retried. This action will discard current error_details and will create new ones if the finalization failed again.
+      - `deleted`: the draft invoice has been permanently deleted. This status is only returned by the delete endpoint and its webhook; a deleted invoice is no longer retrievable afterwards.
     example: finalized
   payment_status:
     type: string

--- a/src/webhooks/invoice_deleted.yaml
+++ b/src/webhooks/invoice_deleted.yaml
@@ -1,0 +1,38 @@
+post:
+  operationId: invoiceDeleted
+  summary: A draft invoice has been deleted
+  description: A draft invoice has been deleted
+  parameters:
+    - $ref: "../parameters/webhook_signature.yaml"
+    - $ref: "../parameters/webhook_signature_algorithm.yaml"
+    - $ref: "../parameters/webhook_unique_key.yaml"
+  requestBody:
+    description: Details of the invoice
+    content:
+      application/json:
+        schema:
+          type: object
+          required:
+            - webhook_type
+            - object_type
+            - organization_id
+            - invoice
+          properties:
+            webhook_type:
+              type: string
+              enum:
+                - invoice.deleted
+            object_type:
+              type: string
+              enum:
+                - invoice
+            organization_id:
+              type: string
+              format: "uuid"
+              description: Unique identifier of the organization, created by Lago.
+              example: "1a901a90-1a90-1a90-1a90-1a901a901a90"
+            invoice:
+              $ref: "../schemas/InvoiceObjectExtended.yaml"
+  responses:
+    "200":
+      description: Return a 200 status to indicate that the data was received successfully


### PR DESCRIPTION
## Context

_Part of the "delete draft invoice" feature_

A new endpoint was added to delete a draft invoice (https://github.com/getlago/lago-api/pull/5968).

## Description

Documents the new "delete a draft invoice" endpoint that was added to the API.

- `DELETE /invoices/{lago_id}` - returns the invoice, or 405 if it's not a draft / already synced externally
- Added `deleted` to the invoice status enum
- Added the `invoice.deleted` webhook
