### PR TITLE
docs(subscriptions): document progressive_billing_disabled and subscription-level usage_thresholds

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -21134,7 +21134,7 @@ components:
           type: array
           deprecated: true
           description: |
-            **Deprecated.** Managing usage thresholds through `plan_overrides` is deprecated. Use the top-level `usage_thresholds` array on the subscription instead, or `progressive_billing_disabled` to switch progressive billing off. An empty array here is ignored and does not clear existing thresholds.
+            **Deprecated.** Managing usage thresholds through `plan_overrides` is deprecated and its behavior is inconsistent: an empty array does not reliably clear thresholds (it is ignored the first time a subscription is overridden), and it never affects thresholds inherited from a parent plan. Use the top-level `usage_thresholds` array on the subscription instead, or `progressive_billing_disabled` to switch progressive billing off.
           items:
             $ref: '#/components/schemas/UsageThresholdInput'
         metadata:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -21132,7 +21132,9 @@ components:
                 description: List of taxes applied to the fixed charge.
         usage_thresholds:
           type: array
-          description: List of usage thresholds applied to the subscription.
+          deprecated: true
+          description: |
+            **Deprecated.** Managing usage thresholds through `plan_overrides` is deprecated. Use the top-level `usage_thresholds` array on the subscription instead, or `progressive_billing_disabled` to switch progressive billing off. An empty array here is ignored and does not clear existing thresholds.
           items:
             $ref: '#/components/schemas/UsageThresholdInput'
         metadata:
@@ -21246,6 +21248,22 @@ components:
                 - 'null'
               example: PO-123
               description: The purchase order number associated with the subscription. It will be added to invoices generated for this subscription.
+            progressive_billing_disabled:
+              type: boolean
+              default: false
+              example: true
+              description: |
+                Disables progressive billing for this subscription, regardless of any usage thresholds defined on the plan (including thresholds inherited from a parent plan when the subscription runs on a plan override).
+
+                Set to `true` to switch progressive billing off for this subscription specifically, without changing the plan's thresholds.
+            usage_thresholds:
+              type: array
+              description: |
+                Usage thresholds managed directly on the subscription. This is the recommended way to set progressive billing thresholds per subscription; when present, they take precedence over the thresholds defined on the plan.
+
+                This field cannot be combined with `plan_overrides.usage_thresholds` in the same request.
+              items:
+                $ref: '#/components/schemas/UsageThresholdInput'
             activation_rules:
               type: array
               items:
@@ -21353,6 +21371,22 @@ components:
                 - 'null'
               example: PO-123
               description: The purchase order number associated with the subscription. It will be added to invoices generated for this subscription.
+            progressive_billing_disabled:
+              type: boolean
+              default: false
+              example: true
+              description: |
+                Disables progressive billing for this subscription, regardless of any usage thresholds defined on the plan (including thresholds inherited from a parent plan when the subscription runs on a plan override).
+
+                Set to `true` to switch progressive billing off for this subscription specifically. This is the recommended way to stop progressive billing on a subscription that inherits thresholds from its plan, since clearing `usage_thresholds` only removes subscription-level thresholds and does not remove those defined on (or inherited from) the plan.
+            usage_thresholds:
+              type: array
+              description: |
+                Usage thresholds managed directly on the subscription. This is the recommended way to set progressive billing thresholds per subscription; when present, they take precedence over the thresholds defined on the plan.
+
+                Sending an empty array removes all subscription-level thresholds. This field cannot be combined with `plan_overrides.usage_thresholds` in the same request. To fully disable progressive billing on a subscription that inherits thresholds from its plan, use `progressive_billing_disabled` instead.
+              items:
+                $ref: '#/components/schemas/UsageThresholdInput'
             activation_rules:
               type: array
               items:

--- a/src/schemas/PlanOverridesObject.yaml
+++ b/src/schemas/PlanOverridesObject.yaml
@@ -115,7 +115,9 @@ properties:
           description: List of taxes applied to the fixed charge.
   usage_thresholds:
     type: array
-    description: List of usage thresholds applied to the subscription.
+    deprecated: true
+    description: |
+      **Deprecated.** Managing usage thresholds through `plan_overrides` is deprecated. Use the top-level `usage_thresholds` array on the subscription instead, or `progressive_billing_disabled` to switch progressive billing off. An empty array here is ignored and does not clear existing thresholds.
     items:
       $ref: "./UsageThresholdInput.yaml"
   metadata:

--- a/src/schemas/PlanOverridesObject.yaml
+++ b/src/schemas/PlanOverridesObject.yaml
@@ -117,7 +117,7 @@ properties:
     type: array
     deprecated: true
     description: |
-      **Deprecated.** Managing usage thresholds through `plan_overrides` is deprecated. Use the top-level `usage_thresholds` array on the subscription instead, or `progressive_billing_disabled` to switch progressive billing off. An empty array here is ignored and does not clear existing thresholds.
+      **Deprecated.** Managing usage thresholds through `plan_overrides` is deprecated and its behavior is inconsistent: an empty array does not reliably clear thresholds (it is ignored the first time a subscription is overridden), and it never affects thresholds inherited from a parent plan. Use the top-level `usage_thresholds` array on the subscription instead, or `progressive_billing_disabled` to switch progressive billing off.
     items:
       $ref: "./UsageThresholdInput.yaml"
   metadata:

--- a/src/schemas/SubscriptionCreateInput.yaml
+++ b/src/schemas/SubscriptionCreateInput.yaml
@@ -91,6 +91,22 @@ properties:
           - "null"
         example: "PO-123"
         description: The purchase order number associated with the subscription. It will be added to invoices generated for this subscription.
+      progressive_billing_disabled:
+        type: boolean
+        default: false
+        example: true
+        description: |
+          Disables progressive billing for this subscription, regardless of any usage thresholds defined on the plan (including thresholds inherited from a parent plan when the subscription runs on a plan override).
+
+          Set to `true` to switch progressive billing off for this subscription specifically, without changing the plan's thresholds.
+      usage_thresholds:
+        type: array
+        description: |
+          Usage thresholds managed directly on the subscription. This is the recommended way to set progressive billing thresholds per subscription; when present, they take precedence over the thresholds defined on the plan.
+
+          This field cannot be combined with `plan_overrides.usage_thresholds` in the same request.
+        items:
+          $ref: "./UsageThresholdInput.yaml"
       activation_rules:
         type: array
         items:

--- a/src/schemas/SubscriptionUpdateInput.yaml
+++ b/src/schemas/SubscriptionUpdateInput.yaml
@@ -58,6 +58,22 @@ properties:
           - "null"
         example: "PO-123"
         description: The purchase order number associated with the subscription. It will be added to invoices generated for this subscription.
+      progressive_billing_disabled:
+        type: boolean
+        default: false
+        example: true
+        description: |
+          Disables progressive billing for this subscription, regardless of any usage thresholds defined on the plan (including thresholds inherited from a parent plan when the subscription runs on a plan override).
+
+          Set to `true` to switch progressive billing off for this subscription specifically. This is the recommended way to stop progressive billing on a subscription that inherits thresholds from its plan, since clearing `usage_thresholds` only removes subscription-level thresholds and does not remove those defined on (or inherited from) the plan.
+      usage_thresholds:
+        type: array
+        description: |
+          Usage thresholds managed directly on the subscription. This is the recommended way to set progressive billing thresholds per subscription; when present, they take precedence over the thresholds defined on the plan.
+
+          Sending an empty array removes all subscription-level thresholds. This field cannot be combined with `plan_overrides.usage_thresholds` in the same request. To fully disable progressive billing on a subscription that inherits thresholds from its plan, use `progressive_billing_disabled` instead.
+        items:
+          $ref: "./UsageThresholdInput.yaml"
       activation_rules:
         type: array
         items:


### PR DESCRIPTION
## Context

Came out of a Mistral support ticket (Pylon #6265). A customer tried to remove progressive billing from a subscription running on a **plan override** using `plan_overrides: { usage_thresholds: [] }`, which silently did nothing. The docs still point to that path, but the API actually exposes two fields for this that were **never documented** (not in the API reference, not in the OpenAPI spec):

- `progressive_billing_disabled` — added in [lago-api#4730](https://github.com/getlago/lago-api/pull/4730) (Dec 2025)
- top-level `usage_thresholds` on the subscription — added in [lago-api#4756](https://github.com/getlago/lago-api/pull/4756) (Mar 2026), which also deprecated `plan_overrides.usage_thresholds`

Both fields are permitted on **create and update** (`SubscriptionsController#create_params` / `#update_params`).

## Why `plan_overrides: { usage_thresholds: [] }` doesn't remove thresholds

Threshold resolution for a subscription (`Subscription#applicable_usage_thresholds`) cascades:

1. `progressive_billing_disabled?` → returns `[]` (short-circuits everything)
2. subscription-level `usage_thresholds`
3. the override child plan's `usage_thresholds`
4. → falls back to the **parent plan's** thresholds

`Plans::OverrideService` gates on `usage_thresholds.present?`, so an empty array is ignored. On an overridden plan, thresholds inherited from the parent survive anyway — so `progressive_billing_disabled: true` is the only reliable way to turn progressive billing off.

## Changes

- **`SubscriptionUpdateInput`** — document `progressive_billing_disabled` and top-level `usage_thresholds`
- **`SubscriptionCreateInput`** — same two fields, for parity
- **`PlanOverridesObject`** — mark `usage_thresholds` as `deprecated`, note the empty-array no-op
- Rebuilt bundled `openapi.yaml` (`npm run build`), `redocly lint` passes

## Review ask

@ mponrajah — since Julien is no longer at Lago, you're the product owner on `disable_progressive_billing` (per the Dec 2025 `#ftr-products-and-plans` decision). Can you confirm the wording, especially the deprecation stance on `plan_overrides.usage_thresholds` and whether we want to actively recommend the top-level array vs the flag?

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## ⚠️ Reviewer note: `plan_overrides.usage_thresholds` behavior is path-dependent

The empty-array behavior of `plan_overrides.usage_thresholds` is **not uniform**, which is why the deprecation note avoids a blanket claim:

- **First override of a parent plan** → `Plans::OverrideService`, gated on `usage_thresholds.present?` → an empty array is **ignored** (no-op).
- **Subscription already on an override** → `Plans::UpdateService` → `UsageThresholds::UpdateService` with `partial: false` → an empty array **deletes** the child plan's thresholds.

In **neither** case does it touch thresholds inherited from a parent plan — that is what tripped up the Mistral subscription. `progressive_billing_disabled` is the only reliable off-switch for an inherited/override setup.