### PR TITLE
docs(webhooks): document invoice.ready_to_finalize webhook

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -8119,6 +8119,45 @@ webhooks:
       responses:
         '200':
           description: Return a 200 status to indicate that the data was received successfully
+  invoice_ready_to_finalize:
+    post:
+      operationId: invoiceReadyToFinalize
+      summary: A draft invoice is ready to be finalized
+      description: A draft invoice is ready to be finalized (taxes are resolved). Sent when the draft invoice is created if no tax provider call is pending, or once the tax provider has returned taxes for the draft invoice.
+      parameters:
+        - $ref: '#/components/parameters/webhook_signature'
+        - $ref: '#/components/parameters/webhook_signature_algorithm'
+        - $ref: '#/components/parameters/webhook_unique_key'
+      requestBody:
+        description: Details of the draft invoice ready to be finalized
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - webhook_type
+                - object_type
+                - organization_id
+                - invoice
+              properties:
+                webhook_type:
+                  type: string
+                  enum:
+                    - invoice.ready_to_finalize
+                object_type:
+                  type: string
+                  enum:
+                    - invoice
+                organization_id:
+                  type: string
+                  format: uuid
+                  description: Unique identifier of the organization, created by Lago.
+                  example: 1a901a90-1a90-1a90-1a90-1a901a901a90
+                invoice:
+                  $ref: '#/components/schemas/InvoiceObjectExtended'
+      responses:
+        '200':
+          description: Return a 200 status to indicate that the data was received successfully
   invoice_voided:
     post:
       operationId: invoiceVoided

--- a/src/openapi.yaml
+++ b/src/openapi.yaml
@@ -453,6 +453,8 @@ webhooks:
     $ref: "./webhooks/invoice_generated.yaml"
   invoice_drafted:
     $ref: "./webhooks/invoice_drafted.yaml"
+  invoice_ready_to_finalize:
+    $ref: "./webhooks/invoice_ready_to_finalize.yaml"
   invoice_voided:
     $ref: "./webhooks/invoice_voided.yaml"
   invoice_deleted:

--- a/src/webhooks/invoice_ready_to_finalize.yaml
+++ b/src/webhooks/invoice_ready_to_finalize.yaml
@@ -1,0 +1,38 @@
+post:
+  operationId: invoiceReadyToFinalize
+  summary: A draft invoice is ready to be finalized
+  description: A draft invoice is ready to be finalized (taxes are resolved). Sent when the draft invoice is created if no tax provider call is pending, or once the tax provider has returned taxes for the draft invoice.
+  parameters:
+    - $ref: "../parameters/webhook_signature.yaml"
+    - $ref: "../parameters/webhook_signature_algorithm.yaml"
+    - $ref: "../parameters/webhook_unique_key.yaml"
+  requestBody:
+    description: Details of the draft invoice ready to be finalized
+    content:
+      application/json:
+        schema:
+          type: object
+          required:
+            - webhook_type
+            - object_type
+            - organization_id
+            - invoice
+          properties:
+            webhook_type:
+              type: string
+              enum:
+                - invoice.ready_to_finalize
+            object_type:
+              type: string
+              enum:
+                - invoice
+            organization_id:
+              type: string
+              format: "uuid"
+              description: Unique identifier of the organization, created by Lago.
+              example: "1a901a90-1a90-1a90-1a90-1a901a901a90"
+            invoice:
+              $ref: "../schemas/InvoiceObjectExtended.yaml"
+  responses:
+    "200":
+      description: Return a 200 status to indicate that the data was received successfully


### PR DESCRIPTION
## Description

Documents the `invoice.ready_to_finalize` webhook, which exists in lago-api (`Webhooks::Invoices::ReadyToFinalizeService`) but was missing from the OpenAPI spec.

This event signals that a draft invoice is ready to be finalized (taxes are resolved). It fires either when the draft is created and no tax provider call is pending (`Invoices::SubscriptionService`), or once the tax provider returns taxes for the draft invoice (`Invoices::ProviderTaxes::PullTaxesAndApplyService`).

The payload uses the same serializer includes as `invoice.drafted` (customer, subscriptions, billing_periods, fees, credits, applied_taxes, error_details), so the spec references the same `InvoiceObjectExtended` schema.

## Changes

- Add `src/webhooks/invoice_ready_to_finalize.yaml` (modeled on `invoice_drafted.yaml`)
- Wire it into `src/openapi.yaml` webhooks section
- Rebuild bundled `openapi.yaml`

`npm run test` (redocly bundle + redocly lint + spectral lint) passes with no new warnings.