### PR TITLE
feat(order-forms): document the Order forms REST API and webhooks

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -140,6 +140,8 @@ tags:
       url: https://getlago.com/docs/api-reference/payment-methods/payment-method-object
   - name: quotes
     description: Everything about Quote collection
+  - name: order_forms
+    description: Everything about Order form collection
 externalDocs:
   description: Lago Github
   url: https://github.com/getlago
@@ -4164,6 +4166,221 @@ paths:
           $ref: '#/components/responses/Unauthorized'
         '404':
           $ref: '#/components/responses/NotFound'
+  /order_forms:
+    get:
+      tags:
+        - order_forms
+      summary: List all order forms
+      description: |-
+        This endpoint is used to list all existing order forms.
+        This is a premium feature.
+      operationId: findAllOrderForms
+      parameters:
+        - $ref: '#/components/parameters/page'
+        - $ref: '#/components/parameters/per_page'
+        - name: status[]
+          in: query
+          description: Filter order forms by status. Possible values are `generated`, `signed`, `expired` and `voided`.
+          required: false
+          explode: true
+          schema:
+            type: array
+            items:
+              type: string
+              enum:
+                - generated
+                - signed
+                - expired
+                - voided
+        - name: customer_id[]
+          in: query
+          description: Filter order forms by the Lago identifiers of their customers.
+          required: false
+          explode: true
+          schema:
+            type: array
+            items:
+              type: string
+              format: uuid
+            example:
+              - 1a901a90-1a90-1a90-1a90-1a901a901a90
+        - name: number[]
+          in: query
+          description: Filter order forms by their number, as assigned by Lago.
+          required: false
+          explode: true
+          schema:
+            type: array
+            items:
+              type: string
+            example:
+              - OF-2026-0001
+              - OF-2026-0002
+        - name: quote_number[]
+          in: query
+          description: Filter order forms by the number of the quote they come from.
+          required: false
+          explode: true
+          schema:
+            type: array
+            items:
+              type: string
+            example:
+              - QT-2026-0001
+        - name: owner_id[]
+          in: query
+          description: Filter order forms by the Lago identifiers of the users owning the quote they come from.
+          required: false
+          explode: true
+          schema:
+            type: array
+            items:
+              type: string
+              format: uuid
+            example:
+              - 1a901a90-1a90-1a90-1a90-1a901a901a90
+        - name: search_term
+          in: query
+          description: Search order forms by number.
+          required: false
+          explode: true
+          schema:
+            type: string
+            example: OF-2026
+        - name: created_at_from
+          in: query
+          description: Filter order forms created from a specific date and time, in UTC (ISO 8601).
+          required: false
+          explode: true
+          schema:
+            type: string
+            format: date-time
+            example: '2026-01-01T00:00:00Z'
+        - name: created_at_to
+          in: query
+          description: Filter order forms created up to a specific date and time, in UTC (ISO 8601).
+          required: false
+          explode: true
+          schema:
+            type: string
+            format: date-time
+            example: '2026-12-31T23:59:59Z'
+        - name: expires_at_from
+          in: query
+          description: Filter order forms expiring from a specific date and time, in UTC (ISO 8601). Order forms that never expire are excluded.
+          required: false
+          explode: true
+          schema:
+            type: string
+            format: date-time
+            example: '2026-01-01T00:00:00Z'
+        - name: expires_at_to
+          in: query
+          description: Filter order forms expiring up to a specific date and time, in UTC (ISO 8601). Order forms that never expire are excluded.
+          required: false
+          explode: true
+          schema:
+            type: string
+            format: date-time
+            example: '2026-12-31T23:59:59Z'
+      responses:
+        '200':
+          description: Order forms
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrderFormsPaginated'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '422':
+          $ref: '#/components/responses/UnprocessableEntity'
+  /order_forms/{lago_id}:
+    parameters:
+      - $ref: '#/components/parameters/lago_order_form_id'
+    get:
+      tags:
+        - order_forms
+      summary: Retrieve an order form
+      description: |-
+        This endpoint retrieves a specific order form.
+        This is a premium feature.
+      operationId: findOrderForm
+      responses:
+        '200':
+          description: Order form
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrderForm'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+  /order_forms/{lago_id}/mark_as_signed:
+    parameters:
+      - $ref: '#/components/parameters/lago_order_form_id'
+    post:
+      tags:
+        - order_forms
+      summary: Mark an order form as signed
+      description: |-
+        This endpoint records the customer's signature on an order form, and creates the order that carries the quoted deal out.
+        Only a `generated` order form can be signed, so a `422` is returned once the order form has been signed, has expired or has been voided.
+        This is a premium feature.
+      operationId: markOrderFormAsSigned
+      requestBody:
+        description: Mark order form as signed payload
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrderFormMarkAsSignedInput'
+        required: false
+      responses:
+        '200':
+          description: Order form marked as signed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrderForm'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '422':
+          $ref: '#/components/responses/UnprocessableEntity'
+  /order_forms/{lago_id}/void:
+    parameters:
+      - $ref: '#/components/parameters/lago_order_form_id'
+    post:
+      tags:
+        - order_forms
+      summary: Void an order form
+      description: |-
+        This endpoint voids an order form, with the `manual` reason, and cascades to the quote version it was generated from, which is voided with the `cascade_of_voided` reason.
+        Only a `generated` order form can be voided, so a `422` is returned once the order form has been signed, has expired or has already been voided.
+        This is a premium feature.
+      operationId: voidOrderForm
+      responses:
+        '200':
+          description: Order form voided
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrderForm'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '422':
+          $ref: '#/components/responses/UnprocessableEntity'
   /organizations:
     put:
       tags:
@@ -8751,6 +8968,170 @@ webhooks:
       responses:
         '200':
           description: Return a 200 status to indicate that the data was received successfully
+  order_form_created:
+    post:
+      operationId: orderFormCreated
+      summary: An order form has been generated from an approved quote
+      description: |-
+        An order form has been generated from an approved quote version, and is now waiting for the customer's signature. It always follows a `quote.approved` event, emitted in the same transaction.
+        This is a premium feature.
+      parameters:
+        - $ref: '#/components/parameters/webhook_signature'
+        - $ref: '#/components/parameters/webhook_signature_algorithm'
+        - $ref: '#/components/parameters/webhook_unique_key'
+      requestBody:
+        description: Details of the new order form
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - webhook_type
+                - object_type
+                - organization_id
+                - order_form
+              properties:
+                webhook_type:
+                  type: string
+                  enum:
+                    - order_form.created
+                object_type:
+                  type: string
+                  enum:
+                    - order_form
+                organization_id:
+                  type: string
+                  format: uuid
+                  description: Unique identifier of the organization, created by Lago.
+                  example: 1a901a90-1a90-1a90-1a90-1a901a901a90
+                order_form:
+                  $ref: '#/components/schemas/OrderFormObject'
+      responses:
+        '200':
+          description: Return a 200 status to indicate that the data was received successfully
+  order_form_signed:
+    post:
+      operationId: orderFormSigned
+      summary: An order form has been marked as signed
+      description: |-
+        An order form has been marked as signed. An order is created from it in the same transaction, so an `order.created` event follows.
+        This is a premium feature.
+      parameters:
+        - $ref: '#/components/parameters/webhook_signature'
+        - $ref: '#/components/parameters/webhook_signature_algorithm'
+        - $ref: '#/components/parameters/webhook_unique_key'
+      requestBody:
+        description: Details of the signed order form
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - webhook_type
+                - object_type
+                - organization_id
+                - order_form
+              properties:
+                webhook_type:
+                  type: string
+                  enum:
+                    - order_form.signed
+                object_type:
+                  type: string
+                  enum:
+                    - order_form
+                organization_id:
+                  type: string
+                  format: uuid
+                  description: Unique identifier of the organization, created by Lago.
+                  example: 1a901a90-1a90-1a90-1a90-1a901a901a90
+                order_form:
+                  $ref: '#/components/schemas/OrderFormObject'
+      responses:
+        '200':
+          description: Return a 200 status to indicate that the data was received successfully
+  order_form_expired:
+    post:
+      operationId: orderFormExpired
+      summary: An order form has expired
+      description: |-
+        An order form reached its `expires_at` without being signed, and is no longer actionable. Expiry is detected by an hourly job comparing calendar dates in the timezone of the customer's billing entity, so the event is emitted during the day the order form expires rather than at the exact `expires_at` time. It cascades to the quote version the order form was generated from, so a `quote.voided` event with the `cascade_of_expired` reason follows.
+        This is a premium feature.
+      parameters:
+        - $ref: '#/components/parameters/webhook_signature'
+        - $ref: '#/components/parameters/webhook_signature_algorithm'
+        - $ref: '#/components/parameters/webhook_unique_key'
+      requestBody:
+        description: Details of the expired order form
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - webhook_type
+                - object_type
+                - organization_id
+                - order_form
+              properties:
+                webhook_type:
+                  type: string
+                  enum:
+                    - order_form.expired
+                object_type:
+                  type: string
+                  enum:
+                    - order_form
+                organization_id:
+                  type: string
+                  format: uuid
+                  description: Unique identifier of the organization, created by Lago.
+                  example: 1a901a90-1a90-1a90-1a90-1a901a901a90
+                order_form:
+                  $ref: '#/components/schemas/OrderFormObject'
+      responses:
+        '200':
+          description: Return a 200 status to indicate that the data was received successfully
+  order_form_voided:
+    post:
+      operationId: orderFormVoided
+      summary: An order form has been voided
+      description: |-
+        An order form has been voided before being signed. It cascades to the quote version the order form was generated from, so a `quote.voided` event with the `cascade_of_voided` reason follows.
+        This is a premium feature.
+      parameters:
+        - $ref: '#/components/parameters/webhook_signature'
+        - $ref: '#/components/parameters/webhook_signature_algorithm'
+        - $ref: '#/components/parameters/webhook_unique_key'
+      requestBody:
+        description: Details of the voided order form
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - webhook_type
+                - object_type
+                - organization_id
+                - order_form
+              properties:
+                webhook_type:
+                  type: string
+                  enum:
+                    - order_form.voided
+                object_type:
+                  type: string
+                  enum:
+                    - order_form
+                organization_id:
+                  type: string
+                  format: uuid
+                  description: Unique identifier of the organization, created by Lago.
+                  example: 1a901a90-1a90-1a90-1a90-1a901a901a90
+                order_form:
+                  $ref: '#/components/schemas/OrderFormObject'
+      responses:
+        '200':
+          description: Return a 200 status to indicate that the data was received successfully
   payment_requires_action:
     post:
       operationId: paymentRequiresAction
@@ -9782,6 +10163,15 @@ components:
       name: lago_id
       in: path
       description: Unique identifier assigned to the invoice within the Lago application. This ID is exclusively created by Lago and serves as a unique identifier for the invoice's record within the Lago system.
+      required: true
+      schema:
+        type: string
+        format: uuid
+        example: 1a901a90-1a90-1a90-1a90-1a901a901a90
+    lago_order_form_id:
+      name: lago_id
+      in: path
+      description: Unique identifier assigned to the order form within the Lago application. This ID is exclusively created by Lago and serves as a unique identifier for the order form's record within the Lago system.
       required: true
       schema:
         type: string
@@ -18945,6 +19335,176 @@ components:
           minimum: 0
       required: []
       description: Parameters available when voiding an invoice that optionally generate credit notes.
+    OrderFormStatusEnum:
+      type: string
+      description: |
+        The status of the order form. It can be any of the following values:
+          - `generated`: the order form is waiting for the customer's signature.
+          - `signed`: the customer has signed, and an order has been created from the order form.
+          - `expired`: the order form reached its `expires_at` without being signed.
+          - `voided`: the order form has been voided before being signed.
+
+        Only a `generated` order form is actionable. Reaching any other status also voids the quote version the order form was generated from.
+      enum:
+        - generated
+        - signed
+        - expired
+        - voided
+      example: generated
+    OrderFormVoidReasonEnum:
+      type:
+        - string
+        - 'null'
+      description: |
+        The reason why the order form is no longer actionable. It is `null` unless the `status` is `voided` or `expired`. It can be any of the following values:
+          - `manual`: the order form has been voided explicitly, through the API or the Lago user interface.
+          - `expired`: the order form reached its `expires_at` without being signed.
+          - `invalid`: the order form has been voided by Lago because it could no longer be executed.
+      enum:
+        - null
+        - manual
+        - expired
+        - invalid
+      example: manual
+    OrderFormObject:
+      type: object
+      required:
+        - lago_id
+        - number
+        - status
+        - void_reason
+        - expires_at
+        - signed_at
+        - voided_at
+        - signed_document_url
+        - lago_organization_id
+        - lago_customer_id
+        - lago_quote_id
+        - lago_quote_version_id
+        - created_at
+        - updated_at
+      properties:
+        lago_id:
+          type: string
+          format: uuid
+          description: Unique identifier of the order form, created by Lago.
+          example: 1a901a90-1a90-1a90-1a90-1a901a901a90
+        number:
+          type: string
+          description: The unique number assigned to the order form by Lago.
+          example: OF-2026-0001
+        status:
+          $ref: '#/components/schemas/OrderFormStatusEnum'
+        void_reason:
+          $ref: '#/components/schemas/OrderFormVoidReasonEnum'
+        expires_at:
+          type:
+            - string
+            - 'null'
+          format: date-time
+          description: The date and time in UTC (ISO 8601) when the order form stops being signable. It is `null` when the order form never expires.
+          example: '2026-06-30T23:59:59Z'
+        signed_at:
+          type:
+            - string
+            - 'null'
+          format: date-time
+          description: The date and time in UTC (ISO 8601) when the order form was marked as signed. It is `null` unless the `status` is `signed`.
+          example: '2026-04-29T08:59:51Z'
+        voided_at:
+          type:
+            - string
+            - 'null'
+          format: date-time
+          description: The date and time in UTC (ISO 8601) when the order form stopped being actionable. It is set both when the order form is voided and when it expires, and is `null` otherwise.
+          example: '2026-04-29T08:59:51Z'
+        signed_document_url:
+          type:
+            - string
+            - 'null'
+          format: uri
+          description: The URL of the signed document attached to the order form. It is `null` when no document was uploaded.
+          example: https://api.getlago.com/rails/active_storage/blobs/redirect/eyJfcmFpbHMi/OF-2026-0001
+        lago_organization_id:
+          type: string
+          format: uuid
+          description: Unique identifier of the organization, created by Lago.
+          example: 1a901a90-1a90-1a90-1a90-1a901a901a90
+        lago_customer_id:
+          type: string
+          format: uuid
+          description: Unique identifier of the customer the order form is addressed to, created by Lago.
+          example: 1a901a90-1a90-1a90-1a90-1a901a901a90
+        lago_quote_id:
+          type: string
+          format: uuid
+          description: Unique identifier of the quote the order form comes from, created by Lago.
+          example: 1a901a90-1a90-1a90-1a90-1a901a901a90
+        lago_quote_version_id:
+          type: string
+          format: uuid
+          description: Unique identifier of the approved quote version the order form was generated from, created by Lago. A quote version carries at most one order form.
+          example: 1a901a90-1a90-1a90-1a90-1a901a901a90
+        created_at:
+          type: string
+          format: date-time
+          description: The date and time in UTC (ISO 8601) when the order form was created.
+          example: '2026-04-29T08:59:51Z'
+        updated_at:
+          type: string
+          format: date-time
+          description: The date and time in UTC (ISO 8601) when the order form was last updated.
+          example: '2026-04-29T08:59:51Z'
+    OrderFormsPaginated:
+      type: object
+      required:
+        - order_forms
+        - meta
+      properties:
+        order_forms:
+          type: array
+          items:
+            $ref: '#/components/schemas/OrderFormObject'
+        meta:
+          $ref: '#/components/schemas/PaginationMeta'
+    OrderForm:
+      type: object
+      required:
+        - order_form
+      properties:
+        order_form:
+          $ref: '#/components/schemas/OrderFormObject'
+    OrderExecutionModeEnum:
+      type: string
+      description: |
+        How the order created from the order form is carried out. It can be any of the following values:
+          - `execute_in_lago`: Lago applies the quoted deal itself, creating the subscriptions, coupons, wallets or one-off invoice it describes.
+          - `order_only`: Lago records the order without applying it, leaving the execution to your own systems.
+      enum:
+        - execute_in_lago
+        - order_only
+      example: execute_in_lago
+    OrderFormMarkAsSignedInput:
+      type: object
+      description: Parameters available when marking an order form as signed. Every parameter is optional, so an empty body records the signature without attaching a document, and creates an order that is not scheduled for execution.
+      required: []
+      properties:
+        order_form:
+          type: object
+          required: []
+          properties:
+            signed_document:
+              type: string
+              description: The document signed by the customer, as a base64 data URI (`data:<content_type>;base64,<data>`). Accepted content types are `application/pdf`, `image/jpeg` and `image/png`, for a maximum of 10 MB. Once attached, it is exposed as `signed_document_url` on the order form.
+              example: data:application/pdf;base64,JVBERi0xLjQKJcfs...
+            execution_mode:
+              $ref: '#/components/schemas/OrderExecutionModeEnum'
+              description: How the order created from the order form is carried out. It becomes mandatory as soon as `execute_at` is provided.
+            execute_at:
+              type: string
+              format: date-time
+              description: The date and time in UTC (ISO 8601) when Lago executes the order created from the order form. It must be in the future, and requires `execution_mode` to be set. When it is omitted, the order is created but never scheduled for execution.
+              example: '2026-07-01T00:00:00Z'
     OrganizationBillingConfiguration:
       type: object
       description: The custom billing settings for your organization.

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -9056,7 +9056,7 @@ webhooks:
       operationId: orderFormExpired
       summary: An order form has expired
       description: |-
-        An order form reached its `expires_at` without being signed, and is no longer actionable. Expiry is detected by an hourly job comparing calendar dates in the timezone of the customer's billing entity, so the event is emitted during the day the order form expires rather than at the exact `expires_at` time. It cascades to the quote version the order form was generated from, so a `quote.voided` event with the `cascade_of_expired` reason follows.
+        An order form reached its `expires_at` without being signed, and is no longer actionable. Expiry is detected by an hourly job comparing calendar dates in the customer's timezone, falling back to the billing entity's and then to UTC, so the event is emitted during the day the order form expires rather than at the exact `expires_at` time. It cascades to the quote version the order form was generated from, so a `quote.voided` event with the `cascade_of_expired` reason follows.
         This is a premium feature.
       parameters:
         - $ref: '#/components/parameters/webhook_signature'
@@ -19345,7 +19345,7 @@ components:
           - `expired`: the order form reached its `expires_at` without being signed.
           - `voided`: the order form has been voided before being signed.
 
-        Only a `generated` order form is actionable. Reaching any other status also voids the quote version the order form was generated from.
+        Only a `generated` order form is actionable. Reaching `expired` or `voided` also voids the quote version the order form was generated from; signing does not, since the deal it quotes goes on to be executed.
       enum:
         - generated
         - signed
@@ -19360,7 +19360,7 @@ components:
         The reason why the order form is no longer actionable. It is `null` unless the `status` is `voided` or `expired`. It can be any of the following values:
           - `manual`: the order form has been voided explicitly, through the API or the Lago user interface.
           - `expired`: the order form reached its `expires_at` without being signed.
-          - `invalid`: the order form has been voided by Lago because it could no longer be executed.
+          - `invalid`: reserved for an order form Lago voids because it can no longer be executed. No flow writes it yet.
       enum:
         - null
         - manual
@@ -19403,7 +19403,7 @@ components:
             - string
             - 'null'
           format: date-time
-          description: The date and time in UTC (ISO 8601) when the order form stops being signable. It is `null` when the order form never expires. It is capped when the quote is approved, so it always falls strictly before the day the quoted deal stops being executable.
+          description: The date and time in UTC (ISO 8601) after which the order form is meant to expire. It is `null` when the order form never expires. It is validated when the quote is approved, where a value on or after the day the quoted deal stops being executable is rejected rather than clamped. Expiry is then swept hourly and compared by calendar date, so signing keeps succeeding until the sweep moves the order form to `expired`.
           example: '2026-06-30T23:59:59Z'
         signed_at:
           type:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -4331,6 +4331,7 @@ paths:
         This endpoint records the customer's signature on an order form, and creates the order that carries the quoted deal out.
         Only a `generated` order form can be signed, so a `422` is returned once the order form has been signed, has expired or has been voided.
         An `execute_at` landing on or after the day the quoted deal stops being executable is rejected as well, so the order can never be scheduled past the term it bills.
+        A concurrent write on the same quote is reported as a `422` rather than retried, so a duplicated call can fail while the first one is still in flight.
         This is a premium feature.
       operationId: markOrderFormAsSigned
       requestBody:
@@ -4365,6 +4366,7 @@ paths:
       description: |-
         This endpoint voids an order form, with the `manual` reason, and cascades to the quote version it was generated from, which is voided with the `cascade_of_voided` reason.
         Only a `generated` order form can be voided, so a `422` is returned once the order form has been signed, has expired or has already been voided.
+        A concurrent write on the same quote is reported as a `422` rather than retried, so a duplicated call can fail while the first one is still in flight.
         This is a premium feature.
       operationId: voidOrderForm
       responses:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -4330,6 +4330,7 @@ paths:
       description: |-
         This endpoint records the customer's signature on an order form, and creates the order that carries the quoted deal out.
         Only a `generated` order form can be signed, so a `422` is returned once the order form has been signed, has expired or has been voided.
+        An `execute_at` landing on or after the day the quoted deal stops being executable is rejected as well, so the order can never be scheduled past the term it bills.
         This is a premium feature.
       operationId: markOrderFormAsSigned
       requestBody:
@@ -19402,7 +19403,7 @@ components:
             - string
             - 'null'
           format: date-time
-          description: The date and time in UTC (ISO 8601) when the order form stops being signable. It is `null` when the order form never expires.
+          description: The date and time in UTC (ISO 8601) when the order form stops being signable. It is `null` when the order form never expires. It is capped when the quote is approved, so it always falls strictly before the day the quoted deal stops being executable.
           example: '2026-06-30T23:59:59Z'
         signed_at:
           type:
@@ -19503,7 +19504,7 @@ components:
             execute_at:
               type: string
               format: date-time
-              description: The date and time in UTC (ISO 8601) when Lago executes the order created from the order form. It must be in the future, and requires `execution_mode` to be set. When it is omitted, the order is created but never scheduled for execution.
+              description: The date and time in UTC (ISO 8601) when Lago executes the order created from the order form. It must be in the future, requires `execution_mode` to be set, and must fall strictly before the day the quoted deal stops being executable, otherwise signing is rejected with a `422`. When it is omitted, the order is created but not scheduled, and waits to be executed on demand.
               example: '2026-07-01T00:00:00Z'
     OrganizationBillingConfiguration:
       type: object

--- a/src/openapi.yaml
+++ b/src/openapi.yaml
@@ -144,6 +144,8 @@ tags:
       url: https://getlago.com/docs/api-reference/payment-methods/payment-method-object
   - name: quotes
     description: Everything about Quote collection
+  - name: order_forms
+    description: Everything about Order form collection
 
 paths:
   /billing_entities:
@@ -290,6 +292,14 @@ paths:
     $ref: "./resources/invoice_retry_payment.yaml"
   /invoices/{lago_id}/void:
     $ref: "./resources/invoice_void.yaml"
+  /order_forms:
+    $ref: "./resources/order_forms.yaml"
+  /order_forms/{lago_id}:
+    $ref: "./resources/order_form.yaml"
+  /order_forms/{lago_id}/mark_as_signed:
+    $ref: "./resources/order_form_mark_as_signed.yaml"
+  /order_forms/{lago_id}/void:
+    $ref: "./resources/order_form_void.yaml"
   /organizations:
     $ref: "./resources/organizations.yaml"
   /payment_receipts:
@@ -487,6 +497,14 @@ webhooks:
     $ref: "./webhooks/invoice_resynced.yaml"
   integration_provider_error:
     $ref: "./webhooks/integration_provider_error.yaml"
+  order_form_created:
+    $ref: "./webhooks/order_form_created.yaml"
+  order_form_signed:
+    $ref: "./webhooks/order_form_signed.yaml"
+  order_form_expired:
+    $ref: "./webhooks/order_form_expired.yaml"
+  order_form_voided:
+    $ref: "./webhooks/order_form_voided.yaml"
   payment_requires_action:
     $ref: "./webhooks/payment_requires_action.yaml"
   payment_succeeded:

--- a/src/parameters/lago_order_form_id.yaml
+++ b/src/parameters/lago_order_form_id.yaml
@@ -1,0 +1,8 @@
+name: lago_id
+in: path
+description: Unique identifier assigned to the order form within the Lago application. This ID is exclusively created by Lago and serves as a unique identifier for the order form's record within the Lago system.
+required: true
+schema:
+  type: string
+  format: "uuid"
+  example: "1a901a90-1a90-1a90-1a90-1a901a901a90"

--- a/src/resources/order_form.yaml
+++ b/src/resources/order_form.yaml
@@ -1,0 +1,23 @@
+parameters:
+  - $ref: "../parameters/lago_order_form_id.yaml"
+get:
+  tags:
+    - order_forms
+  summary: Retrieve an order form
+  description: |-
+    This endpoint retrieves a specific order form.
+    This is a premium feature.
+  operationId: findOrderForm
+  responses:
+    "200":
+      description: Order form
+      content:
+        application/json:
+          schema:
+            $ref: "../schemas/OrderForm.yaml"
+    "401":
+      $ref: "../responses/Unauthorized.yaml"
+    "403":
+      $ref: "../responses/Forbidden.yaml"
+    "404":
+      $ref: "../responses/NotFound.yaml"

--- a/src/resources/order_form_mark_as_signed.yaml
+++ b/src/resources/order_form_mark_as_signed.yaml
@@ -7,6 +7,7 @@ post:
   description: |-
     This endpoint records the customer's signature on an order form, and creates the order that carries the quoted deal out.
     Only a `generated` order form can be signed, so a `422` is returned once the order form has been signed, has expired or has been voided.
+    An `execute_at` landing on or after the day the quoted deal stops being executable is rejected as well, so the order can never be scheduled past the term it bills.
     This is a premium feature.
   operationId: markOrderFormAsSigned
   requestBody:

--- a/src/resources/order_form_mark_as_signed.yaml
+++ b/src/resources/order_form_mark_as_signed.yaml
@@ -8,6 +8,7 @@ post:
     This endpoint records the customer's signature on an order form, and creates the order that carries the quoted deal out.
     Only a `generated` order form can be signed, so a `422` is returned once the order form has been signed, has expired or has been voided.
     An `execute_at` landing on or after the day the quoted deal stops being executable is rejected as well, so the order can never be scheduled past the term it bills.
+    A concurrent write on the same quote is reported as a `422` rather than retried, so a duplicated call can fail while the first one is still in flight.
     This is a premium feature.
   operationId: markOrderFormAsSigned
   requestBody:

--- a/src/resources/order_form_mark_as_signed.yaml
+++ b/src/resources/order_form_mark_as_signed.yaml
@@ -1,0 +1,33 @@
+parameters:
+  - $ref: "../parameters/lago_order_form_id.yaml"
+post:
+  tags:
+    - order_forms
+  summary: Mark an order form as signed
+  description: |-
+    This endpoint records the customer's signature on an order form, and creates the order that carries the quoted deal out.
+    Only a `generated` order form can be signed, so a `422` is returned once the order form has been signed, has expired or has been voided.
+    This is a premium feature.
+  operationId: markOrderFormAsSigned
+  requestBody:
+    description: Mark order form as signed payload
+    content:
+      application/json:
+        schema:
+          $ref: "../schemas/OrderFormMarkAsSignedInput.yaml"
+    required: false
+  responses:
+    "200":
+      description: Order form marked as signed
+      content:
+        application/json:
+          schema:
+            $ref: "../schemas/OrderForm.yaml"
+    "401":
+      $ref: "../responses/Unauthorized.yaml"
+    "403":
+      $ref: "../responses/Forbidden.yaml"
+    "404":
+      $ref: "../responses/NotFound.yaml"
+    "422":
+      $ref: "../responses/UnprocessableEntity.yaml"

--- a/src/resources/order_form_void.yaml
+++ b/src/resources/order_form_void.yaml
@@ -7,6 +7,7 @@ post:
   description: |-
     This endpoint voids an order form, with the `manual` reason, and cascades to the quote version it was generated from, which is voided with the `cascade_of_voided` reason.
     Only a `generated` order form can be voided, so a `422` is returned once the order form has been signed, has expired or has already been voided.
+    A concurrent write on the same quote is reported as a `422` rather than retried, so a duplicated call can fail while the first one is still in flight.
     This is a premium feature.
   operationId: voidOrderForm
   responses:

--- a/src/resources/order_form_void.yaml
+++ b/src/resources/order_form_void.yaml
@@ -1,0 +1,26 @@
+parameters:
+  - $ref: "../parameters/lago_order_form_id.yaml"
+post:
+  tags:
+    - order_forms
+  summary: Void an order form
+  description: |-
+    This endpoint voids an order form, with the `manual` reason, and cascades to the quote version it was generated from, which is voided with the `cascade_of_voided` reason.
+    Only a `generated` order form can be voided, so a `422` is returned once the order form has been signed, has expired or has already been voided.
+    This is a premium feature.
+  operationId: voidOrderForm
+  responses:
+    "200":
+      description: Order form voided
+      content:
+        application/json:
+          schema:
+            $ref: "../schemas/OrderForm.yaml"
+    "401":
+      $ref: "../responses/Unauthorized.yaml"
+    "403":
+      $ref: "../responses/Forbidden.yaml"
+    "404":
+      $ref: "../responses/NotFound.yaml"
+    "422":
+      $ref: "../responses/UnprocessableEntity.yaml"

--- a/src/resources/order_forms.yaml
+++ b/src/resources/order_forms.yaml
@@ -1,0 +1,129 @@
+get:
+  tags:
+    - order_forms
+  summary: List all order forms
+  description: |-
+    This endpoint is used to list all existing order forms.
+    This is a premium feature.
+  operationId: findAllOrderForms
+  parameters:
+    - $ref: "../parameters/page.yaml"
+    - $ref: "../parameters/per_page.yaml"
+    - name: status[]
+      in: query
+      description: Filter order forms by status. Possible values are `generated`, `signed`, `expired` and `voided`.
+      required: false
+      explode: true
+      schema:
+        type: array
+        items:
+          type: string
+          enum:
+            - generated
+            - signed
+            - expired
+            - voided
+    - name: customer_id[]
+      in: query
+      description: Filter order forms by the Lago identifiers of their customers.
+      required: false
+      explode: true
+      schema:
+        type: array
+        items:
+          type: string
+          format: "uuid"
+        example:
+          - 1a901a90-1a90-1a90-1a90-1a901a901a90
+    - name: number[]
+      in: query
+      description: Filter order forms by their number, as assigned by Lago.
+      required: false
+      explode: true
+      schema:
+        type: array
+        items:
+          type: string
+        example:
+          - OF-2026-0001
+          - OF-2026-0002
+    - name: quote_number[]
+      in: query
+      description: Filter order forms by the number of the quote they come from.
+      required: false
+      explode: true
+      schema:
+        type: array
+        items:
+          type: string
+        example:
+          - QT-2026-0001
+    - name: owner_id[]
+      in: query
+      description: Filter order forms by the Lago identifiers of the users owning the quote they come from.
+      required: false
+      explode: true
+      schema:
+        type: array
+        items:
+          type: string
+          format: "uuid"
+        example:
+          - 1a901a90-1a90-1a90-1a90-1a901a901a90
+    - name: search_term
+      in: query
+      description: Search order forms by number.
+      required: false
+      explode: true
+      schema:
+        type: string
+        example: "OF-2026"
+    - name: created_at_from
+      in: query
+      description: Filter order forms created from a specific date and time, in UTC (ISO 8601).
+      required: false
+      explode: true
+      schema:
+        type: string
+        format: "date-time"
+        example: "2026-01-01T00:00:00Z"
+    - name: created_at_to
+      in: query
+      description: Filter order forms created up to a specific date and time, in UTC (ISO 8601).
+      required: false
+      explode: true
+      schema:
+        type: string
+        format: "date-time"
+        example: "2026-12-31T23:59:59Z"
+    - name: expires_at_from
+      in: query
+      description: Filter order forms expiring from a specific date and time, in UTC (ISO 8601). Order forms that never expire are excluded.
+      required: false
+      explode: true
+      schema:
+        type: string
+        format: "date-time"
+        example: "2026-01-01T00:00:00Z"
+    - name: expires_at_to
+      in: query
+      description: Filter order forms expiring up to a specific date and time, in UTC (ISO 8601). Order forms that never expire are excluded.
+      required: false
+      explode: true
+      schema:
+        type: string
+        format: "date-time"
+        example: "2026-12-31T23:59:59Z"
+  responses:
+    "200":
+      description: Order forms
+      content:
+        application/json:
+          schema:
+            $ref: "../schemas/OrderFormsPaginated.yaml"
+    "401":
+      $ref: "../responses/Unauthorized.yaml"
+    "403":
+      $ref: "../responses/Forbidden.yaml"
+    "422":
+      $ref: "../responses/UnprocessableEntity.yaml"

--- a/src/schemas/OrderExecutionModeEnum.yaml
+++ b/src/schemas/OrderExecutionModeEnum.yaml
@@ -1,0 +1,9 @@
+type: string
+description: |
+  How the order created from the order form is carried out. It can be any of the following values:
+    - `execute_in_lago`: Lago applies the quoted deal itself, creating the subscriptions, coupons, wallets or one-off invoice it describes.
+    - `order_only`: Lago records the order without applying it, leaving the execution to your own systems.
+enum:
+  - execute_in_lago
+  - order_only
+example: "execute_in_lago"

--- a/src/schemas/OrderForm.yaml
+++ b/src/schemas/OrderForm.yaml
@@ -1,0 +1,6 @@
+type: object
+required:
+  - order_form
+properties:
+  order_form:
+    $ref: "./OrderFormObject.yaml"

--- a/src/schemas/OrderFormMarkAsSignedInput.yaml
+++ b/src/schemas/OrderFormMarkAsSignedInput.yaml
@@ -1,0 +1,20 @@
+type: object
+description: Parameters available when marking an order form as signed. Every parameter is optional, so an empty body records the signature without attaching a document, and creates an order that is not scheduled for execution.
+required: []
+properties:
+  order_form:
+    type: object
+    required: []
+    properties:
+      signed_document:
+        type: string
+        description: The document signed by the customer, as a base64 data URI (`data:<content_type>;base64,<data>`). Accepted content types are `application/pdf`, `image/jpeg` and `image/png`, for a maximum of 10 MB. Once attached, it is exposed as `signed_document_url` on the order form.
+        example: "data:application/pdf;base64,JVBERi0xLjQKJcfs..."
+      execution_mode:
+        $ref: "./OrderExecutionModeEnum.yaml"
+        description: How the order created from the order form is carried out. It becomes mandatory as soon as `execute_at` is provided.
+      execute_at:
+        type: string
+        format: "date-time"
+        description: The date and time in UTC (ISO 8601) when Lago executes the order created from the order form. It must be in the future, and requires `execution_mode` to be set. When it is omitted, the order is created but never scheduled for execution.
+        example: "2026-07-01T00:00:00Z"

--- a/src/schemas/OrderFormMarkAsSignedInput.yaml
+++ b/src/schemas/OrderFormMarkAsSignedInput.yaml
@@ -16,5 +16,11 @@ properties:
       execute_at:
         type: string
         format: "date-time"
-        description: The date and time in UTC (ISO 8601) when Lago executes the order created from the order form. It must be in the future, and requires `execution_mode` to be set. When it is omitted, the order is created but never scheduled for execution.
+        description: >-
+          The date and time in UTC (ISO 8601) when Lago executes the order created
+          from the order form. It must be in the future, requires `execution_mode`
+          to be set, and must fall strictly before the day the quoted deal stops
+          being executable, otherwise signing is rejected with a `422`. When it is
+          omitted, the order is created but not scheduled, and waits to be executed
+          on demand.
         example: "2026-07-01T00:00:00Z"

--- a/src/schemas/OrderFormObject.yaml
+++ b/src/schemas/OrderFormObject.yaml
@@ -1,0 +1,88 @@
+type: object
+required:
+  - lago_id
+  - number
+  - status
+  - void_reason
+  - expires_at
+  - signed_at
+  - voided_at
+  - signed_document_url
+  - lago_organization_id
+  - lago_customer_id
+  - lago_quote_id
+  - lago_quote_version_id
+  - created_at
+  - updated_at
+properties:
+  lago_id:
+    type: string
+    format: "uuid"
+    description: Unique identifier of the order form, created by Lago.
+    example: "1a901a90-1a90-1a90-1a90-1a901a901a90"
+  number:
+    type: string
+    description: The unique number assigned to the order form by Lago.
+    example: "OF-2026-0001"
+  status:
+    $ref: "./OrderFormStatusEnum.yaml"
+  void_reason:
+    $ref: "./OrderFormVoidReasonEnum.yaml"
+  expires_at:
+    type:
+      - string
+      - "null"
+    format: "date-time"
+    description: The date and time in UTC (ISO 8601) when the order form stops being signable. It is `null` when the order form never expires.
+    example: "2026-06-30T23:59:59Z"
+  signed_at:
+    type:
+      - string
+      - "null"
+    format: "date-time"
+    description: The date and time in UTC (ISO 8601) when the order form was marked as signed. It is `null` unless the `status` is `signed`.
+    example: "2026-04-29T08:59:51Z"
+  voided_at:
+    type:
+      - string
+      - "null"
+    format: "date-time"
+    description: The date and time in UTC (ISO 8601) when the order form stopped being actionable. It is set both when the order form is voided and when it expires, and is `null` otherwise.
+    example: "2026-04-29T08:59:51Z"
+  signed_document_url:
+    type:
+      - string
+      - "null"
+    format: "uri"
+    description: The URL of the signed document attached to the order form. It is `null` when no document was uploaded.
+    example: "https://api.getlago.com/rails/active_storage/blobs/redirect/eyJfcmFpbHMi/OF-2026-0001"
+  lago_organization_id:
+    type: string
+    format: "uuid"
+    description: Unique identifier of the organization, created by Lago.
+    example: "1a901a90-1a90-1a90-1a90-1a901a901a90"
+  lago_customer_id:
+    type: string
+    format: "uuid"
+    description: Unique identifier of the customer the order form is addressed to, created by Lago.
+    example: "1a901a90-1a90-1a90-1a90-1a901a901a90"
+  lago_quote_id:
+    type: string
+    format: "uuid"
+    description: Unique identifier of the quote the order form comes from, created by Lago.
+    example: "1a901a90-1a90-1a90-1a90-1a901a901a90"
+  lago_quote_version_id:
+    type: string
+    format: "uuid"
+    description: Unique identifier of the approved quote version the order form was generated from, created by Lago. A quote version carries at most one order form.
+    example: "1a901a90-1a90-1a90-1a90-1a901a901a90"
+  created_at:
+    type: string
+    format: "date-time"
+    description: The date and time in UTC (ISO 8601) when the order form was created.
+    example: "2026-04-29T08:59:51Z"
+  updated_at:
+    type: string
+    format: "date-time"
+    description: The date and time in UTC (ISO 8601) when the order form was last updated.
+    example: "2026-04-29T08:59:51Z"

--- a/src/schemas/OrderFormObject.yaml
+++ b/src/schemas/OrderFormObject.yaml
@@ -34,10 +34,12 @@ properties:
       - "null"
     format: "date-time"
     description: >-
-      The date and time in UTC (ISO 8601) when the order form stops being signable.
-      It is `null` when the order form never expires. It is capped when the quote
-      is approved, so it always falls strictly before the day the quoted deal stops
-      being executable.
+      The date and time in UTC (ISO 8601) after which the order form is meant to
+      expire. It is `null` when the order form never expires. It is validated when
+      the quote is approved, where a value on or after the day the quoted deal stops
+      being executable is rejected rather than clamped. Expiry is then swept hourly
+      and compared by calendar date, so signing keeps succeeding until the sweep
+      moves the order form to `expired`.
     example: "2026-06-30T23:59:59Z"
   signed_at:
     type:

--- a/src/schemas/OrderFormObject.yaml
+++ b/src/schemas/OrderFormObject.yaml
@@ -33,7 +33,11 @@ properties:
       - string
       - "null"
     format: "date-time"
-    description: The date and time in UTC (ISO 8601) when the order form stops being signable. It is `null` when the order form never expires.
+    description: >-
+      The date and time in UTC (ISO 8601) when the order form stops being signable.
+      It is `null` when the order form never expires. It is capped when the quote
+      is approved, so it always falls strictly before the day the quoted deal stops
+      being executable.
     example: "2026-06-30T23:59:59Z"
   signed_at:
     type:

--- a/src/schemas/OrderFormStatusEnum.yaml
+++ b/src/schemas/OrderFormStatusEnum.yaml
@@ -6,7 +6,7 @@ description: |
     - `expired`: the order form reached its `expires_at` without being signed.
     - `voided`: the order form has been voided before being signed.
 
-  Only a `generated` order form is actionable. Reaching any other status also voids the quote version the order form was generated from.
+  Only a `generated` order form is actionable. Reaching `expired` or `voided` also voids the quote version the order form was generated from; signing does not, since the deal it quotes goes on to be executed.
 enum:
   - generated
   - signed

--- a/src/schemas/OrderFormStatusEnum.yaml
+++ b/src/schemas/OrderFormStatusEnum.yaml
@@ -1,0 +1,15 @@
+type: string
+description: |
+  The status of the order form. It can be any of the following values:
+    - `generated`: the order form is waiting for the customer's signature.
+    - `signed`: the customer has signed, and an order has been created from the order form.
+    - `expired`: the order form reached its `expires_at` without being signed.
+    - `voided`: the order form has been voided before being signed.
+
+  Only a `generated` order form is actionable. Reaching any other status also voids the quote version the order form was generated from.
+enum:
+  - generated
+  - signed
+  - expired
+  - voided
+example: "generated"

--- a/src/schemas/OrderFormVoidReasonEnum.yaml
+++ b/src/schemas/OrderFormVoidReasonEnum.yaml
@@ -5,7 +5,7 @@ description: |
   The reason why the order form is no longer actionable. It is `null` unless the `status` is `voided` or `expired`. It can be any of the following values:
     - `manual`: the order form has been voided explicitly, through the API or the Lago user interface.
     - `expired`: the order form reached its `expires_at` without being signed.
-    - `invalid`: the order form has been voided by Lago because it could no longer be executed.
+    - `invalid`: reserved for an order form Lago voids because it can no longer be executed. No flow writes it yet.
 enum:
   - null
   - manual

--- a/src/schemas/OrderFormVoidReasonEnum.yaml
+++ b/src/schemas/OrderFormVoidReasonEnum.yaml
@@ -1,0 +1,14 @@
+type:
+  - string
+  - "null"
+description: |
+  The reason why the order form is no longer actionable. It is `null` unless the `status` is `voided` or `expired`. It can be any of the following values:
+    - `manual`: the order form has been voided explicitly, through the API or the Lago user interface.
+    - `expired`: the order form reached its `expires_at` without being signed.
+    - `invalid`: the order form has been voided by Lago because it could no longer be executed.
+enum:
+  - null
+  - manual
+  - expired
+  - invalid
+example: "manual"

--- a/src/schemas/OrderFormsPaginated.yaml
+++ b/src/schemas/OrderFormsPaginated.yaml
@@ -1,0 +1,11 @@
+type: object
+required:
+  - order_forms
+  - meta
+properties:
+  order_forms:
+    type: array
+    items:
+      $ref: "./OrderFormObject.yaml"
+  meta:
+    $ref: "./PaginationMeta.yaml"

--- a/src/webhooks/order_form_created.yaml
+++ b/src/webhooks/order_form_created.yaml
@@ -1,0 +1,40 @@
+post:
+  operationId: orderFormCreated
+  summary: An order form has been generated from an approved quote
+  description: |-
+    An order form has been generated from an approved quote version, and is now waiting for the customer's signature. It always follows a `quote.approved` event, emitted in the same transaction.
+    This is a premium feature.
+  parameters:
+    - $ref: "../parameters/webhook_signature.yaml"
+    - $ref: "../parameters/webhook_signature_algorithm.yaml"
+    - $ref: "../parameters/webhook_unique_key.yaml"
+  requestBody:
+    description: Details of the new order form
+    content:
+      application/json:
+        schema:
+          type: object
+          required:
+            - webhook_type
+            - object_type
+            - organization_id
+            - order_form
+          properties:
+            webhook_type:
+              type: string
+              enum:
+                - order_form.created
+            object_type:
+              type: string
+              enum:
+                - order_form
+            organization_id:
+              type: string
+              format: "uuid"
+              description: Unique identifier of the organization, created by Lago.
+              example: "1a901a90-1a90-1a90-1a90-1a901a901a90"
+            order_form:
+              $ref: "../schemas/OrderFormObject.yaml"
+  responses:
+    "200":
+      description: Return a 200 status to indicate that the data was received successfully

--- a/src/webhooks/order_form_expired.yaml
+++ b/src/webhooks/order_form_expired.yaml
@@ -1,0 +1,40 @@
+post:
+  operationId: orderFormExpired
+  summary: An order form has expired
+  description: |-
+    An order form reached its `expires_at` without being signed, and is no longer actionable. Expiry is detected by an hourly job comparing calendar dates in the timezone of the customer's billing entity, so the event is emitted during the day the order form expires rather than at the exact `expires_at` time. It cascades to the quote version the order form was generated from, so a `quote.voided` event with the `cascade_of_expired` reason follows.
+    This is a premium feature.
+  parameters:
+    - $ref: "../parameters/webhook_signature.yaml"
+    - $ref: "../parameters/webhook_signature_algorithm.yaml"
+    - $ref: "../parameters/webhook_unique_key.yaml"
+  requestBody:
+    description: Details of the expired order form
+    content:
+      application/json:
+        schema:
+          type: object
+          required:
+            - webhook_type
+            - object_type
+            - organization_id
+            - order_form
+          properties:
+            webhook_type:
+              type: string
+              enum:
+                - order_form.expired
+            object_type:
+              type: string
+              enum:
+                - order_form
+            organization_id:
+              type: string
+              format: "uuid"
+              description: Unique identifier of the organization, created by Lago.
+              example: "1a901a90-1a90-1a90-1a90-1a901a901a90"
+            order_form:
+              $ref: "../schemas/OrderFormObject.yaml"
+  responses:
+    "200":
+      description: Return a 200 status to indicate that the data was received successfully

--- a/src/webhooks/order_form_expired.yaml
+++ b/src/webhooks/order_form_expired.yaml
@@ -2,7 +2,7 @@ post:
   operationId: orderFormExpired
   summary: An order form has expired
   description: |-
-    An order form reached its `expires_at` without being signed, and is no longer actionable. Expiry is detected by an hourly job comparing calendar dates in the timezone of the customer's billing entity, so the event is emitted during the day the order form expires rather than at the exact `expires_at` time. It cascades to the quote version the order form was generated from, so a `quote.voided` event with the `cascade_of_expired` reason follows.
+    An order form reached its `expires_at` without being signed, and is no longer actionable. Expiry is detected by an hourly job comparing calendar dates in the customer's timezone, falling back to the billing entity's and then to UTC, so the event is emitted during the day the order form expires rather than at the exact `expires_at` time. It cascades to the quote version the order form was generated from, so a `quote.voided` event with the `cascade_of_expired` reason follows.
     This is a premium feature.
   parameters:
     - $ref: "../parameters/webhook_signature.yaml"

--- a/src/webhooks/order_form_signed.yaml
+++ b/src/webhooks/order_form_signed.yaml
@@ -1,0 +1,40 @@
+post:
+  operationId: orderFormSigned
+  summary: An order form has been marked as signed
+  description: |-
+    An order form has been marked as signed. An order is created from it in the same transaction, so an `order.created` event follows.
+    This is a premium feature.
+  parameters:
+    - $ref: "../parameters/webhook_signature.yaml"
+    - $ref: "../parameters/webhook_signature_algorithm.yaml"
+    - $ref: "../parameters/webhook_unique_key.yaml"
+  requestBody:
+    description: Details of the signed order form
+    content:
+      application/json:
+        schema:
+          type: object
+          required:
+            - webhook_type
+            - object_type
+            - organization_id
+            - order_form
+          properties:
+            webhook_type:
+              type: string
+              enum:
+                - order_form.signed
+            object_type:
+              type: string
+              enum:
+                - order_form
+            organization_id:
+              type: string
+              format: "uuid"
+              description: Unique identifier of the organization, created by Lago.
+              example: "1a901a90-1a90-1a90-1a90-1a901a901a90"
+            order_form:
+              $ref: "../schemas/OrderFormObject.yaml"
+  responses:
+    "200":
+      description: Return a 200 status to indicate that the data was received successfully

--- a/src/webhooks/order_form_voided.yaml
+++ b/src/webhooks/order_form_voided.yaml
@@ -1,0 +1,40 @@
+post:
+  operationId: orderFormVoided
+  summary: An order form has been voided
+  description: |-
+    An order form has been voided before being signed. It cascades to the quote version the order form was generated from, so a `quote.voided` event with the `cascade_of_voided` reason follows.
+    This is a premium feature.
+  parameters:
+    - $ref: "../parameters/webhook_signature.yaml"
+    - $ref: "../parameters/webhook_signature_algorithm.yaml"
+    - $ref: "../parameters/webhook_unique_key.yaml"
+  requestBody:
+    description: Details of the voided order form
+    content:
+      application/json:
+        schema:
+          type: object
+          required:
+            - webhook_type
+            - object_type
+            - organization_id
+            - order_form
+          properties:
+            webhook_type:
+              type: string
+              enum:
+                - order_form.voided
+            object_type:
+              type: string
+              enum:
+                - order_form
+            organization_id:
+              type: string
+              format: "uuid"
+              description: Unique identifier of the organization, created by Lago.
+              example: "1a901a90-1a90-1a90-1a90-1a901a901a90"
+            order_form:
+              $ref: "../schemas/OrderFormObject.yaml"
+  responses:
+    "200":
+      description: Return a 200 status to indicate that the data was received successfully


### PR DESCRIPTION
> **Stacked on #567** (`lago-1698`). Base is `lago-1698`, so review only the order-form commit; merge #567 first and this retargets to `main`.

## Context

Second step of the Quotes documentation stack. The order form is what a customer signs: it is generated when a quote version is approved, and signing it creates the order. The [REST endpoints](https://github.com/getlago/lago-api/pull/5360) are on `main`, and so are the four `order_form.*` webhooks from [lago-api#6134](https://github.com/getlago/lago-api/pull/6134). **Everything here has been re-verified against merged `main`.**

Orders get the next branch.

## Changes

**4 endpoints** under a new `order_forms` tag, all gated on the premium `order_forms` feature flag:

| Endpoint | Notes |
|---|---|
| `GET /order_forms` | filters on `status[]`, `customer_id[]`, `number[]`, `quote_number[]`, `owner_id[]`, `search_term`, and `created_at` / `expires_at` ranges |
| `GET /order_forms/{lago_id}` | |
| `POST /order_forms/{lago_id}/mark_as_signed` | optional `signed_document`, `execution_mode`, `execute_at` |
| `POST /order_forms/{lago_id}/void` | |

**4 webhooks**: `order_form.created`, `order_form.signed`, `order_form.expired`, `order_form.voided`.

## Notes for review

- **The signing and execution windows are bounded by the deal's own term** ([lago-api#6138](https://github.com/getlago/lago-api/pull/6138)). `QuoteVersions::DealExpiration` folds every `plans[].payload.endDate` and every wallet-credit / recurring-rule `expirationAt` into one boundary, and refuses a date landing on or after it, compared by date. It folded the version's `end_date` too until [#6182](https://github.com/getlago/lago-api/pull/6182) removed that column, so a `one_off` quote is now never bounded. The rule is described in prose rather than by its error code, matching the rest of the spec — no resource description names one.
- **One `OrderFormObject` serves both REST and webhooks** — all four webhook services use the plain `OrderFormSerializer`, so there is no webhook-specific shape here, unlike the quote events in #567.
- **`signed_document` is a base64 data URI**, not a multipart upload (`Utils::Base64File.decode`). Documented with the accepted content types and the 10 MB cap from the model.
- **`voided_at` is set on expiry too**, not just on void: `ExpireService` writes `status: expired` alongside `voided_at` and `void_reason: expired`. The field descriptions say so, since the name suggests otherwise.
- **`execution_mode` becomes mandatory as soon as `execute_at` is set**, per `ExecutionSettingsValidation`. With neither, the order is created but never scheduled: `Order.executable` requires a non-null `execute_at`, and there is no execute endpoint.
- **Expiry is hourly, not instant.** The clock job runs at `*:40` and `OrderForm.expirable` compares calendar dates in the billing entity's timezone, so `order_form.expired` fires during the expiry day rather than at `expires_at`. Worth confirming that's the behaviour we want to promise.
- Both lifecycle transitions cascade to the quote version (`cascade_of_voided` / `cascade_of_expired`); the descriptions name the follow-on `quote.voided` event.
- `OrderExecutionModeEnum` is extracted here but belongs to the order too; the orders branch will reuse it.
- `redocly lint` and `spectral lint` pass. 5 new `array-params-plural` warnings, same reason as #567: the API filter params are singular while accepting both a scalar and an array.



## Review fixes applied

From the OpenAPI Guardian sweep — all four must-fixes, each verified against merged `main` first:

- **Signing does not cascade a void.** `MarkAsSignedService` contains no void call; only `expired` and `voided` void the quote version. `OrderFormStatusEnum` said "any other status".
- **`expires_at` is rejected, not clamped.** `OrderForms::CreateService` fails the approval rather than capping the value — my earlier "capped" wording was wrong.
- **Expiry is not instant.** The sweep runs hourly and compares calendar dates, and `mark_as_signed` never checks `expires_at`, so an order form stays signable until the sweep moves it to `expired`. Now stated.
- **Timezone attribution corrected.** `Utils::Timezone` is `COALESCE(customers.timezone, billing_entities.timezone, 'UTC')` — the customer's timezone, not the billing entity's.

Also softened the `invalid` void reason: no flow writes it, so it is documented as reserved.


## Now also covers lago-api#6182

**Merged** to `main` as `1b1c24a`, and re-verified against it. `OrderForms::MarkAsSignedService` and `VoidService` now report a lost race on the quote as a `422` validation error instead of raising, so double-clicking Sign or Void no longer returns a 500. Both endpoint descriptions say so.

No payload change: `OrderFormObject` is untouched by #6182 and #6185.

