### PR TITLE
docs(wallet): add fixed_charge to applies_to.fee_types enum

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -15782,6 +15782,19 @@ components:
             $ref: '#/components/schemas/SubscriptionObject'
         meta:
           $ref: '#/components/schemas/PaginationMeta'
+    WalletFeeTypeEnum:
+      type: string
+      description: |
+        Fee type to which a wallet can be restricted. It can be any of the following values:
+          - `charge`
+          - `subscription`
+          - `commitment`
+          - `fixed_charge`
+      enum:
+        - charge
+        - subscription
+        - commitment
+        - fixed_charge
     WalletRecurringTransactionRule:
       type: object
       description: Object that represents rule for wallet recurring transactions.
@@ -16062,11 +16075,7 @@ components:
             fee_types:
               type: array
               items:
-                type: string
-                enum:
-                  - charge
-                  - subscription
-                  - commitment
+                $ref: '#/components/schemas/WalletFeeTypeEnum'
               description: An array of fee types to which the wallet is applicable. By specifying the fee types in this field, you can restrict the wallet's usage to specific fee types only.
               example:
                 - charge
@@ -16267,11 +16276,7 @@ components:
                     - array
                     - 'null'
                   items:
-                    type: string
-                    enum:
-                      - charge
-                      - subscription
-                      - commitment
+                    $ref: '#/components/schemas/WalletFeeTypeEnum'
                   description: An array of fee types to which the wallet is applicable. By specifying the fee types in this field, you can restrict the wallet's usage to specific fee types only.
                   example:
                     - charge
@@ -16619,11 +16624,7 @@ components:
                     - array
                     - 'null'
                   items:
-                    type: string
-                    enum:
-                      - charge
-                      - subscription
-                      - commitment
+                    $ref: '#/components/schemas/WalletFeeTypeEnum'
                   description: An array of fee types to which the wallet is applicable. By specifying the fee types in this field, you can restrict the wallet's usage to specific fee types only.
                   example:
                     - charge

--- a/src/schemas/WalletCreateInput.yaml
+++ b/src/schemas/WalletCreateInput.yaml
@@ -109,11 +109,7 @@ properties:
               - array
               - "null"
             items:
-              type: string
-              enum:
-                - charge
-                - subscription
-                - commitment
+              $ref: "./WalletFeeTypeEnum.yaml"
             description: An array of fee types to which the wallet is applicable. By specifying the fee types in this field, you can restrict the wallet's usage to specific fee types only.
             example: ["charge"]
           billable_metric_codes:

--- a/src/schemas/WalletFeeTypeEnum.yaml
+++ b/src/schemas/WalletFeeTypeEnum.yaml
@@ -1,0 +1,12 @@
+type: string
+description: |
+  Fee type to which a wallet can be restricted. It can be any of the following values:
+    - `charge`
+    - `subscription`
+    - `commitment`
+    - `fixed_charge`
+enum:
+  - charge
+  - subscription
+  - commitment
+  - fixed_charge

--- a/src/schemas/WalletObject.yaml
+++ b/src/schemas/WalletObject.yaml
@@ -127,11 +127,7 @@ properties:
       fee_types:
         type: array
         items:
-          type: string
-          enum:
-            - charge
-            - subscription
-            - commitment
+          $ref: "./WalletFeeTypeEnum.yaml"
         description: An array of fee types to which the wallet is applicable. By specifying the fee types in this field, you can restrict the wallet's usage to specific fee types only.
         example: ["charge"]
       billable_metric_codes:

--- a/src/schemas/WalletUpdateInput.yaml
+++ b/src/schemas/WalletUpdateInput.yaml
@@ -180,11 +180,7 @@ properties:
               - array
               - "null"
             items:
-              type: string
-              enum:
-                - charge
-                - subscription
-                - commitment
+              $ref: "./WalletFeeTypeEnum.yaml"
             description: An array of fee types to which the wallet is applicable. By specifying the fee types in this field, you can restrict the wallet's usage to specific fee types only.
             example: ["charge"]
           billable_metric_codes:

--- a/src/schemas/_index.yaml
+++ b/src/schemas/_index.yaml
@@ -376,6 +376,8 @@ Wallet:
   $ref: "./Wallet.yaml"
 WalletCreateInput:
   $ref: "./WalletCreateInput.yaml"
+WalletFeeTypeEnum:
+  $ref: "./WalletFeeTypeEnum.yaml"
 WalletObject:
   $ref: "./WalletObject.yaml"
 WalletsPaginated:


### PR DESCRIPTION
## Context

A wallet can be scoped to `fixed_charge` through `applies_to.fee_types` via the API — `Wallets::ValidateLimitationsService` validates incoming fee types against `Fee::FEE_TYPES`, which includes `fixed_charge`. The API reference only documented `charge`, `subscription` and `commitment`.

## Changes

- Add `fixed_charge` to the wallet `applies_to.fee_types` enum.
- Extract the enum into a reusable `WalletFeeTypeEnum` schema, referenced by `WalletCreateInput`, `WalletUpdateInput` and `WalletObject`, so the three definitions can no longer drift apart.
