### PR TITLE
docs(subscriptions): document cancelling incomplete subscriptions

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -5384,12 +5384,21 @@ paths:
       parameters:
         - name: status
           in: query
-          description: If the field is not defined, Lago will terminate only `active` subscriptions. However, if you wish to cancel a `pending` subscription, please ensure that you include `status=pending` in your request.
+          description: |
+            Selects which subscription to terminate for the given `external_id`, based on its status. If the field is not defined, Lago targets only `active` subscriptions.
+
+            - `pending`: cancel a subscription scheduled for a future activation (include `status=pending`).
+            - `incomplete`: cancel a payment-gated subscription that is still awaiting its activation payment (include `status=incomplete`). The subscription is canceled with `cancellation_reason: manual`, its draft invoice is closed, and any pending payment is canceled on a best-effort basis with the payment provider (some provider statuses cannot be canceled). Applied coupons, credit notes and wallet credits are recredited. Termination behaviours (`on_termination_credit_note`, `on_termination_invoice`) are ignored, as an incomplete subscription has never been billed.
           required: false
           explode: true
           schema:
             type: string
-            example: pending
+            enum:
+              - active
+              - pending
+              - incomplete
+            example: incomplete
+            default: active
         - name: on_termination_credit_note
           in: query
           description: |
@@ -15784,11 +15793,13 @@ components:
           enum:
             - payment_failed
             - timeout
+            - manual
           description: |
-            The reason a payment-gated subscription was canceled before activation. Null unless the subscription was canceled by payment gating.
+            The reason a payment-gated subscription was canceled while still `incomplete`. Null unless the subscription was canceled before activation.
 
             - `payment_failed`: the gating payment failed.
             - `timeout`: the activation rule expired before the payment succeeded.
+            - `manual`: the incomplete subscription was canceled on demand, via a terminate request with `status=incomplete`.
         activated_at:
           type:
             - string

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -15790,7 +15790,6 @@ components:
             - payment_failed
             - timeout
             - manual
-            - null
           description: |
             The reason a payment-gated subscription was canceled while still `incomplete`. Null unless the subscription was canceled before activation.
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -5388,15 +5388,11 @@ paths:
             Selects which subscription to terminate for the given `external_id`, based on its status. If the field is not defined, Lago targets only `active` subscriptions.
 
             - `pending`: cancel a subscription scheduled for a future activation (include `status=pending`).
-            - `incomplete`: cancel a payment-gated subscription that is still awaiting its activation payment (include `status=incomplete`). The subscription is canceled with `cancellation_reason: manual`, its draft invoice is closed, and any pending payment is canceled on a best-effort basis with the payment provider (some provider statuses cannot be canceled). Applied coupons, credit notes and wallet credits are recredited. Termination behaviours (`on_termination_credit_note`, `on_termination_invoice`) are ignored, as an incomplete subscription has never been billed.
+            - `incomplete`: cancel a payment-gated subscription that is still awaiting its activation payment (include `status=incomplete`). The subscription is canceled with `cancellation_reason: manual`, its invoice is closed and nothing is billed, and any pending payment is canceled on a best-effort basis with the payment provider (some provider statuses cannot be canceled). Applied coupons, credit notes and wallet credits are recredited. Termination behaviours (`on_termination_credit_note`, `on_termination_invoice`) are ignored, as an incomplete subscription has never been billed.
           required: false
           explode: true
           schema:
             type: string
-            enum:
-              - active
-              - pending
-              - incomplete
             example: incomplete
             default: active
         - name: on_termination_credit_note
@@ -15794,6 +15790,7 @@ components:
             - payment_failed
             - timeout
             - manual
+            - null
           description: |
             The reason a payment-gated subscription was canceled while still `incomplete`. Null unless the subscription was canceled before activation.
 

--- a/src/resources/subscription.yaml
+++ b/src/resources/subscription.yaml
@@ -94,15 +94,11 @@ delete:
         Selects which subscription to terminate for the given `external_id`, based on its status. If the field is not defined, Lago targets only `active` subscriptions.
 
         - `pending`: cancel a subscription scheduled for a future activation (include `status=pending`).
-        - `incomplete`: cancel a payment-gated subscription that is still awaiting its activation payment (include `status=incomplete`). The subscription is canceled with `cancellation_reason: manual`, its draft invoice is closed, and any pending payment is canceled on a best-effort basis with the payment provider (some provider statuses cannot be canceled). Applied coupons, credit notes and wallet credits are recredited. Termination behaviours (`on_termination_credit_note`, `on_termination_invoice`) are ignored, as an incomplete subscription has never been billed.
+        - `incomplete`: cancel a payment-gated subscription that is still awaiting its activation payment (include `status=incomplete`). The subscription is canceled with `cancellation_reason: manual`, its invoice is closed and nothing is billed, and any pending payment is canceled on a best-effort basis with the payment provider (some provider statuses cannot be canceled). Applied coupons, credit notes and wallet credits are recredited. Termination behaviours (`on_termination_credit_note`, `on_termination_invoice`) are ignored, as an incomplete subscription has never been billed.
       required: false
       explode: true
       schema:
         type: string
-        enum:
-          - active
-          - pending
-          - incomplete
         example: "incomplete"
         default: active
     - name: on_termination_credit_note

--- a/src/resources/subscription.yaml
+++ b/src/resources/subscription.yaml
@@ -90,12 +90,21 @@ delete:
   parameters:
     - name: status
       in: query
-      description: If the field is not defined, Lago will terminate only `active` subscriptions. However, if you wish to cancel a `pending` subscription, please ensure that you include `status=pending` in your request.
+      description: |
+        Selects which subscription to terminate for the given `external_id`, based on its status. If the field is not defined, Lago targets only `active` subscriptions.
+
+        - `pending`: cancel a subscription scheduled for a future activation (include `status=pending`).
+        - `incomplete`: cancel a payment-gated subscription that is still awaiting its activation payment (include `status=incomplete`). The subscription is canceled with `cancellation_reason: manual`, its draft invoice is closed, and any pending payment is canceled on a best-effort basis with the payment provider (some provider statuses cannot be canceled). Applied coupons, credit notes and wallet credits are recredited. Termination behaviours (`on_termination_credit_note`, `on_termination_invoice`) are ignored, as an incomplete subscription has never been billed.
       required: false
       explode: true
       schema:
         type: string
-        example: "pending"
+        enum:
+          - active
+          - pending
+          - incomplete
+        example: "incomplete"
+        default: active
     - name: on_termination_credit_note
       in: query
       description: |

--- a/src/schemas/SubscriptionObject.yaml
+++ b/src/schemas/SubscriptionObject.yaml
@@ -224,7 +224,6 @@ properties:
       - payment_failed
       - timeout
       - manual
-      - null
     description: |
       The reason a payment-gated subscription was canceled while still `incomplete`. Null unless the subscription was canceled before activation.
 

--- a/src/schemas/SubscriptionObject.yaml
+++ b/src/schemas/SubscriptionObject.yaml
@@ -223,11 +223,13 @@ properties:
     enum:
       - payment_failed
       - timeout
+      - manual
     description: |
-      The reason a payment-gated subscription was canceled before activation. Null unless the subscription was canceled by payment gating.
+      The reason a payment-gated subscription was canceled while still `incomplete`. Null unless the subscription was canceled before activation.
 
       - `payment_failed`: the gating payment failed.
       - `timeout`: the activation rule expired before the payment succeeded.
+      - `manual`: the incomplete subscription was canceled on demand, via a terminate request with `status=incomplete`.
   activated_at:
     type:
       - string

--- a/src/schemas/SubscriptionObject.yaml
+++ b/src/schemas/SubscriptionObject.yaml
@@ -224,6 +224,7 @@ properties:
       - payment_failed
       - timeout
       - manual
+      - null
     description: |
       The reason a payment-gated subscription was canceled while still `incomplete`. Null unless the subscription was canceled before activation.
 


### PR DESCRIPTION
## Context

lago-api now lets merchants cancel a payment-gated subscription while it is still `incomplete`, via `DELETE /subscriptions/{external_id}?status=incomplete`, recording `cancellation_reason: manual`.

## Description

- **Terminate endpoint** (`DELETE /subscriptions/{external_id}`): document `status=incomplete` and describe the behaviour — the gating invoice is closed (nothing billed), the pending payment is canceled best-effort with the provider, coupons/credit notes/wallet credits are recredited, and termination options are ignored since an incomplete subscription has never been billed.
- **`SubscriptionObject.cancellation_reason`**: add the `manual` value, and add `null` to the enum so the common null response validates.
- Regenerate the bundled `openapi.yaml`.

_Guardian review addressed: accurate invoice wording (open/closed, not "draft"); dropped the `status` request enum (the param is an unvalidated selector, and the enum was a breaking type-tightening for generated clients); `null` added to `cancellation_reason`._

## Related
- Docs: getlago/lago-doc#651
- Implementation: getlago/lago-api#6164 (INT-214)

🤖 Generated with [Claude Code](https://claude.com/claude-code)