### PR TITLE
docs(analytics): document billing_entity_id

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -12176,6 +12176,7 @@ components:
         - amount_cents
         - currency
         - invoices_count
+        - billing_entity_id
       properties:
         month:
           type: string
@@ -12193,6 +12194,11 @@ components:
           type: integer
           description: Contains invoices count.
           example: 10
+        billing_entity_id:
+          type: string
+          format: uuid
+          description: Unique identifier assigned to the billing entity the revenue is attributed to, created by Lago.
+          example: 1a901a90-1a90-1a90-1a90-1a901a901a90
     GrossRevenues:
       type: object
       required:
@@ -12308,6 +12314,7 @@ components:
         - amount_cents
         - currency
         - lago_invoice_ids
+        - billing_entity_id
       properties:
         month:
           type: string
@@ -12329,6 +12336,11 @@ components:
           description: The Lago invoice IDs associated with the revenue.
           example:
             - 5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba
+        billing_entity_id:
+          type: string
+          format: uuid
+          description: Unique identifier assigned to the billing entity the overdue balance is attributed to, created by Lago.
+          example: 1a901a90-1a90-1a90-1a90-1a901a901a90
     OverdueBalances:
       type: object
       required:

--- a/src/schemas/GrossRevenueObject.yaml
+++ b/src/schemas/GrossRevenueObject.yaml
@@ -4,6 +4,7 @@ required:
   - amount_cents
   - currency
   - invoices_count
+  - billing_entity_id
 properties:
   month:
     type: string
@@ -21,3 +22,8 @@ properties:
     type: integer
     description: Contains invoices count.
     example: 10
+  billing_entity_id:
+    type: string
+    format: "uuid"
+    description: Unique identifier assigned to the billing entity the revenue is attributed to, created by Lago.
+    example: "1a901a90-1a90-1a90-1a90-1a901a901a90"

--- a/src/schemas/OverdueBalanceObject.yaml
+++ b/src/schemas/OverdueBalanceObject.yaml
@@ -4,6 +4,7 @@ required:
   - amount_cents
   - currency
   - lago_invoice_ids
+  - billing_entity_id
 properties:
   month:
     type: string
@@ -24,3 +25,8 @@ properties:
       format: uuid
     description: The Lago invoice IDs associated with the revenue.
     example: ['5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba']
+  billing_entity_id:
+    type: string
+    format: "uuid"
+    description: Unique identifier assigned to the billing entity the overdue balance is attributed to, created by Lago.
+    example: "1a901a90-1a90-1a90-1a90-1a901a901a90"


### PR DESCRIPTION
## Context

Auditing the analytics schemas against what the API actually returns, for the type mismatch behind
[lago-go-client#358](https://github.com/getlago/lago-go-client/pull/358), turned up a second, quieter
drift: `GET /analytics/gross_revenue` and `GET /analytics/overdue_balance` both return a
`billing_entity_id` on every row, and neither schema declares it. Clients generated from this spec
drop the field, so attributing a monthly figure to a billing entity means reading an undocumented key.

## Changes

Both objects now declare `billing_entity_id` as a required UUID

## Notes for review

- **These endpoints take a code and return an id.** Every other schema in the spec exposes
  `billing_entity_code`; `billing_entity_id` appears nowhere else, and the analytics endpoints accept
  `billing_entity_code` as their filter. This documents what ships today rather than papering over
  it, but the asymmetry may deserve an API-side follow-up.
- **Not covered:** all five analytics endpoints accept that `billing_entity_code` query parameter,
  and none of the five resource definitions document it. Left out to keep this to the response
  schemas; happy to fold it in.

## Related

- Type fix on the same endpoints: getlago/lago-api#6237
- Client-side workaround that surfaced the drift: getlago/lago-go-client#358

🤖 Generated with [Claude Code](https://claude.com/claude-code)
